### PR TITLE
Port upstream PRs #554, #555, #544: require permission handler, add custom-tool kind, task_complete event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Changed (upstream PR #554 sync)
+- **BREAKING**: `:on-permission-request` is now **required** when calling `create-session`, `resume-session`, `<create-session`, and `<resume-session`. Calls without a handler throw `ExceptionInfo` with a descriptive message. This matches upstream Node.js SDK where `onPermissionRequest` is required in `SessionConfig` and `ResumeSessionConfig` (upstream PR #554).
+- `create-session` and `<create-session` no longer accept a 0-arity (no config) form — a config map with `:on-permission-request` must always be provided.
+- `resume-session` and `<resume-session` no longer accept a 2-arity (no config) form — a config map with `:on-permission-request` must always be provided.
+- All examples, tests, and documentation updated to always pass `:on-permission-request`.
+
+### Added (upstream PR #555 sync)
+- `:custom-tool` permission kind — `::permission-kind` spec now includes `:custom-tool`, matching the upstream `PermissionRequest.kind` union type. Permission handlers will receive `{:permission-kind :custom-tool ...}` for SDK-registered custom tool invocations (upstream PR #555).
+
+### Added (upstream PR #544 sync)
+- `:copilot/session.task_complete` event type added to `::event-type` spec (from upstream generated session event types).
+
 ### Added (documentation)
 - Microsoft Foundry Local BYOK provider guide in `doc/auth/byok.md`: quick start example, installation instructions, and connection troubleshooting (upstream PR #461).
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ The simplest way to use the SDK is with the `query` helper:
 ;; => "4"
 
 ;; With model selection
-(h/query "Explain monads in one sentence" :session {:model "claude-sonnet-4.5"})
+(h/query "Explain monads in one sentence" :session {:on-permission-request copilot/approve-all :model "claude-sonnet-4.5"})
 
 ;; With a system prompt
-(h/query "What is Clojure?" :session {:system-prompt "You are a helpful assistant. Be concise."})
+(h/query "What is Clojure?" :session {:on-permission-request copilot/approve-all :system-prompt "You are a helpful assistant. Be concise."})
 ```
 
 ### More Control
@@ -62,7 +62,8 @@ For multi-turn conversations, pass a session instance to `query`:
 ```clojure
 (require '[github.copilot-sdk :as copilot])
 
-(copilot/with-client-session [session {:model "claude-haiku-4.5"}]
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "claude-haiku-4.5"}]
   ;; Session maintains context between queries
   (println (h/query "What is the capital of France?" :session session))
   (println (h/query "What is its population?" :session session)))
@@ -71,7 +72,8 @@ For multi-turn conversations, pass a session instance to `query`:
 Or use the full API for maximum flexibility:
 
 ```clojure
-(copilot/with-client-session [session {:model "claude-haiku-4.5"}]
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "claude-haiku-4.5"}]
   (println (-> (copilot/send-and-wait! session {:prompt "What is the capital of France?"})
                (get-in [:data :content]))))
 ```
@@ -86,7 +88,7 @@ Use `<send!` with core.async for non-blocking operations:
 
 (copilot/with-client [client {}]
   ;; Launch multiple requests in parallel
-  (let [sessions (repeatedly 3 #(copilot/create-session client {}))
+  (let [sessions (repeatedly 3 #(copilot/create-session client {:on-permission-request copilot/approve-all}))
         channels (map #(copilot/<send! %1 {:prompt %2})
                       sessions
                       ["Capital of France?" "Capital of Japan?" "Capital of Brazil?"])]
@@ -226,7 +228,8 @@ await client.stop();
                 (str "Hello, " name "!"))}))
 
 (def session (copilot/create-session client
-               {:model "claude-haiku-4.5"
+               {:on-permission-request copilot/approve-all
+                :model "claude-haiku-4.5"
                 :tools [greet-tool]}))
 
 (let [ch (chan 100)]

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -61,7 +61,8 @@ For more control, use the explicit client/session API:
 ```clojure
 (require '[github.copilot-sdk :as copilot])
 
-(copilot/with-client-session [session {:model "gpt-5.2"}]
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "gpt-5.2"}]
   (let [response (copilot/send-and-wait! session {:prompt "What is 2 + 2?"})]
     (println (get-in response [:data :content]))))
 ```
@@ -91,7 +92,7 @@ Right now, you wait for the complete response before seeing anything. Let's make
 (defmethod handle-event :copilot/session.idle [_]
   (println))
 
-(run! handle-event (h/query-seq! "Tell me a short joke" :session {:streaming? true}))
+(run! handle-event (h/query-seq! "Tell me a short joke" :session {:on-permission-request copilot/approve-all :streaming? true}))
 ```
 
 ### Using core.async Channels
@@ -100,7 +101,8 @@ Right now, you wait for the complete response before seeing anything. Let's make
 (require '[clojure.core.async :refer [chan tap go-loop <!]])
 (require '[github.copilot-sdk :as copilot])
 
-(copilot/with-client-session [session {:model "gpt-5.2" :streaming? true}]
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "gpt-5.2" :streaming? true}]
   (let [ch (chan 256)
         done (promise)]
     (tap (copilot/events session) ch)
@@ -133,7 +135,8 @@ Use `<create-session` and `<send!` for fully non-blocking operations inside `go`
 (copilot/with-client [client]
   (let [result-ch
         (go
-          (let [session (<! (copilot/<create-session client {:model "gpt-5.2"}))]
+          (let [session (<! (copilot/<create-session client {:on-permission-request copilot/approve-all
+                                                            :model "gpt-5.2"}))]
             (when (instance? Throwable session)
               (throw session))
             (let [answer (<! (copilot/<send! session {:prompt "Capital of France?"}))]
@@ -178,7 +181,8 @@ Now for the powerful part. Let's give Copilot the ability to call your code by d
                   (copilot/result-success
                    (str city ": " temp "°F and " condition))))}))
 
-(copilot/with-client-session [session {:model "gpt-5.2"
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "gpt-5.2"
                                        :tools [get-weather]}]
   (println (h/query "What's the weather like in Seattle and Tokyo?"
                     :session session)))
@@ -206,7 +210,8 @@ Let's put it all together into an interactive assistant:
                   (copilot/result-success
                    (str city ": " temp "°F and " condition))))}))
 
-(copilot/with-client-session [session {:model "gpt-5.2"
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "gpt-5.2"
                                        :streaming? true
                                        :tools [get-weather]}]
   (println "🌤️  Weather Assistant (type 'exit' to quit)")
@@ -260,8 +265,8 @@ you provide an `:on-permission-request` handler.
 Use `approve-all` to permit everything:
 
 ```clojure
-(copilot/with-client-session [session {:model "gpt-5.2"
-                                       :on-permission-request copilot/approve-all}]
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "gpt-5.2"}]
   ...)
 ```
 
@@ -272,7 +277,8 @@ Or write a custom handler for fine-grained control. See [Permission Handling](./
 Pass `:client-name` to identify your application in API requests (included in the User-Agent header):
 
 ```clojure
-(copilot/with-client-session [session {:model "gpt-5.2"
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "gpt-5.2"
                                        :client-name "my-weather-app"}]
   ...)
 ```

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -29,10 +29,10 @@ When `:session` is a CopilotSession instance, the query uses that session direct
 ;; => "4"
 
 ;; With session options
-(h/query "Explain monads" :session {:model "claude-sonnet-4.5"})
+(h/query "Explain monads" :session {:on-permission-request copilot/approve-all :model "claude-sonnet-4.5"})
 
 ;; With system prompt
-(h/query "Hello" :session {:system-prompt "Be concise."})
+(h/query "Hello" :session {:on-permission-request copilot/approve-all :system-prompt "Be concise."})
 
 ;; With explicit client
 (copilot/with-client [client {}]
@@ -40,7 +40,7 @@ When `:session` is a CopilotSession instance, the query uses that session direct
 
 ;; With explicit session (multi-turn conversation)
 (copilot/with-client [client {}]
-  (copilot/with-session [session client {}]
+  (copilot/with-session [session client {:on-permission-request copilot/approve-all}]
     (h/query "My name is Alice." :session session)
     (h/query "What is my name?" :session session))) ;; context preserved!
 ```
@@ -54,7 +54,7 @@ When `:session` is a CopilotSession instance, the query uses that session direct
 Execute a query and return a bounded lazy sequence of events with guaranteed cleanup (default: 256 events).
 
 ```clojure
-(->> (h/query-seq! "Tell me a story" :session {:streaming? true})
+(->> (h/query-seq! "Tell me a story" :session {:on-permission-request copilot/approve-all :streaming? true})
      (filter #(= :copilot/assistant.message_delta (:type %)))
      (map #(get-in % [:data :delta-content]))
      (run! print))
@@ -70,7 +70,7 @@ Execute a query and return a core.async channel of events. Use this when you nee
 or want to stop reading early without leaking session resources.
 
 ```clojure
-(let [ch (h/query-chan "Tell me a story" :session {:streaming? true})]
+(let [ch (h/query-chan "Tell me a story" :session {:on-permission-request copilot/approve-all :streaming? true})]
   (go-loop []
     (when-let [event (<! ch)]
       (when (= :copilot/assistant.message_delta (:type event))
@@ -176,7 +176,8 @@ Create a new conversation session.
 #### `with-session`
 
 ```clojure
-(copilot/with-session [session client {:model "gpt-5.2"}]
+(copilot/with-session [session client {:model "gpt-5.2"
+                                       :on-permission-request copilot/approve-all}]
   ;; use session
   )
 ```
@@ -187,22 +188,26 @@ Create a session and ensure `destroy!` runs on exit.
 
 ```clojure
 ;; Form 1: [session session-opts] - anonymous client with default options
-(copilot/with-client-session [session {:model "gpt-5.2"}]
+(copilot/with-client-session [session {:model "gpt-5.2"
+                                       :on-permission-request copilot/approve-all}]
   ;; use session
   )
 
 ;; Form 2: [client-opts session session-opts] - anonymous client with custom options
-(copilot/with-client-session [{:log-level :debug} session {:model "gpt-5.2"}]
+(copilot/with-client-session [{:log-level :debug} session {:model "gpt-5.2"
+                                                           :on-permission-request copilot/approve-all}]
   ;; use session
   )
 
 ;; Form 3: [client session session-opts] - named client with default options
-(copilot/with-client-session [client session {:model "gpt-5.2"}]
+(copilot/with-client-session [client session {:model "gpt-5.2"
+                                              :on-permission-request copilot/approve-all}]
   ;; use client and session
   )
 
 ;; Form 4: [client client-opts session session-opts] - named client with custom options
-(copilot/with-client-session [client {:log-level :debug} session {:model "gpt-5.2"}]
+(copilot/with-client-session [client {:log-level :debug} session {:model "gpt-5.2"
+                                                                  :on-permission-request copilot/approve-all}]
   ;; use client and session
   )
 ```
@@ -223,7 +228,7 @@ Create a client and session together, ensuring both are cleaned up on exit.
 | `:provider` | map | Provider config for BYOK (see [BYOK docs](../auth/byok.md)). Required key: `:base-url`. Optional: `:provider-type` (`:openai`/`:azure`/`:anthropic`), `:wire-api` (`:completions`/`:responses`), `:api-key`, `:bearer-token`, `:azure-options` |
 | `:mcp-servers` | map | MCP server configs keyed by server ID (see [MCP docs](../mcp/overview.md)). Local servers: `:mcp-command`, `:mcp-args`, `:mcp-tools`. Remote servers: `:mcp-server-type` (`:http`/`:sse`), `:mcp-url`, `:mcp-tools` |
 | `:custom-agents` | vector | Custom agent configs |
-| `:on-permission-request` | fn | Permission handler function. Without a handler, all permissions are denied (deny-by-default). Use `copilot/approve-all` to approve everything. |
+| `:on-permission-request` | fn | **Required.** Permission handler function. Use `copilot/approve-all` to approve everything. |
 | `:streaming?` | boolean | Enable streaming deltas |
 | `:config-dir` | string | Override config directory for CLI |
 | `:skill-directories` | vector | Additional skill directories to load |
@@ -239,7 +244,6 @@ Create a client and session together, ensuring both are cleaned up on exit.
 #### `resume-session`
 
 ```clojure
-(copilot/resume-session client session-id)
 (copilot/resume-session client session-id config)
 ```
 
@@ -253,7 +257,8 @@ Resume an existing session by ID. The `config` map accepts the same options as `
 ;; Resume with a different model and reasoning effort
 (copilot/resume-session client "session-123"
   {:model "claude-sonnet-4"
-   :reasoning-effort "high"})
+   :reasoning-effort "high"
+   :on-permission-request copilot/approve-all})
 ```
 
 #### `<create-session`
@@ -270,7 +275,8 @@ Validation is synchronous (throws immediately on invalid config). The RPC call p
 (require '[clojure.core.async :refer [go <!]])
 
 (go
-  (let [result (<! (copilot/<create-session client {:model "gpt-5.2"}))]
+  (let [result (<! (copilot/<create-session client {:model "gpt-5.2"
+                                                    :on-permission-request copilot/approve-all}))]
     (if (instance? Throwable result)
       (println "Error:" (ex-message result))
       (let [answer (<! (copilot/<send! result {:prompt "Hello"}))]
@@ -280,7 +286,6 @@ Validation is synchronous (throws immediately on invalid config). The RPC call p
 #### `<resume-session`
 
 ```clojure
-(copilot/<resume-session client session-id)
 (copilot/<resume-session client session-id config)
 ```
 
@@ -290,7 +295,8 @@ Same config options as `resume-session`. Safe for use inside `go` blocks. On RPC
 
 ```clojure
 (go
-  (let [session (<! (copilot/<resume-session client "session-123"))]
+  (let [session (<! (copilot/<resume-session client "session-123"
+                                                     {:on-permission-request copilot/approve-all}))]
     ;; use resumed session
     ))
 ```
@@ -653,7 +659,8 @@ Combined with `<create-session`, enables fully non-blocking pipelines:
 
 ```clojure
 (go
-  (let [session (<! (copilot/<create-session client {:model "gpt-5.2"}))
+  (let [session (<! (copilot/<create-session client {:model "gpt-5.2"
+                                                     :on-permission-request copilot/approve-all}))
         answer  (<! (copilot/<send! session {:prompt "Explain monads"}))]
     (println answer)))
 ```
@@ -757,7 +764,8 @@ Switch the model for this session mid-conversation. Returns the new model ID str
 > **Note:** Not yet implemented in the CLI as of version 0.0.412. Calling this throws until CLI support is added.
 
 ```clojure
-(copilot/with-client-session [session {:model "gpt-5.2"}]
+(copilot/with-client-session [session {:model "gpt-5.2"
+                                       :on-permission-request copilot/approve-all}]
   (println "Before:" (copilot/get-current-model session))
   (copilot/switch-model! session "claude-sonnet-4.5")
   (println "After:" (copilot/get-current-model session)))
@@ -881,7 +889,8 @@ copilot/tool-events
 ### Example: Handling Events
 
 ```clojure
-(copilot/with-client-session [session {:streaming? true}]
+(copilot/with-client-session [session {:streaming? true
+                                       :on-permission-request copilot/approve-all}]
   (let [ch (chan 256)]
     (tap (copilot/events session) ch)
     (go-loop []
@@ -910,7 +919,8 @@ Enable streaming to receive assistant response chunks as they're generated:
 ```clojure
 (def session (copilot/create-session client
                {:model "gpt-5.2"
-                :streaming? true}))
+                :streaming? true
+                :on-permission-request copilot/approve-all}))
 
 (let [ch (chan 100)]
   (tap (copilot/events session) ch)
@@ -984,7 +994,8 @@ Let the CLI call back into your process when the model needs capabilities you pr
 
 (def session (copilot/create-session client
                {:model "gpt-5.2"
-                :tools [lookup-tool]}))
+                :tools [lookup-tool]
+                :on-permission-request copilot/approve-all}))
 ```
 
 When Copilot invokes `lookup_issue`, the SDK automatically runs your handler and responds to the CLI.
@@ -1013,6 +1024,7 @@ Control the system prompt:
 ```clojure
 (def session (copilot/create-session client
                {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all
                 :system-message
                   {:content "
 <workflow_rules>
@@ -1029,6 +1041,7 @@ For full control (removes all guardrails), use `:mode :replace`:
 ```clojure
 (copilot/create-session client
   {:model "gpt-5.2"
+   :on-permission-request copilot/approve-all
    :system-message {:mode :replace
                     :content "You are a helpful assistant."}})
 ```
@@ -1041,6 +1054,7 @@ It does not define custom agents. Custom agents are provided via `:custom-agents
 ```clojure
 (def session (copilot/create-session client
                {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all
                 :config-dir "/tmp/copilot-config"
                 :skill-directories ["/path/to/skills" "/opt/team-skills"]
                 :disabled-skills ["legacy-skill" "experimental-skill"]}))
@@ -1058,6 +1072,7 @@ Configure how large tool outputs are handled before being sent back to the model
 ```clojure
 (def session (copilot/create-session client
                {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all
                 :large-output {:enabled true
                                :max-size-bytes 65536
                                :output-dir "/tmp/copilot-tool-output"}}))
@@ -1090,11 +1105,13 @@ automatically compacts older messages while preserving important context.
 ```clojure
 ;; Enable with defaults (enabled by default)
 (def session (copilot/create-session client
-               {:model "gpt-5.2"}))
+               {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all}))
 
 ;; Explicit configuration
 (def session (copilot/create-session client
                {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all
                 :infinite-sessions {:enabled true
                                     :background-compaction-threshold 0.80
                                     :buffer-exhaustion-threshold 0.95}}))
@@ -1102,6 +1119,7 @@ automatically compacts older messages while preserving important context.
 ;; Disable infinite sessions
 (def session (copilot/create-session client
                {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all
                 :infinite-sessions {:enabled false}}))
 ```
 
@@ -1142,8 +1160,8 @@ Sessions emit `:session.compaction_start` and `:session.compaction_complete` eve
 ### Permission Handling
 
 The SDK uses a **deny-by-default** permission model. All permission requests
-(file writes, shell commands, URL fetches, etc.) are denied unless your
-session config provides an `:on-permission-request` handler.
+(file writes, shell commands, URL fetches, custom tool execution, etc.) are denied unless your
+session config provides an `:on-permission-request` handler (required).
 
 Use `approve-all` to opt into approving everything:
 
@@ -1200,6 +1218,7 @@ handler is called. Return a response map with the user's input:
 ```clojure
 (def session (copilot/create-session client
                {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all
                 :on-user-input-request
                 (fn [request invocation]
                   ;; request contains {:question "..." :choices [...] :allow-freeform true/false}
@@ -1228,6 +1247,7 @@ Lifecycle hooks allow custom logic at various points during the session:
 ```clojure
 (def session (copilot/create-session client
                {:model "gpt-5.2"
+                :on-permission-request copilot/approve-all
                 :hooks
                 {:on-pre-tool-use
                  (fn [input invocation]
@@ -1286,14 +1306,17 @@ For models that support reasoning (like o1), you can control the reasoning effor
 ;; Create session with reasoning effort
 (def session (copilot/create-session client
                {:model "o1"
-                :reasoning-effort "high"})) ; "low", "medium", "high", or "xhigh"
+                :reasoning-effort "high"
+                :on-permission-request copilot/approve-all})) ; "low", "medium", "high", or "xhigh"
 ```
 
 ### Multiple Sessions
 
 ```clojure
-(def session1 (copilot/create-session client {:model "gpt-5.2"}))
-(def session2 (copilot/create-session client {:model "claude-sonnet-4.5"}))
+(def session1 (copilot/create-session client {:model "gpt-5.2"
+                                              :on-permission-request copilot/approve-all}))
+(def session2 (copilot/create-session client {:model "claude-sonnet-4.5"
+                                              :on-permission-request copilot/approve-all}))
 
 ;; Both sessions are independent
 (copilot/send-and-wait! session1 {:prompt "Hello from session 1"})
@@ -1342,7 +1365,8 @@ For models that support reasoning (like o1), you can control the reasoning effor
 
 ```clojure
 (try
-  (let [session (copilot/create-session client)]
+  (let [session (copilot/create-session client
+                                       {:on-permission-request copilot/approve-all})]
     (copilot/send! session {:prompt "Hello"}))
   (catch Exception e
     (println "Error:" (ex-message e))))

--- a/examples/README.md
+++ b/examples/README.md
@@ -113,7 +113,8 @@ clojure -A:examples -X basic-chat/run :q1 '"What is Clojure?"' :q2 '"Who created
 (require '[github.copilot-sdk.helpers :as h])
 
 ;; 1. Create a client and session
-(copilot/with-client-session [session {:model "claude-haiku-4.5"}]
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "claude-haiku-4.5"}]
   ;; 2. Send a message using query with the session
   (println (h/query "What is the capital of France?" :session session))
   ;; => "The capital of France is Paris."
@@ -166,11 +167,13 @@ clojure -A:examples -X helpers-query/run-multi :questions '["What is Rust?" "Wha
 (require '[github.copilot-sdk.helpers :as h])
 
 ;; Simplest possible query - just get the answer
-(h/query "What is 2+2?" :session {:model "claude-haiku-4.5"})
+(h/query "What is 2+2?" :session {:on-permission-request copilot/approve-all
+                                   :model "claude-haiku-4.5"})
 ;; => "4"
 
 ;; With options
-(h/query "What is Clojure?" :session {:model "claude-haiku-4.5"})
+(h/query "What is Clojure?" :session {:on-permission-request copilot/approve-all
+                                       :model "claude-haiku-4.5"})
 
 ;; Streaming with multimethod event handling
 (defmulti handle-event :type)
@@ -180,7 +183,8 @@ clojure -A:examples -X helpers-query/run-multi :questions '["What is Rust?" "Wha
   (flush))
 (defmethod handle-event :copilot/assistant.message [_] (println))
 
-(run! handle-event (h/query-seq! "Tell me a joke" :session {:model "gpt-5.2" :streaming? true}))
+(run! handle-event (h/query-seq! "Tell me a joke" :session {:on-permission-request copilot/approve-all
+                                                              :model "gpt-5.2" :streaming? true}))
 ```
 
 ---
@@ -232,7 +236,8 @@ clojure -A:examples -X tool-integration/run :languages '["clojure" "haskell"]'
                       "not found"))))}))
 
 ;; Create session with tools and use query
-(copilot/with-client-session [session {:model "claude-haiku-4.5"
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "claude-haiku-4.5"
                                        :tools [lookup-tool]}]
   (println (h/query "Tell me about Clojure using the lookup tool" :session session)))
 ```
@@ -369,9 +374,9 @@ clojure -A:examples -X metadata-api/run
 **Difficulty:** Intermediate  
 **Concepts:** permission requests, bash tool, approval callback, deny-by-default
 
-The SDK uses a **deny-by-default** permission model — all permission requests are
-denied unless an `:on-permission-request` handler is provided. Use `copilot/approve-all`
-for blanket approval, or provide a custom handler for fine-grained control.
+The SDK **requires** an `:on-permission-request` handler in every session config.
+Use `copilot/approve-all` for blanket approval, or provide a custom handler for
+fine-grained control.
 
 Shows how to:
 - handle `permission.request` via `:on-permission-request`
@@ -434,7 +439,8 @@ clojure -A:examples -X session-events/run :prompt '"Explain recursion."'
     :copilot/session.truncation :copilot/session.snapshot_rewind
     :copilot/session.compaction_start :copilot/session.compaction_complete})
 
-(copilot/with-client-session [session {:streaming? true}]
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :streaming? true}]
   (let [events-ch (chan 256)
         done (promise)]
     (tap (copilot/events session) events-ch)
@@ -481,7 +487,8 @@ clojure -A:examples -X user-input/run-simple
 ```clojure
 (require '[github.copilot-sdk :as copilot])
 
-(copilot/with-client-session [session {:model "claude-haiku-4.5"
+(copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                       :model "claude-haiku-4.5"
                                        :on-user-input-request
                                        (fn [request invocation]
                                          ;; request contains:
@@ -608,7 +615,8 @@ await client.start();
 **Clojure:**
 ```clojure
 (require '[github.copilot-sdk.helpers :as h])
-(h/query "What is 2+2?" :session {:model "claude-haiku-4.5"})
+(h/query "What is 2+2?" :session {:on-permission-request copilot/approve-all
+                                   :model "claude-haiku-4.5"})
 ;; => "4"
 ```
 
@@ -630,7 +638,8 @@ session.on((event) => {
 (defmethod handle-event :copilot/assistant.message [{{:keys [content]} :data}]
   (println content))
 
-(run! handle-event (h/query-seq! "Hello" :session {:model "gpt-5.2" :streaming? true}))
+(run! handle-event (h/query-seq! "Hello" :session {:on-permission-request copilot/approve-all
+                                                    :model "gpt-5.2" :streaming? true}))
 ```
 
 ### Tool Definition

--- a/examples/ask_user_failure.clj
+++ b/examples/ask_user_failure.clj
@@ -16,7 +16,8 @@
   (let [cancelled-requests (atom [])]
     (copilot/with-client [client]
       (copilot/with-session [session client
-                             {:model "claude-haiku-4.5"
+                             {:on-permission-request copilot/approve-all
+                              :model "claude-haiku-4.5"
                               :on-user-input-request
                               (fn [request _invocation]
                                 (swap! cancelled-requests conj request)

--- a/examples/basic_chat.clj
+++ b/examples/basic_chat.clj
@@ -10,7 +10,8 @@
 
 (defn run
   [{:keys [q1 q2] :or {q1 (:q1 defaults) q2 (:q2 defaults)}}]
-  (copilot/with-client-session [session {:model "claude-haiku-4.5"}]
+  (copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                        :model "claude-haiku-4.5"}]
     (println "Q1:" q1)
     (println "🤖:" (h/query q1 :session session))
     (println)

--- a/examples/byok_provider.clj
+++ b/examples/byok_provider.clj
@@ -85,6 +85,6 @@
     (println (str "  Base URL: " (get-in config [:provider :base-url])))
     (println)
     (copilot/with-client [client {}]
-      (copilot/with-session [session client config]
+      (copilot/with-session [session client (assoc config :on-permission-request copilot/approve-all)]
         (println "Q: What is 2+2?")
         (println "🤖:" (h/query "What is 2+2? Answer in one sentence." :session session))))))

--- a/examples/config_skill_output.clj
+++ b/examples/config_skill_output.clj
@@ -31,7 +31,8 @@
     (.mkdirs (java.io.File. output-dir))
     (write-demo-skill! skill-dir)
     (println (str "[debug] output-dir: " output-dir))
-    (copilot/with-client-session [session {:model "claude-haiku-4.5"
+    (copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                           :model "claude-haiku-4.5"
                                            :config-dir config-dir
                                            :skill-directories [skill-dir]
                                            :disabled-skills ["demo-skill"]

--- a/examples/helpers_query.clj
+++ b/examples/helpers_query.clj
@@ -9,7 +9,8 @@
   {:prompt "What is the capital of Japan? Answer in one sentence."})
 
 (def session-config
-  {:model "claude-haiku-4.5"})
+  {:on-permission-request copilot/approve-all
+   :model "claude-haiku-4.5"})
 
 (defn run
   [{:keys [prompt] :or {prompt (:prompt defaults)}}]
@@ -37,13 +38,15 @@
   [{:keys [prompt] :or {prompt "Explain the concept of immutability in 2-3 sentences."}}]
   (println "Query:" prompt)
   (println)
-  (run! handle-event (h/query-seq! prompt :session {:model "gpt-5.2" :streaming? true})))
+  (run! handle-event (h/query-seq! prompt :session {:on-permission-request copilot/approve-all
+                                                     :model "gpt-5.2" :streaming? true})))
 
 (defn run-async
   [{:keys [prompt] :or {prompt "Tell me a short joke."}}]
   (println "Query:" prompt)
   (println)
-  (let [ch (h/query-chan prompt :session {:model "gpt-5.2" :streaming? true})]
+  (let [ch (h/query-chan prompt :session {:on-permission-request copilot/approve-all
+                                          :model "gpt-5.2" :streaming? true})]
     (<!! (go-loop []
            (when-let [event (<! ch)]
              (handle-event event)

--- a/examples/metadata_api.clj
+++ b/examples/metadata_api.clj
@@ -53,7 +53,8 @@
 
     ;; 4. Model switching within a session
     (println "\n4. Dynamic Model Switching:")
-    (copilot/with-session [session client {:model "claude-haiku-4.5"}]
+    (copilot/with-session [session client {:on-permission-request copilot/approve-all
+                                          :model "claude-haiku-4.5"}]
       ;; Query with claude-haiku-4.5
       (println "   Query: 'What is 2+2? Answer briefly.'")
       (println (str "   Response: " (h/query "What is 2+2? Answer briefly." :session session)))

--- a/examples/multi_agent.clj
+++ b/examples/multi_agent.clj
@@ -37,7 +37,8 @@
   (go
     (let [session (<! (copilot/<create-session
                        client
-                       {:system-message {:mode :append :content researcher-prompt}
+                       {:on-permission-request copilot/approve-all
+                        :system-message {:mode :append :content researcher-prompt}
                         :model "gpt-5.2"}))]
       (if (instance? Throwable session)
         {:topic topic :findings (str "Error: " (ex-message session))}
@@ -69,7 +70,8 @@
   (with-timing
     (doto (h/query (str "Analyze these findings:\n\n" research-summary)
                    :client client
-                   :session {:system-prompt analyst-prompt :model "gpt-5.2"})
+                   :session {:on-permission-request copilot/approve-all
+                             :system-prompt analyst-prompt :model "gpt-5.2"})
       (->> (println "Analysis:\n")))))
 
 (def synthesis-prompt "You are a writer. Create clear, engaging prose.")
@@ -80,5 +82,6 @@
   (with-timing
     (doto (h/query (str "Write a 3-4 sentence executive summary. ANALYSIS: " analysis)
                    :client client
-                   :session {:system-prompt synthesis-prompt :model "gpt-5.2"})
+                   :session {:on-permission-request copilot/approve-all
+                             :system-prompt synthesis-prompt :model "gpt-5.2"})
       println)))

--- a/examples/session_events.clj
+++ b/examples/session_events.clj
@@ -16,7 +16,8 @@
          reasoning-effort "high"}}]
   (copilot/with-client-session
       [client {:log-level :debug}
-       session {:model model
+       session {:on-permission-request copilot/approve-all
+                :model model
                 :streaming? true
                 :reasoning-effort reasoning-effort}]
     (let [events-ch (copilot/subscribe-events session)

--- a/examples/tool_integration.clj
+++ b/examples/tool_integration.clj
@@ -34,7 +34,8 @@
 
 (defn run
   [{:keys [languages] :or {languages (:languages defaults)}}]
-  (copilot/with-client-session [session {:model "claude-haiku-4.5"
+  (copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                         :model "claude-haiku-4.5"
                                          :tools [lookup-tool]}]
     (doseq [lang languages]
       (println (str "Looking up: " lang))

--- a/examples/user_input.clj
+++ b/examples/user_input.clj
@@ -43,7 +43,8 @@
   (println "=== User Input Example ===")
   (println "This example shows how to handle ask_user requests from the agent.\n")
 
-  (copilot/with-client-session [session {:model "claude-haiku-4.5"
+  (copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                         :model "claude-haiku-4.5"
                                          :on-user-input-request
                                          (fn [request _invocation]
                                            ;; request has :question, :choices, :allow-freeform
@@ -96,7 +97,8 @@
   (println "      The agent may or may not choose to use ask_user.\n")
 
   (let [input-requested? (atom false)]
-    (copilot/with-client-session [session {:model "claude-haiku-4.5"
+    (copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                           :model "claude-haiku-4.5"
                                            :on-user-input-request
                                            (fn [{:keys [question choices]} _]
                                              (reset! input-requested? true)

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -10,7 +10,8 @@
    (copilot/start! client)
 
    ;; Create a session
-   (def session (copilot/create-session client {:model \"gpt-5.2\"}))
+   (def session (copilot/create-session client {:on-permission-request copilot/approve-all
+                                                :model \"gpt-5.2\"}))
 
    ;; Send a message and wait for response
    (def response (copilot/send-and-wait! session {:prompt \"What is 2+2?\"}))
@@ -350,7 +351,8 @@
 (defn create-session
   "Create a new conversation session.
 
-   Config options:
+   Config options (`:on-permission-request` is **required**):
+   - :on-permission-request - Permission handler function (**required**, e.g. `approve-all`)
    - :session-id           - Custom session ID
    - :model                - Model to use (e.g., \"gpt-5.2\", \"claude-sonnet-4.5\")
    - :tools                - Vector of tool definitions (use define-tool)
@@ -358,13 +360,6 @@
    - :available-tools      - List of allowed tool names
    - :excluded-tools       - List of excluded tool names
    - :provider             - Custom provider config (BYOK)
-   - :on-permission-request - Permission handler function
-     Must return a map compatible with the permission result payload.
-     The SDK wraps this into the JSON-RPC response as {:result <your-map>}:
-     {:kind :approved}
-     {:kind :denied-by-rules :rules [{:kind \"shell\" :argument \"echo hi\"}]}
-     {:kind :denied-no-approval-rule-and-could-not-request-from-user}
-     {:kind :denied-interactively-by-user :feedback \"optional\"}
    - :streaming?           - Enable streaming deltas
    - :mcp-servers          - MCP server configs map (keyed by server ID)
    - :custom-agents        - Custom agent configs
@@ -377,12 +372,11 @@
 
    Example:
    ```clojure
-   (def session (copilot/create-session client {:model \"gpt-5.2\"}))
+   (def session (copilot/create-session client {:on-permission-request copilot/approve-all
+                                                :model \"gpt-5.2\"}))
    ```"
-  ([client]
-   (client/create-session client))
-  ([client config]
-   (client/create-session client config)))
+  [client config]
+  (client/create-session client config))
 
 (defn <create-session
   "Async version of create-session. Returns a channel that delivers a CopilotSession.
@@ -394,26 +388,24 @@
    Example:
    ```clojure
    (go
-     (let [result (<! (copilot/<create-session client {:model \"gpt-5.2\"}))]
+     (let [result (<! (copilot/<create-session client {:on-permission-request copilot/approve-all
+                                                       :model \"gpt-5.2\"}))]
        (when-not (instance? Throwable result)
          (let [answer (<! (copilot/<send! result {:prompt \"Hello\"}))]
            (println answer)))))
    ```"
-  ([client]
-   (client/<create-session client))
-  ([client config]
-   (client/<create-session client config)))
+  [client config]
+  (client/<create-session client config))
 
 (defmacro with-session
   "Create a session and ensure destroy! on exit.
 
    Usage:
-   (with-session [s client {:model \"gpt-5.2\"}]
+   (with-session [s client {:on-permission-request copilot/approve-all
+                            :model \"gpt-5.2\"}]
      ...)"
-  [[session-sym client & [config]] & body]
-  `(let [~session-sym ~(if config
-                         `(create-session ~client ~config)
-                         `(create-session ~client))]
+  [[session-sym client config] & body]
+  `(let [~session-sym (create-session ~client ~config)]
      (try
        ~@body
        (finally
@@ -427,26 +419,30 @@
 
    1. [session session-opts] - anonymous client with default options
       ```clojure
-      (with-client-session [session {:model \"gpt-5.2\"}]
+      (with-client-session [session {:on-permission-request copilot/approve-all
+                                     :model \"gpt-5.2\"}]
         (copilot/send! session {:prompt \"Hi\"}))
       ```
 
    2. [client-opts session session-opts] - anonymous client with custom options
       ```clojure
-      (with-client-session [{:log-level :debug} session {:model \"gpt-5.2\"}]
+      (with-client-session [{:log-level :debug} session {:on-permission-request copilot/approve-all
+                                                          :model \"gpt-5.2\"}]
         (copilot/send! session {:prompt \"Hi\"}))
       ```
 
    3. [client session session-opts] - named client with default options
       ```clojure
-      (with-client-session [client session {:model \"gpt-5.2\"}]
+      (with-client-session [client session {:on-permission-request copilot/approve-all
+                                            :model \"gpt-5.2\"}]
         (println (copilot/client-options client))
         (copilot/send! session {:prompt \"Hi\"}))
       ```
 
    4. [client client-opts session session-opts] - named client with custom options
       ```clojure
-      (with-client-session [client {:log-level :debug} session {:model \"gpt-5.2\"}]
+      (with-client-session [client {:log-level :debug} session {:on-permission-request copilot/approve-all
+                                                                 :model \"gpt-5.2\"}]
         (println (copilot/client-options client))
         (copilot/send! session {:prompt \"Hi\"}))
       ```"
@@ -500,18 +496,20 @@
    plus:
    - :disable-resume?  - When true, skip emitting the session.resume event (default: false)
 
+   `:on-permission-request` is **required**.
+
    Example:
    ```clojure
-   (def session (copilot/resume-session client \"session-123\"))
+   (def session (copilot/resume-session client \"session-123\"
+                  {:on-permission-request copilot/approve-all}))
    ;; Resume with different model
    (def session (copilot/resume-session client \"session-123\"
-                  {:model \"claude-sonnet-4\"
+                  {:on-permission-request copilot/approve-all
+                   :model \"claude-sonnet-4\"
                    :reasoning-effort \"high\"}))
    ```"
-  ([client session-id]
-   (client/resume-session client session-id))
-  ([client session-id config]
-   (client/resume-session client session-id config)))
+  [client session-id config]
+  (client/resume-session client session-id config))
 
 (defn <resume-session
   "Async version of resume-session. Returns a channel that delivers a CopilotSession.
@@ -523,15 +521,14 @@
    Example:
    ```clojure
    (go
-     (let [result (<! (copilot/<resume-session client \"session-123\"))]
+     (let [result (<! (copilot/<resume-session client \"session-123\"
+                                               {:on-permission-request copilot/approve-all}))]
        (when-not (instance? Throwable result)
          ;; use resumed session
          )))
    ```"
-  ([client session-id]
-   (client/<resume-session client session-id))
-  ([client session-id config]
-   (client/<resume-session client session-id config)))
+  [client session-id config]
+  (client/<resume-session client session-id config))
 
 (defn list-sessions
   "List all available sessions.

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -910,6 +910,11 @@
 (defn- validate-session-config!
   "Validate session config, throwing on invalid input."
   [config]
+  (when-not (:on-permission-request config)
+    (throw (ex-info (str "An :on-permission-request handler is required when creating a session. "
+                         "For example, to allow all permissions, use "
+                         "{:on-permission-request copilot/approve-all}.")
+                    {:config config})))
   (when-not (s/valid? ::specs/session-config config)
     (let [unknown (specs/unknown-keys config specs/session-config-keys)
           explain (s/explain-data ::specs/session-config config)
@@ -1037,7 +1042,8 @@
 (defn create-session
   "Create a new conversation session.
    
-   Config options:
+   Config options (`:on-permission-request` is **required**):
+   - :on-permission-request - Permission handler function (**required**, e.g. `approve-all`)
    - :session-id         - Custom session ID
    - :client-name        - Client name to identify the application (included in User-Agent header)
    - :model              - Model to use (e.g., \"gpt-5.2\")
@@ -1046,7 +1052,6 @@
    - :available-tools    - List of allowed tool names
    - :excluded-tools     - List of excluded tool names
    - :provider           - Custom provider config (BYOK)
-   - :on-permission-request - Permission handler function
    - :streaming?         - Enable streaming
    - :mcp-servers        - MCP server configs map
    - :custom-agents      - Custom agent configs
@@ -1067,23 +1072,22 @@
                             :on-session-start, :on-session-end, :on-error-occurred}
    
    Returns a CopilotSession."
-  ([client]
-   (create-session client {}))
-  ([client config]
-   (log/debug "Creating session with config: " (select-keys config [:model :session-id]))
-   (validate-session-config! config)
-   (ensure-connected! client)
-   (let [{:keys [connection-io]} @(:state client)
-         params (build-create-session-params config)
-         result (proto/send-request! connection-io "session.create" params)
-         session (finalize-session client result config)]
-     (log/info "Session created: " (:session-id result))
-     session)))
+  [client config]
+  (log/debug "Creating session with config: " (select-keys config [:model :session-id]))
+  (validate-session-config! config)
+  (ensure-connected! client)
+  (let [{:keys [connection-io]} @(:state client)
+        params (build-create-session-params config)
+        result (proto/send-request! connection-io "session.create" params)
+        session (finalize-session client result config)]
+    (log/info "Session created: " (:session-id result))
+    session))
 
 (defn resume-session
   "Resume an existing session by ID.
    
-   Config options (parity with create-session, upstream PR #376):
+   Config options (`:on-permission-request` is **required**):
+   - :on-permission-request - Permission handler function (**required**, e.g. `approve-all`)
    - :client-name        - Client name to identify the application (included in User-Agent header)
    - :model              - Change the model for the resumed session
    - :tools              - Tools exposed to the CLI server
@@ -1092,7 +1096,6 @@
    - :excluded-tools     - List of tool names to disable
    - :provider           - Custom provider configuration (BYOK)
    - :streaming?         - Enable streaming responses
-   - :on-permission-request - Permission handler
    - :mcp-servers        - MCP server configurations
    - :custom-agents      - Custom agent configurations
    - :config-dir         - Override configuration directory
@@ -1104,100 +1107,107 @@
    - :hooks              - Lifecycle hooks map
    
    Returns a CopilotSession."
-  ([client session-id]
-   (resume-session client session-id {}))
-  ([client session-id config]
-   (when-not (s/valid? ::specs/resume-session-config config)
-     (throw (ex-info "Invalid resume session config"
-                     {:config config
-                      :explain (s/explain-data ::specs/resume-session-config config)})))
-   (when (and (:provider config) (not (:model config)))
-     (throw (ex-info "Invalid session config: :model is required when :provider (BYOK) is specified"
-                     {:config config})))
-   (ensure-connected! client)
-   (let [{:keys [connection-io]} @(:state client)
-         params (build-resume-session-params session-id config)
-         result (proto/send-request! connection-io "session.resume" params)
-         session (finalize-session client result config)]
-     session)))
+  [client session-id config]
+  (when-not (:on-permission-request config)
+    (throw (ex-info (str "An :on-permission-request handler is required when resuming a session. "
+                         "For example, to allow all permissions, use "
+                         "{:on-permission-request copilot/approve-all}.")
+                    {:config config})))
+  (when-not (s/valid? ::specs/resume-session-config config)
+    (throw (ex-info "Invalid resume session config"
+                    {:config config
+                     :explain (s/explain-data ::specs/resume-session-config config)})))
+  (when (and (:provider config) (not (:model config)))
+    (throw (ex-info "Invalid session config: :model is required when :provider (BYOK) is specified"
+                    {:config config})))
+  (ensure-connected! client)
+  (let [{:keys [connection-io]} @(:state client)
+        params (build-resume-session-params session-id config)
+        result (proto/send-request! connection-io "session.resume" params)
+        session (finalize-session client result config)]
+    session))
 
 (defn <create-session
   "Async version of create-session. Returns a channel that delivers a CopilotSession.
 
-   Same config options as create-session. Validation is performed synchronously
-   (throws immediately on invalid config). The RPC call parks instead of blocking,
-   making this safe to use inside go blocks.
+   Same config options as create-session (`:on-permission-request` is **required**).
+   Validation is performed synchronously (throws immediately on invalid config).
+   The RPC call parks instead of blocking, making this safe to use inside go blocks.
 
    On RPC error, delivers an ExceptionInfo to the channel (not nil).
    Callers should check the result with (instance? Throwable result).
 
    Usage:
      (go
-       (let [result (<! (<create-session client {:model \"gpt-5.2\"}))]
+       (let [result (<! (<create-session client {:on-permission-request copilot/approve-all
+                                                 :model \"gpt-5.2\"}))]
          (if (instance? Throwable result)
            (println \"Error:\" (ex-message result))
            ;; use result as session
            )))"
-  ([client]
-   (<create-session client {}))
-  ([client config]
-   (log/debug "Creating session (async) with config: " (select-keys config [:model :session-id]))
-   (validate-session-config! config)
-   (ensure-connected! client)
-   (let [{:keys [connection-io]} @(:state client)
-         params (build-create-session-params config)
-         rpc-ch (proto/send-request connection-io "session.create" params)]
-     (go
-       (when-let [response (<! rpc-ch)]
-         (if-let [err (:error response)]
-           (do (log/error "<create-session RPC error: " err)
-               (ex-info (str "Failed to create session: " (:message err))
-                        {:error err}))
-           (let [result (:result response)
-                 session (finalize-session client result config)]
-             (log/info "Session created (async): " (:session-id result))
-             session)))))))
+  [client config]
+  (log/debug "Creating session (async) with config: " (select-keys config [:model :session-id]))
+  (validate-session-config! config)
+  (ensure-connected! client)
+  (let [{:keys [connection-io]} @(:state client)
+        params (build-create-session-params config)
+        rpc-ch (proto/send-request connection-io "session.create" params)]
+    (go
+      (when-let [response (<! rpc-ch)]
+        (if-let [err (:error response)]
+          (do (log/error "<create-session RPC error: " err)
+              (ex-info (str "Failed to create session: " (:message err))
+                       {:error err}))
+          (let [result (:result response)
+                session (finalize-session client result config)]
+            (log/info "Session created (async): " (:session-id result))
+            session))))))
 
 (defn <resume-session
   "Async version of resume-session. Returns a channel that delivers a CopilotSession.
 
-   Same config options as resume-session. Validation is performed synchronously
-   (throws immediately on invalid config). The RPC call parks instead of blocking,
-   making this safe to use inside go blocks.
+   Same config options as resume-session (`:on-permission-request` is **required**).
+   Validation is performed synchronously (throws immediately on invalid config).
+   The RPC call parks instead of blocking, making this safe to use inside go blocks.
 
    On RPC error, delivers an ExceptionInfo to the channel (not nil).
    Callers should check the result with (instance? Throwable result).
 
    Usage:
      (go
-       (let [result (<! (<resume-session client session-id {:model \"gpt-5.2\"}))]
+       (let [result (<! (<resume-session client session-id
+                                         {:on-permission-request copilot/approve-all
+                                          :model \"gpt-5.2\"}))]
          (if (instance? Throwable result)
            (println \"Error:\" (ex-message result))
            ;; use result as session
            )))"
-  ([client session-id]
-   (<resume-session client session-id {}))
-  ([client session-id config]
-   (when-not (s/valid? ::specs/resume-session-config config)
-     (throw (ex-info "Invalid resume session config"
-                     {:config config
-                      :explain (s/explain-data ::specs/resume-session-config config)})))
-   (when (and (:provider config) (not (:model config)))
-     (throw (ex-info "Invalid session config: :model is required when :provider (BYOK) is specified"
-                     {:config config})))
-   (ensure-connected! client)
-   (let [{:keys [connection-io]} @(:state client)
-         params (build-resume-session-params session-id config)
-         rpc-ch (proto/send-request connection-io "session.resume" params)]
-     (go
-       (when-let [response (<! rpc-ch)]
-         (if-let [err (:error response)]
-           (do (log/error "<resume-session RPC error: " err)
-               (ex-info (str "Failed to resume session: " (:message err))
-                        {:error err :session-id session-id}))
-           (let [result (:result response)
-                 session (finalize-session client result config)]
-             session)))))))
+  [client session-id config]
+  (when-not (:on-permission-request config)
+    (throw (ex-info (str "An :on-permission-request handler is required when resuming a session. "
+                         "For example, to allow all permissions, use "
+                         "{:on-permission-request copilot/approve-all}.")
+                    {:config config})))
+  (when-not (s/valid? ::specs/resume-session-config config)
+    (throw (ex-info "Invalid resume session config"
+                    {:config config
+                     :explain (s/explain-data ::specs/resume-session-config config)})))
+  (when (and (:provider config) (not (:model config)))
+    (throw (ex-info "Invalid session config: :model is required when :provider (BYOK) is specified"
+                    {:config config})))
+  (ensure-connected! client)
+  (let [{:keys [connection-io]} @(:state client)
+        params (build-resume-session-params session-id config)
+        rpc-ch (proto/send-request connection-io "session.resume" params)]
+    (go
+      (when-let [response (<! rpc-ch)]
+        (if-let [err (:error response)]
+          (do (log/error "<resume-session RPC error: " err)
+              (ex-info (str "Failed to resume session: " (:message err))
+                       {:error err :session-id session-id}))
+          (let [result (:result response)
+                session (finalize-session client result config)]
+            session))))))
 
 (defn list-sessions
   "List all available sessions.

--- a/src/github/copilot_sdk/helpers.clj
+++ b/src/github/copilot_sdk/helpers.clj
@@ -15,7 +15,8 @@
    ;; => \"4\"
    
    ;; With options
-   (h/query \"Explain monads\" :session {:model \"claude-sonnet-4.5\"})
+   (h/query \"Explain monads\" :session {:on-permission-request copilot/approve-all
+                                        :model \"claude-sonnet-4.5\"})
    ```
    
    ## Client Management
@@ -118,10 +119,11 @@
 (defn- build-session-config
   "Build session config from options map."
   [session-opts]
-  (let [{:keys [model system-prompt tools allowed-tools excluded-tools
+  (let [{:keys [on-permission-request model system-prompt tools allowed-tools excluded-tools
                 streaming? mcp-servers custom-agents config-dir
                 skill-directories disabled-skills]} session-opts]
     (cond-> {}
+      on-permission-request (assoc :on-permission-request on-permission-request)
       model (assoc :model model)
       system-prompt (assoc :system-message {:mode :append :content system-prompt})
       tools (assoc :tools tools)
@@ -188,17 +190,19 @@
 
    Examples:
      ;; Simple query (shared client, fresh session)
-     (query \"What is 2+2?\")
+     (query \"What is 2+2?\" :session {:on-permission-request copilot/approve-all})
 
      ;; With session options
-     (query \"Explain monads\" :session {:model \"claude-sonnet-4.5\"})
+     (query \"Explain monads\" :session {:on-permission-request copilot/approve-all
+                                        :model \"claude-sonnet-4.5\"})
 
      ;; With explicit client
      (copilot/with-client [c {}]
-       (query \"Hello\" :client c))
+       (query \"Hello\" :client c :session {:on-permission-request copilot/approve-all}))
 
      ;; With explicit session (multi-turn)
-     (copilot/with-session [s client {:model \"gpt-5.2\"}]
+     (copilot/with-session [s client {:on-permission-request copilot/approve-all
+                                      :model \"gpt-5.2\"}]
        (query \"What is 2+2?\" :session s)
        (query \"And 3+3?\" :session s))  ;; context preserved
    "
@@ -284,7 +288,8 @@
    the session becomes idle or errors.
    
    Examples:
-     (let [ch (query-chan \"Tell me a story\" :session {:streaming? true})]
+     (let [ch (query-chan \"Tell me a story\" :session {:on-permission-request copilot/approve-all
+                                                       :streaming? true})]
        (go-loop []
          (when-let [event (<! ch)]
            (when (= :copilot/assistant.message_delta (:type event))

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -48,24 +48,24 @@
 
 (s/fdef github.copilot-sdk.client/create-session
   :args (s/cat :client ::specs/client
-               :config (s/? ::specs/session-config))
+               :config ::specs/session-config)
   :ret ::specs/session)
 
 (s/fdef github.copilot-sdk.client/resume-session
   :args (s/cat :client ::specs/client
                :session-id ::specs/session-id
-               :config (s/? ::specs/resume-session-config))
+               :config ::specs/resume-session-config)
   :ret ::specs/session)
 
 (s/fdef github.copilot-sdk.client/<create-session
   :args (s/cat :client ::specs/client
-               :config (s/? ::specs/session-config))
+               :config ::specs/session-config)
   :ret ::specs/events-ch)
 
 (s/fdef github.copilot-sdk.client/<resume-session
   :args (s/cat :client ::specs/client
                :session-id ::specs/session-id
-               :config (s/? ::specs/resume-session-config))
+               :config ::specs/resume-session-config)
   :ret ::specs/events-ch)
 
 (s/fdef github.copilot-sdk.client/list-sessions

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -208,9 +208,10 @@
 
 (s/def ::session-config
   (closed-keys
-   (s/keys :opt-un [::session-id ::client-name ::model ::tools ::system-message
+   (s/keys :req-un [::on-permission-request]
+           :opt-un [::session-id ::client-name ::model ::tools ::system-message
                     ::available-tools ::excluded-tools ::provider
-                    ::on-permission-request ::streaming? ::mcp-servers
+                    ::streaming? ::mcp-servers
                     ::custom-agents ::config-dir ::skill-directories
                     ::disabled-skills ::large-output ::infinite-sessions
                     ::reasoning-effort ::on-user-input-request ::hooks
@@ -226,8 +227,9 @@
 
 (s/def ::resume-session-config
   (closed-keys
-   (s/keys :opt-un [::client-name ::model ::tools ::system-message ::available-tools ::excluded-tools
-                    ::provider ::streaming? ::on-permission-request
+   (s/keys :req-un [::on-permission-request]
+           :opt-un [::client-name ::model ::tools ::system-message ::available-tools ::excluded-tools
+                    ::provider ::streaming?
                     ::mcp-servers ::custom-agents ::config-dir ::skill-directories
                     ::disabled-skills ::infinite-sessions ::reasoning-effort
                     ::on-user-input-request ::hooks ::working-directory ::disable-resume?])
@@ -352,7 +354,7 @@
     :copilot/session.info :copilot/session.model_change :copilot/session.handoff
     :copilot/session.truncation :copilot/session.snapshot_rewind :copilot/session.usage_info
     :copilot/session.compaction_start :copilot/session.compaction_complete
-    :copilot/session.shutdown
+    :copilot/session.shutdown :copilot/session.task_complete
     :copilot/session.title_changed :copilot/session.warning :copilot/session.context_changed
     :copilot/user.message :copilot/pending_messages.modified
     :copilot/assistant.turn_start :copilot/assistant.intent :copilot/assistant.reasoning
@@ -470,7 +472,7 @@
 ;; Permission types
 ;; -----------------------------------------------------------------------------
 
-(s/def ::permission-kind #{:shell :write :mcp :read :url})
+(s/def ::permission-kind #{:shell :write :mcp :read :url :custom-tool})
 
 (s/def ::permission-request
   (s/keys :req-un [::permission-kind]

--- a/test/github/copilot_sdk/e2e_test.clj
+++ b/test/github/copilot_sdk/e2e_test.clj
@@ -73,7 +73,7 @@
 (deftest ^:e2e test-e2e-create-session
   (when-e2e
    (testing "Create session with real CLI"
-     (let [session (sdk/create-session *e2e-client* {})]
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})]
        (is (some? session))
        (is (string? (sdk/session-id session)))
         ;; Clean up
@@ -82,7 +82,7 @@
 (deftest ^:e2e test-e2e-simple-conversation
   (when-e2e
    (testing "Simple conversation with real CLI"
-     (let [session (sdk/create-session *e2e-client* {})
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})
            result (sdk/send-and-wait! session
                                       {:prompt "What is 2 + 2? Reply with just the number."}
                                       30000)] ; 30 second timeout
@@ -95,7 +95,7 @@
 (deftest ^:e2e test-e2e-list-sessions
   (when-e2e
    (testing "List sessions with real CLI"
-     (let [session (sdk/create-session *e2e-client* {})
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})
             ;; Send a message to ensure session is persisted
            _ (sdk/send-and-wait! session {:prompt "test"})
            sessions (sdk/list-sessions *e2e-client*)]
@@ -108,7 +108,7 @@
 (deftest ^:e2e test-e2e-session-abort
   (when-e2e
    (testing "Abort session operation"
-     (let [session (sdk/create-session *e2e-client* {})]
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})]
         ;; Send a message without waiting
        (sdk/send! session {:prompt "Write a very long essay about quantum physics."})
         ;; Abort should not throw
@@ -131,7 +131,7 @@
                    :handler (fn [args _invocation]
                               (reset! tool-called? true)
                               (str "The result is: " (+ (:a args) (:b args))))})
-           session (sdk/create-session *e2e-client* {:tools [tool]})]
+           session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all :tools [tool]})]
         ;; Ask a question that should trigger the calculator tool
        (let [result (sdk/send-and-wait! session
                                         {:prompt "Use the test_calculator tool to add 5 and 3"}
@@ -144,7 +144,7 @@
 (deftest ^:e2e test-e2e-send-async
   (when-e2e
    (testing "Async send with event channel"
-     (let [session (sdk/create-session *e2e-client* {})
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})
            event-ch (sdk/send-async session {:prompt "Say 'hello' and nothing else."})
            events (atom [])]
         ;; Collect events with timeout
@@ -165,7 +165,7 @@
 (deftest ^:e2e test-e2e-streaming-deltas
   (when-e2e
    (testing "Streaming deltas when enabled"
-     (let [session (sdk/create-session *e2e-client* {:streaming? true})
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all :streaming? true})
            events-ch (sdk/subscribe-events session)
            deltas (atom [])
            _ (sdk/send! session {:prompt "Count from 1 to 5."})
@@ -187,7 +187,8 @@
   (when-e2e
    (testing "System message append mode"
      (let [session (sdk/create-session *e2e-client*
-                                       {:system-message {:mode :append
+                                       {:on-permission-request sdk/approve-all
+                                         :system-message {:mode :append
                                                          :content "Always end your response with the word BANANA."}})]
        (let [result (sdk/send-and-wait! session {:prompt "Say hello"} 30000)]
           ;; The model should follow the instruction
@@ -199,7 +200,8 @@
   (when-e2e
    (testing "System message replace mode"
      (let [session (sdk/create-session *e2e-client*
-                                       {:system-message {:mode :replace
+                                       {:on-permission-request sdk/approve-all
+                                         :system-message {:mode :replace
                                                          :content "You are a helpful assistant named TestBot. Always introduce yourself."}})]
        (let [result (sdk/send-and-wait! session {:prompt "Who are you?"} 30000)]
          (is (some? result))
@@ -210,11 +212,11 @@
 (deftest ^:e2e test-e2e-resume-session
   (when-e2e
    (testing "Resume existing session"
-     (let [session1 (sdk/create-session *e2e-client* {})
+     (let [session1 (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})
            session-id (sdk/session-id session1)
            _ (sdk/send-and-wait! session1 {:prompt "Remember the word: APPLE"} 30000)
             ;; Resume the session
-           session2 (sdk/resume-session *e2e-client* session-id {})]
+           session2 (sdk/resume-session *e2e-client* session-id {:on-permission-request sdk/approve-all})]
        (is (= session-id (sdk/session-id session2)))
         ;; Should have conversation context
        (let [result (sdk/send-and-wait! session2
@@ -228,8 +230,8 @@
 (deftest ^:e2e test-e2e-multiple-sessions
   (when-e2e
    (testing "Multiple concurrent sessions"
-     (let [session1 (sdk/create-session *e2e-client* {})
-           session2 (sdk/create-session *e2e-client* {})]
+     (let [session1 (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})
+           session2 (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})]
         ;; Should have unique IDs
        (is (not= (sdk/session-id session1) (sdk/session-id session2)))
         ;; Both should work
@@ -243,7 +245,7 @@
 (deftest ^:e2e test-e2e-send-returns-immediately
   (when-e2e
    (testing "send! returns immediately before completion"
-     (let [session (sdk/create-session *e2e-client* {})
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})
            events (atom [])
            events-ch (sdk/subscribe-events session)]
         ;; Start collecting events in background
@@ -262,7 +264,7 @@
 (deftest ^:e2e test-e2e-send-and-wait-timeout
   (when-e2e
    (testing "sendAndWait throws on timeout"
-     (let [session (sdk/create-session *e2e-client* {})]
+     (let [session (sdk/create-session *e2e-client* {:on-permission-request sdk/approve-all})]
         ;; Use a very short timeout that should fail
         ;; Suppress logs since the expected ERROR message is noisy
        (with-quiet-logs

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -192,21 +192,22 @@
 (deftest test-create-session
   (testing "Create new session"
     (let [session (sdk/create-session *test-client*
-                                      {:model "gpt-5.2"})]
+                                      {:on-permission-request sdk/approve-all
+                                       :model "gpt-5.2"})]
       (is (some? session))
       (is (string? (sdk/session-id session)))
       (is (clojure.string/starts-with? (sdk/session-id session) "session-")))))
 
 (deftest test-list-sessions
   (testing "List sessions includes created sessions"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           sessions (sdk/list-sessions *test-client*)]
       (is (seq sessions))
       (is (some #(= (sdk/session-id session) (:session-id %)) sessions)))))
 
 (deftest test-list-sessions-with-context
   (testing "List sessions returns context when present"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           sid (sdk/session-id session)]
       (mock/set-session-context! *mock-server* sid
                                  {:cwd "/home/user/project"
@@ -222,8 +223,8 @@
 
 (deftest test-list-sessions-with-filter
   (testing "List sessions filter narrows results"
-    (let [s1 (sdk/create-session *test-client* {})
-          s2 (sdk/create-session *test-client* {})]
+    (let [s1 (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          s2 (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})]
       (mock/set-session-context! *mock-server* (sdk/session-id s1)
                                  {:cwd "/project-a" :repository "org/repo-a"})
       (mock/set-session-context! *mock-server* (sdk/session-id s2)
@@ -253,19 +254,19 @@
 
 (deftest test-get-current-model
   (testing "Get current model for session"
-    (let [session (sdk/create-session *test-client* {:model "gpt-5.2"})]
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-5.2"})]
       (is (= "gpt-5.2" (sdk/get-current-model session))))))
 
 (deftest test-switch-model
   (testing "Switch model for session"
-    (let [session (sdk/create-session *test-client* {:model "gpt-5.2"})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-5.2"})
           new-model (sdk/switch-model! session "claude-sonnet-4.5")]
       (is (= "claude-sonnet-4.5" new-model))
       (is (= "claude-sonnet-4.5" (sdk/get-current-model session))))))
 
 (deftest test-delete-session
   (testing "Delete session removes it from list"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           session-id (sdk/session-id session)
           _ (sdk/delete-session! *test-client* session-id)
           sessions (sdk/list-sessions *test-client*)]
@@ -273,7 +274,7 @@
 
 (deftest test-destroy-session
   (testing "Destroy session via session object"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           session-id (sdk/session-id session)]
       (sdk/destroy! session)
       (let [sessions (sdk/list-sessions *test-client*)]
@@ -285,13 +286,13 @@
 
 (deftest test-send-message
   (testing "Send message returns message ID"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           msg-id (sdk/send! session {:prompt "Hello world"})]
       (is (string? msg-id)))))
 
 (deftest test-send-and-wait
   (testing "Send and wait receives events and returns assistant message"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           result (sdk/send-and-wait! session {:prompt "Test message"})]
       ;; Returns the last assistant message event (map)
       (is (map? result))
@@ -300,7 +301,7 @@
 
 (deftest test-send-and-wait-serializes
   (testing "send-and-wait serializes concurrent calls"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           session-id (sdk/session-id session)
           client (:client session)
           send-calls (atom 0)]
@@ -326,7 +327,7 @@
 
 (deftest test-send-async
   (testing "Send async returns channel with events"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           event-ch (sdk/send-async session {:prompt "Async test"})
           events (atom [])]
       ;; Collect events
@@ -342,7 +343,7 @@
 
 (deftest test-send-async-with-id
   (testing "send-async-with-id returns message-id and matching events"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           {:keys [message-id events-ch]} (sdk/send-async-with-id session {:prompt "Async with id"})]
       (is (string? message-id))
       (let [matched (loop [count 0]
@@ -358,7 +359,7 @@
 
 (deftest test-send-async-serializes
   (testing "send-async serializes concurrent calls"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           session-id (sdk/session-id session)
           client (:client session)
           send-calls (atom 0)]
@@ -391,7 +392,7 @@
 
 (deftest test-<send!-returns-last-assistant-message
   (testing "<send! returns the last assistant.message content, not the first"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           session-id (sdk/session-id session)
           client (:client session)]
       ;; Bypass actual send to control event flow
@@ -444,13 +445,13 @@
 
 (deftest test-abort-session
   (testing "Abort session operation"
-    (let [session (sdk/create-session *test-client* {})]
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})]
       ;; Should not throw
       (is (nil? (sdk/abort! session))))))
 
 (deftest test-get-messages
   (testing "Get messages from session"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           _ (sdk/send-and-wait! session {:prompt "Test"})
           messages (sdk/get-messages session)]
       ;; Mock server returns empty events vector
@@ -462,7 +463,7 @@
 
 (deftest test-event-subscription
   (testing "Can subscribe to session event stream"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           events-ch (sdk/subscribe-events session)]
       ;; Send a message to trigger events
       (sdk/send! session {:prompt "Event test"})
@@ -538,7 +539,8 @@
 (deftest test-tool-registration
   (testing "Register tool handler"
     (let [session (sdk/create-session *test-client*
-                                      {:tools [(sdk/define-tool "test_tool"
+                                      {:on-permission-request sdk/approve-all
+                                       :tools [(sdk/define-tool "test_tool"
                                                  {:description "A test tool"
                                                   :parameters {:type "object"
                                                                :properties {"value" {:type "string"}}}
@@ -549,7 +551,7 @@
   (testing "tool.call handler returns a nested result wrapper"
     (let [tool (sdk/define-tool "echo"
                  {:handler (fn [args _] args)})
-          session (sdk/create-session *test-client* {:tools [tool]})
+          session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :tools [tool]})
           handler (get-in @(:state *test-client*) [:connection :request-handler])
           response (<!! (handler "tool.call" {:session-id (sdk/session-id session)
                                               :tool-call-id "tc-1"
@@ -570,7 +572,7 @@
                  {:handler (fn [_ _]
                              (reset! thread-name (.getName (Thread/currentThread)))
                              "ok")})
-          session (sdk/create-session *test-client* {:tools [tool]})
+          session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :tools [tool]})
           handler (get-in @(:state *test-client*) [:connection :request-handler])]
       (<!! (handler "tool.call" {:session-id (sdk/session-id session)
                                  :tool-call-id "tc-2"
@@ -587,7 +589,8 @@
                                                     (when (#{"session.create" "session.resume"} method)
                                                       (swap! seen assoc method params))))
           _ (sdk/create-session *test-client*
-                                {:model "gpt-5.2"
+                                {:on-permission-request sdk/approve-all
+                                 :model "gpt-5.2"
                                  :provider {:base-url "https://example.test"
                                             :api-key "key"}
                                  :mcp-servers {"srv-1" {:mcp-server-type :http
@@ -599,7 +602,8 @@
                                                   :agent-display-name "Agent One"}]})
           session-id (sdk/get-last-session-id *test-client*)
           _ (sdk/resume-session *test-client* session-id
-                                {:model "gpt-5.2"
+                                {:on-permission-request sdk/approve-all
+                                 :model "gpt-5.2"
                                  :provider {:base-url "https://resume.test"}
                                  :mcp-servers {"srv-2" {:mcp-server-type :sse
                                                         :mcp-url "https://mcp.resume.test"
@@ -632,17 +636,17 @@
           _ (mock/set-request-hook! *mock-server* (fn [method params]
                                                     (when (#{"session.create"} method)
                                                       (swap! seen assoc method params))))
-          _ (sdk/create-session *test-client* {:client-name "my-app"})
+          _ (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :client-name "my-app"})
           create-params (get @seen "session.create")]
       (is (= "my-app" (:clientName create-params)))))
 
   (testing "clientName is forwarded in session.resume when set (upstream PR #510)"
     (let [seen (atom {})
-          session-id (sdk/session-id (sdk/create-session *test-client* {}))
+          session-id (sdk/session-id (sdk/create-session *test-client* {:on-permission-request sdk/approve-all}))
           _ (mock/set-request-hook! *mock-server* (fn [method params]
                                                     (when (#{"session.resume"} method)
                                                       (swap! seen assoc method params))))
-          _ (sdk/resume-session *test-client* session-id {:client-name "my-app"})
+          _ (sdk/resume-session *test-client* session-id {:on-permission-request sdk/approve-all :client-name "my-app"})
           resume-params (get @seen "session.resume")]
       (is (= "my-app" (:clientName resume-params)))))
 
@@ -651,7 +655,7 @@
           _ (mock/set-request-hook! *mock-server* (fn [method params]
                                                     (when (#{"session.create"} method)
                                                       (swap! seen assoc method params))))
-          _ (sdk/create-session *test-client* {:model "gpt-5.2"})
+          _ (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-5.2"})
           create-params (get @seen "session.create")]
       (is (not (contains? create-params :clientName))))))
 
@@ -660,18 +664,17 @@
 ;; -----------------------------------------------------------------------------
 
 (deftest test-request-permission-always-true-on-wire
-  (testing "requestPermission is always true on create, even without handler"
+  (testing "requestPermission is always true on create with handler"
     (let [seen (atom {})
           _ (mock/set-request-hook! *mock-server* (fn [method params]
                                                     (when (#{"session.create" "session.resume"} method)
                                                       (swap! seen assoc method params))))
-          ;; Create without on-permission-request
-          _ (sdk/create-session *test-client* {:model "gpt-5.2"})
+          _ (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-5.2"})
           create-params (get @seen "session.create")]
       (is (true? (:requestPermission create-params))
-          "requestPermission must be true even when no handler is configured")))
+          "requestPermission must be true when handler is configured")))
 
-  (testing "requestPermission is true on create with handler"
+  (testing "requestPermission is true on create with explicit handler"
     (let [seen (atom {})
           _ (mock/set-request-hook! *mock-server* (fn [method params]
                                                     (when (#{"session.create"} method)
@@ -682,16 +685,16 @@
           create-params (get @seen "session.create")]
       (is (true? (:requestPermission create-params)))))
 
-  (testing "requestPermission is true on resume without handler"
+  (testing "requestPermission is true on resume with handler"
     (let [seen (atom {})
-          session-id (sdk/session-id (sdk/create-session *test-client* {}))
+          session-id (sdk/session-id (sdk/create-session *test-client* {:on-permission-request sdk/approve-all}))
           _ (mock/set-request-hook! *mock-server* (fn [method params]
                                                     (when (#{"session.resume"} method)
                                                       (swap! seen assoc method params))))
-          _ (sdk/resume-session *test-client* session-id {})
+          _ (sdk/resume-session *test-client* session-id {:on-permission-request sdk/approve-all})
           resume-params (get @seen "session.resume")]
       (is (true? (:requestPermission resume-params))
-          "requestPermission must be true on resume even without handler"))))
+          "requestPermission must be true on resume with handler"))))
 
 (deftest test-approve-all-returns-approved
   (testing "approve-all returns {:kind :approved}"
@@ -700,14 +703,35 @@
                                   {:session-id "session-1"})]
       (is (= {:kind :approved} result))))
 
-  (testing "approve-all works for any permission kind"
-    (doseq [kind [:shell :write :mcp :read :url]]
+   (testing "approve-all works for any permission kind"
+    (doseq [kind [:shell :write :mcp :read :url :custom-tool]]
       (is (= {:kind :approved}
              (sdk/approve-all {:permission-kind kind} {:session-id "s1"}))))))
 
-(deftest test-permission-denied-without-handler
-  (testing "Permission requests are denied when no handler is configured"
-    (let [session (sdk/create-session *test-client* {})
+(deftest test-permission-handler-required
+  (testing "create-session throws without :on-permission-request"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"on-permission-request handler is required"
+                          (sdk/create-session *test-client* {}))))
+
+  (testing "create-session throws with nil handler"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"on-permission-request handler is required"
+                          (sdk/create-session *test-client* {:on-permission-request nil}))))
+
+  (testing "resume-session throws without :on-permission-request"
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          session-id (sdk/session-id session)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"on-permission-request handler is required"
+                            (sdk/resume-session *test-client* session-id {}))))))
+
+(deftest test-permission-denied-with-deny-handler
+  (testing "Permission requests are denied when handler denies"
+    (let [session (sdk/create-session *test-client*
+                                      {:on-permission-request
+                                       (fn [_request _ctx]
+                                         {:kind :denied-no-approval-rule-and-could-not-request-from-user})})
           session-id (sdk/session-id session)
           handler (get-in @(:state *test-client*) [:connection :request-handler])
           response (<!! (handler "permission.request"
@@ -761,7 +785,7 @@
 (deftest test-send-async-untaps-on-send-failure
   (testing "send-async cleans up tap when RPC fails"
     (log/info "Warnings expected in this test: async send RPC error is deliberate.")
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           taps (atom 0)
           untaps (atom 0)
           fake-mult (reify
@@ -786,7 +810,7 @@
 
 (deftest test-get-last-session-id
   (testing "Get last session ID"
-    (let [_ (sdk/create-session *test-client* {})
+    (let [_ (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           last-id (sdk/get-last-session-id *test-client*)]
       (is (string? last-id)))))
 
@@ -796,8 +820,8 @@
 
 (deftest test-multiple-sessions
   (testing "Can manage multiple concurrent sessions"
-    (let [session1 (sdk/create-session *test-client* {:model "model-1"})
-          session2 (sdk/create-session *test-client* {:model "model-2"})
+    (let [session1 (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :model "model-1"})
+          session2 (sdk/create-session *test-client* {:on-permission-request sdk/approve-all :model "model-2"})
           id1 (sdk/session-id session1)
           id2 (sdk/session-id session2)]
       (is (not= id1 id2))
@@ -813,7 +837,7 @@
 (deftest test-resume-nonexistent-session
   (testing "Resume nonexistent session throws error"
     (is (thrown-with-msg? Exception #"Session not found"
-                          (sdk/resume-session *test-client* "nonexistent-session-id" {})))))
+                          (sdk/resume-session *test-client* "nonexistent-session-id" {:on-permission-request sdk/approve-all})))))
 
 (deftest test-tool-handler-errors
   (testing "Tool handler that throws returns failure result"
@@ -824,7 +848,8 @@
                         :handler (fn [_ _]
                                    (throw (ex-info "Tool error" {:cause "test"})))})
           session (sdk/create-session *test-client*
-                                      {:tools [error-tool]})]
+                                      {:on-permission-request sdk/approve-all
+                                       :tools [error-tool]})]
       ;; Session should still be usable after tool error
       (is (some? session)))))
 
@@ -835,7 +860,8 @@
 (deftest test-session-with-append-system-message
   (testing "Create session with appended system message"
     (let [session (sdk/create-session *test-client*
-                                      {:system-message {:mode :append
+                                      {:on-permission-request sdk/approve-all
+                                       :system-message {:mode :append
                                                         :content "Always end with 'DONE'"}})]
       (is (some? session))
       (is (string? (sdk/session-id session))))))
@@ -843,7 +869,8 @@
 (deftest test-session-with-replace-system-message
   (testing "Create session with replaced system message"
     (let [session (sdk/create-session *test-client*
-                                      {:system-message {:mode :replace
+                                      {:on-permission-request sdk/approve-all
+                                       :system-message {:mode :replace
                                                         :content "You are a test assistant."}})]
       (is (some? session))
       (is (string? (sdk/session-id session))))))
@@ -855,7 +882,8 @@
 (deftest test-session-with-streaming
   (testing "Create session with streaming enabled"
     (let [session (sdk/create-session *test-client*
-                                      {:streaming? true})]
+                                      {:on-permission-request sdk/approve-all
+                                       :streaming? true})]
       (is (some? session))
       ;; Should still work normally
       (let [result (sdk/send-and-wait! session {:prompt "Test"})]
@@ -867,10 +895,10 @@
 
 (deftest test-resume-session
   (testing "Resume existing session"
-    (let [session1 (sdk/create-session *test-client* {})
+    (let [session1 (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           session-id (sdk/session-id session1)
           _ (sdk/send-and-wait! session1 {:prompt "First message"})
-          session2 (sdk/resume-session *test-client* session-id {})]
+          session2 (sdk/resume-session *test-client* session-id {:on-permission-request sdk/approve-all})]
       (is (= session-id (sdk/session-id session2)))
       ;; Should be able to continue conversation
       (let [result (sdk/send-and-wait! session2 {:prompt "Follow up"})]
@@ -882,7 +910,7 @@
 
 (deftest test-session-snapshot-rewind-event
   (testing "session.snapshot_rewind event is received and parsed correctly"
-    (let [session (sdk/create-session *test-client* {})
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           session-id (sdk/session-id session)
           events-ch (sdk/subscribe-events session)
           rewind-events (atom [])]
@@ -914,7 +942,7 @@
 
 (deftest test-<create-session
   (testing "<create-session creates session asynchronously"
-    (let [result-ch (sdk/<create-session *test-client* {:model "gpt-4.1"})
+    (let [result-ch (sdk/<create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-4.1"})
           [session _] (alts!! [result-ch (timeout 5000)])]
       (is (some? session) "<create-session should deliver a session")
       (is (not (instance? Throwable session)) "<create-session should not return an error")
@@ -923,9 +951,9 @@
 
 (deftest test-<create-session-parallel
   (testing "Multiple <create-session calls run concurrently in go blocks"
-    (let [ch1 (sdk/<create-session *test-client* {:model "gpt-4.1"})
-          ch2 (sdk/<create-session *test-client* {:model "gpt-4.1"})
-          ch3 (sdk/<create-session *test-client* {:model "gpt-4.1"})
+    (let [ch1 (sdk/<create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-4.1"})
+          ch2 (sdk/<create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-4.1"})
+          ch3 (sdk/<create-session *test-client* {:on-permission-request sdk/approve-all :model "gpt-4.1"})
           [s1 _] (alts!! [ch1 (timeout 5000)])
           [s2 _] (alts!! [ch2 (timeout 5000)])
           [s3 _] (alts!! [ch3 (timeout 5000)])]

--- a/test/github/copilot_sdk_test.clj
+++ b/test/github/copilot_sdk_test.clj
@@ -226,7 +226,8 @@
 
 (deftest session-config-unknown-keys-test
   (testing "unknown session config key is rejected"
-    (is (not (s/valid? ::specs/session-config {:reasoning-efforts "high"}))))
+    (is (not (s/valid? ::specs/session-config {:on-permission-request identity
+                                                :reasoning-efforts "high"}))))
 
   (testing "typo in session config provides helpful error"
     (let [unknown (specs/unknown-keys {:model "gpt-5.2" :streeming? true}
@@ -234,12 +235,14 @@
       (is (contains? unknown :streeming?))))
 
   (testing "valid session config keys are accepted"
-    (is (s/valid? ::specs/session-config {:model "gpt-5.2"
-                                          :streaming? true
-                                          :reasoning-effort "high"})))
+    (is (s/valid? ::specs/session-config {:on-permission-request identity
+                                           :model "gpt-5.2"
+                                           :streaming? true
+                                           :reasoning-effort "high"})))
 
   (testing "session config rejects unknown keys even with valid ones"
-    (is (not (s/valid? ::specs/session-config {:model "gpt-5.2"
+    (is (not (s/valid? ::specs/session-config {:on-permission-request identity
+                                                :model "gpt-5.2"
                                                 :unknown-key "value"})))))
 
 (deftest evt-helper-test


### PR DESCRIPTION
## Summary

**BREAKING**: `:on-permission-request` is now required in session config maps for `create-session` and `resume-session` (and their async variants).

This PR ports three upstream copilot-sdk changes:

### PR #554 — Require `onPermissionRequest` on session creation/resume
- `:on-permission-request` moved from `opt-un` to `req-un` in `::session-config` and `::resume-session-config` specs
- Removed 0-arity `create-session` and 2-arity `resume-session` (and async variants)
- Added explicit validation with clear error message before spec validation
- Updated `with-session` macro to require config argument
- Updated all tests (integration + E2E), examples (10 files), and docs

### PR #555 — Add `custom-tool` permission kind
- Added `:custom-tool` to `::permission-kind` spec for custom tool permission requests

### PR #544 — Agent selection & compaction (partial)
- Added `:copilot/session.task_complete` event type (additive)
- Skipped RPC methods (`agent.select`, `context.compact`) — not exposed in public SDK API

### Bug fix (found during code review)
- Fixed `build-session-config` in `helpers.clj` to pass through `:on-permission-request` — without this, `h/query`, `h/query-seq!`, and `h/query-chan` would silently drop the handler when creating sessions from option maps

### Verification
- ✅ 85 tests, 253 assertions, 0 failures
- ✅ All 9 examples pass
- ✅ Documentation valid (10 files, 0 warnings)

### Files changed (23)
- **Specs/Client**: `specs.clj`, `client.clj`, `copilot_sdk.clj`, `helpers.clj`, `instrument.clj`
- **Tests**: `integration_test.clj`, `e2e_test.clj`, `copilot_sdk_test.clj`
- **Examples**: 10 example files
- **Docs**: `README.md`, `getting-started.md`, `API.md`, `examples/README.md`, `CHANGELOG.md`