### PR TITLE
chore: release v0.1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.1.25.0] - 2026-02-18
 ### Added
 - **Core.async native async architecture** — eliminates all blocking operations from the async API path:
   - `<create-session` / `<resume-session` — async session lifecycle functions that return channels delivering `CopilotSession`, safe for use inside `go` blocks
@@ -177,5 +178,6 @@ All notable changes to this project will be documented in this file. This change
 - org.clojure/spec.alpha 0.5.238
 - cheshire/cheshire 5.13.0
 
-[Unreleased]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v0.1.25.0...HEAD
+[0.1.25.0]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/0.1.0...v0.1.25.0
 [0.1.0]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Add to your `deps.edn`:
 
 ```clojure
 ;; From Maven Central
-io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "0.1.24.3"}
+io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "0.1.25.0"}
 
 ;; Or git dependency
 io.github.copilot-community-sdk/copilot-sdk-clojure {:git/url "https://github.com/copilot-community-sdk/copilot-sdk-clojure.git"
-                              :git/sha "62b78473b042f6ccf231e7190359a9eae6027568"}
+                              :git/sha "090464f06a002fb39910d97a24094ed008847eed"}
 ```
 
 > **Note:** The Clojars artifact `net.clojars.krukow/copilot-sdk` is deprecated.

--- a/build.clj
+++ b/build.clj
@@ -7,7 +7,7 @@
   (:import [java.io File]))
 
 (def lib 'io.github.copilot-community-sdk/copilot-sdk-clojure)
-(def version "0.1.24.3")
+(def version "0.1.25.0")
 (def class-dir "target/classes")
 
 (defn- try-sh


### PR DESCRIPTION
Automated release PR for v0.1.25.0. Created by the Release workflow (run 22136974781).