### PR TITLE
feat: sync with upstream v0.1.24 — session context, list-tools, get-quota, model ops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,20 @@ bb test
 COPILOT_E2E_TESTS=true bb test
 ```
 
+### Instrumented Testing
+
+All public API functions have `clojure.spec` fdefs defined in `instrument.clj`.
+When `github.copilot-sdk.instrument` is required (which happens automatically during
+integration tests), every public function call is validated against its spec at runtime.
+
+This means integration tests run with full spec checking — any argument or return
+value that violates a spec will throw immediately. When adding new public functions:
+
+1. Add an `s/fdef` in `src/github/copilot_sdk/instrument.clj`
+2. Add the function to both `instrument-all!` and `unstrument-all!` lists
+3. Ensure the corresponding specs exist in `src/github/copilot_sdk/specs.clj`
+4. Run `bb test` — if specs are wrong, instrumented tests will catch it
+
 ### Running Examples
 
 Examples are part of the test suite but run separately:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Added (v0.1.24 sync)
+- `list-sessions` now accepts optional filter map `{:cwd :git-root :repository :branch}` to narrow results by session context (upstream PR #427)
+- Session metadata from `list-sessions` now includes `:context` map with working directory info (`{:cwd :git-root :repository :branch}`) when available (upstream PR #427)
+- `list-tools` — list available tools with metadata; accepts optional model param for model-specific overrides (upstream PR #464)
+- `get-quota` — get account quota information (entitlements, usage, overage) (upstream PR #464)
+- `get-current-model` — get the current model for a session (session-scoped) (upstream PR #464)
+- `switch-model!` — switch the model for a session (session-scoped) (upstream PR #464)
+- New event types: `session.context_changed`, `session.title_changed`, `session.warning` (upstream PRs #396, #427)
+
 ### Changed
 - **BREAKING**: Namespace prefix renamed from `krukow.copilot-sdk` to `github.copilot-sdk`.
   All requires must be updated (e.g., `github.copilot-sdk.client`, `github.copilot-sdk.helpers`).

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -53,7 +53,8 @@
   :ret ::specs/session)
 
 (s/fdef github.copilot-sdk.client/list-sessions
-  :args (s/cat :client ::specs/client)
+  :args (s/cat :client ::specs/client
+               :filter (s/? (s/nilable ::specs/session-list-filter)))
   :ret (s/coll-of ::specs/session-metadata))
 
 (s/fdef github.copilot-sdk.client/delete-session!
@@ -85,6 +86,15 @@
 (s/fdef github.copilot-sdk.client/list-models
   :args (s/cat :client ::specs/client)
   :ret (s/coll-of ::specs/model-info))
+
+(s/fdef github.copilot-sdk.client/list-tools
+  :args (s/cat :client ::specs/client
+               :model (s/? (s/nilable string?)))
+  :ret (s/coll-of ::specs/tool-info-entry))
+
+(s/fdef github.copilot-sdk.client/get-quota
+  :args (s/cat :client ::specs/client)
+  :ret ::specs/quota-snapshots)
 
 (s/fdef github.copilot-sdk.client/force-stop!
   :args (s/cat :client ::specs/client)
@@ -175,6 +185,15 @@
                :opts (s/? (s/keys :opt-un [::specs/buffer ::specs/xf])))
   :ret any?)  ; core.async channel
 
+(s/fdef github.copilot-sdk.session/get-current-model
+  :args (s/cat :session ::specs/session)
+  :ret ::specs/model-id)
+
+(s/fdef github.copilot-sdk.session/switch-model!
+  :args (s/cat :session ::specs/session
+               :model-id string?)
+  :ret ::specs/model-id)
+
 ;; -----------------------------------------------------------------------------
 ;; Function specs for helpers namespace
 ;; -----------------------------------------------------------------------------
@@ -214,6 +233,8 @@
                       github.copilot-sdk.client/get-status
                       github.copilot-sdk.client/get-auth-status
                       github.copilot-sdk.client/list-models
+                      github.copilot-sdk.client/list-tools
+                      github.copilot-sdk.client/get-quota
                       github.copilot-sdk.client/create-session
                       github.copilot-sdk.client/resume-session
                       github.copilot-sdk.client/list-sessions
@@ -233,6 +254,8 @@
                       github.copilot-sdk.session/destroy!
                       github.copilot-sdk.session/session-id
                       github.copilot-sdk.session/workspace-path
+                      github.copilot-sdk.session/get-current-model
+                      github.copilot-sdk.session/switch-model!
                       github.copilot-sdk.session/events
                       github.copilot-sdk.session/subscribe-events
                       github.copilot-sdk.session/unsubscribe-events
@@ -254,6 +277,8 @@
                       github.copilot-sdk.client/get-status
                       github.copilot-sdk.client/get-auth-status
                       github.copilot-sdk.client/list-models
+                      github.copilot-sdk.client/list-tools
+                      github.copilot-sdk.client/get-quota
                       github.copilot-sdk.client/create-session
                       github.copilot-sdk.client/resume-session
                       github.copilot-sdk.client/list-sessions
@@ -273,6 +298,8 @@
                       github.copilot-sdk.session/destroy!
                       github.copilot-sdk.session/session-id
                       github.copilot-sdk.session/workspace-path
+                      github.copilot-sdk.session/get-current-model
+                      github.copilot-sdk.session/switch-model!
                       github.copilot-sdk.session/events
                       github.copilot-sdk.session/subscribe-events
                       github.copilot-sdk.session/unsubscribe-events

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -623,3 +623,24 @@
   "Get the session workspace path when provided by the CLI."
   [session]
   (:workspace-path session))
+
+(defn get-current-model
+  "Get the current model for this session.
+   Returns the model ID string, or nil if none set."
+  [session]
+  (let [{:keys [session-id client]} session
+        conn (connection-io client)
+        result (proto/send-request! conn "session.model.getCurrent"
+                                    {:sessionId session-id})]
+    (:model-id result)))
+
+(defn switch-model!
+  "Switch the model for this session.
+   Returns the new model ID string, or nil."
+  [session model-id]
+  (let [{:keys [session-id client]} session
+        conn (connection-io client)
+        result (proto/send-request! conn "session.model.switchTo"
+                                    {:sessionId session-id
+                                     :modelId model-id})]
+    (:model-id result)))


### PR DESCRIPTION
## Summary

Ports upstream Node.js SDK changes (PRs #427, #464, #396) to the Clojure SDK.

## New Functions

| Function | Scope | Upstream PR | Description |
|----------|-------|-------------|-------------|
| `list-tools` | client | #464 | List available tools with optional model-specific overrides |
| `get-quota` | client | #464 | Get account quota/usage information |
| `get-current-model` | session | #464 | Get current model for a session |
| `switch-model!` | session | #464 | Switch model mid-session |

## Updated Functions

- **`list-sessions`** — now accepts optional filter map `{:cwd :git-root :repository :branch}` and returns `:context` in session metadata (upstream PR #427)

## New Event Types

- `session.context_changed` — cwd/git context changed
- `session.title_changed` — session title updated  
- `session.warning` — warning with type + message

Also added `session.shutdown` and `skill.invoked` to exported `event-types` and `session-events` constants.

## Files Changed (10 files, +549/-27)

- **specs.clj** — `session-context`, `session-list-filter`, `tool-info-entry`, `quota-snapshot`, `model-id` specs; 3 new event data specs
- **client.clj** — `list-sessions` filter/context support, `list-tools`, `get-quota`
- **session.clj** — `get-current-model`, `switch-model!`
- **copilot_sdk.clj** — public facade + updated event type constants
- **instrument.clj** — fdefs + instrument/unstrument lists for all new functions
- **mock_server.clj** — handlers for `tools.list`, `account.getQuota`, `session.model.getCurrent`, `session.model.switchTo`, context support in `session.list`
- **integration_test.clj** — 6 new tests (context, filter, list-tools, get-quota, get-current-model, switch-model)
- **API.md** — full documentation for all new functions and updated list-sessions
- **CHANGELOG.md** — unreleased section entries
- **AGENTS.md** — instrumented testing guidance

## Testing

All 74 tests pass (210 assertions, 0 failures). JAR builds successfully. Doc validation passes.