### PR TITLE
feat: add get-session-metadata for O(1) session lookup (upstream PR #899)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Added (v0.2.1 sync)
 - **`steerable` field on `session.start` events** — `session.start` event data now includes optional `:steerable?` boolean field indicating whether the session supports remote steering via Mission Control. New `::steerable?` spec added (upstream PR #927).
+- **`get-session-metadata`** — new function on client for efficient O(1) session lookup by ID. Returns session metadata map if found, or `nil` if not found. Sends `session.getMetadata` JSON-RPC call. Shared `wire->session-metadata` helper extracted from `list-sessions` to eliminate duplication (upstream PR #899).
 
 ### Changed (v0.2.1 sync)
 - **`session.idle` is now ephemeral** — the runtime no longer persists `session.idle` events in session history. `get-messages` will no longer return `session.idle` events. Live event listeners (used by `send-and-wait!` and `send!`) are unaffected and still receive it (upstream PR #927).

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -586,8 +586,8 @@ The returned map has the same shape as entries returned by `list-sessions`:
 ```clojure
 (def metadata (copilot/get-session-metadata client "session-abc123"))
 ;; => {:session-id "session-abc123"
-;;     :start-time #inst "2025-01-15T10:00:00Z"
-;;     :modified-time #inst "2025-01-15T10:05:00Z"
+;;     :start-time #object[java.time.Instant 0x... "2025-01-15T10:00:00Z"]
+;;     :modified-time #object[java.time.Instant 0x... "2025-01-15T10:05:00Z"]
 ;;     :remote? false
 ;;     :summary "Refactoring auth module"
 ;;     :context {:cwd "/home/user/project"}}

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -567,6 +567,35 @@ Returns a vector of session metadata maps with `:start-time` and `:modified-time
 ;;     ...]
 ```
 
+#### `get-session-metadata`
+
+```clojure
+(copilot/get-session-metadata client session-id)
+```
+
+Get metadata for a specific session by ID. Returns the session metadata map if found, or `nil` if the session does not exist. Provides an efficient O(1) lookup instead of calling `list-sessions` and filtering client-side.
+
+The returned map has the same shape as entries returned by `list-sessions`:
+- `:session-id` — session ID string
+- `:start-time` — `java.time.Instant` when the session was created
+- `:modified-time` — `java.time.Instant` of last modification
+- `:remote?` — boolean, true if the session is remote
+- `:summary` — optional summary string
+- `:context` — optional map with `:cwd` and optional `:git-root`, `:repository`, `:branch`
+
+```clojure
+(def metadata (copilot/get-session-metadata client "session-abc123"))
+;; => {:session-id "session-abc123"
+;;     :start-time #inst "2025-01-15T10:00:00Z"
+;;     :modified-time #inst "2025-01-15T10:05:00Z"
+;;     :remote? false
+;;     :summary "Refactoring auth module"
+;;     :context {:cwd "/home/user/project"}}
+
+(copilot/get-session-metadata client "non-existent-id")
+;; => nil
+```
+
 #### `delete-session!`
 
 ```clojure

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -653,7 +653,7 @@
    Example:
    ```clojure
    (copilot/get-session-metadata client \"session-abc123\")
-   ;; => {:session-id \"session-abc123\" :start-time #inst \"...\" ...}
+   ;; => {:session-id \"session-abc123\" :start-time #object[java.time.Instant ...] ...}
 
    (copilot/get-session-metadata client \"non-existent-id\")
    ;; => nil

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -644,6 +644,23 @@
   ([client filter-opts]
    (client/list-sessions client filter-opts)))
 
+(defn get-session-metadata
+  "Gets metadata for a specific session by ID.
+
+   Returns the session metadata map if found, or nil if not found.
+   Provides an efficient O(1) lookup instead of listing all sessions.
+
+   Example:
+   ```clojure
+   (copilot/get-session-metadata client \"session-abc123\")
+   ;; => {:session-id \"session-abc123\" :start-time #inst \"...\" ...}
+
+   (copilot/get-session-metadata client \"non-existent-id\")
+   ;; => nil
+   ```"
+  [client session-id]
+  (client/get-session-metadata client session-id))
+
 (defn delete-session!
   "Delete a session and its data from disk."
   [client session-id]

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -1591,6 +1591,20 @@
           (try (stop! c) (catch Throwable _))
           (throw t))))))
 
+(defn- wire->session-metadata
+  "Convert a wire-format session map to the Clojure session-metadata shape."
+  [s]
+  (let [ctx (:context s)]
+    (cond-> {:session-id (:session-id s)
+             :start-time (java.time.Instant/parse (:start-time s))
+             :modified-time (java.time.Instant/parse (:modified-time s))
+             :summary (:summary s)
+             :remote? (:is-remote s)}
+      ctx (assoc :context (cond-> {:cwd (:cwd ctx)}
+                            (:git-root ctx) (assoc :git-root (:git-root ctx))
+                            (:repository ctx) (assoc :repository (:repository ctx))
+                            (:branch ctx) (assoc :branch (:branch ctx)))))))
+
 (defn list-sessions
   "List all available sessions.
    Returns a vector of session metadata maps.
@@ -1611,18 +1625,28 @@
                                      (cond-> {}
                                        wire-filter (assoc :filter wire-filter)))
          sessions (:sessions result)]
-     (mapv (fn [s]
-             (let [ctx (:context s)]
-               (cond-> {:session-id (:session-id s)
-                        :start-time (java.time.Instant/parse (:start-time s))
-                        :modified-time (java.time.Instant/parse (:modified-time s))
-                        :summary (:summary s)
-                        :remote? (:is-remote s)}
-                 ctx (assoc :context (cond-> {:cwd (:cwd ctx)}
-                                      (:git-root ctx) (assoc :git-root (:git-root ctx))
-                                      (:repository ctx) (assoc :repository (:repository ctx))
-                                      (:branch ctx) (assoc :branch (:branch ctx)))))))
-           sessions))))
+     (mapv wire->session-metadata sessions))))
+
+(defn get-session-metadata
+  "Gets metadata for a specific session by ID.
+
+   Provides an efficient O(1) lookup of a single session's metadata instead
+   of listing all sessions and filtering client-side.
+
+   Returns the session metadata map if found, or nil if not found.
+
+   The returned map has keys:
+   - :session-id — the session ID string
+   - :start-time — java.time.Instant when the session was created
+   - :modified-time — java.time.Instant of last modification
+   - :remote? — boolean, true if the session is remote
+   - :summary — optional summary string
+   - :context — optional map with :cwd and optional :git-root, :repository, :branch"
+  [client session-id]
+  (ensure-connected! client)
+  (let [{:keys [connection-io]} @(:state client)
+        result (proto/send-request! connection-io "session.getMetadata" {:session-id session-id})]
+    (some-> (:session result) wire->session-metadata)))
 
 (defn delete-session!
   "Permanently deletes a session and all its data from disk, including

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -1594,16 +1594,19 @@
 (defn- wire->session-metadata
   "Convert a wire-format session map to the Clojure session-metadata shape."
   [s]
-  (let [ctx (:context s)]
-    (cond-> {:session-id (:session-id s)
-             :start-time (java.time.Instant/parse (:start-time s))
-             :modified-time (java.time.Instant/parse (:modified-time s))
-             :summary (:summary s)
-             :remote? (:is-remote s)}
-      ctx (assoc :context (cond-> {:cwd (:cwd ctx)}
-                            (:git-root ctx) (assoc :git-root (:git-root ctx))
-                            (:repository ctx) (assoc :repository (:repository ctx))
-                            (:branch ctx) (assoc :branch (:branch ctx)))))))
+  (let [ctx (:context s)
+        cwd (:cwd ctx)
+        base (cond-> {:session-id (:session-id s)
+                      :start-time (java.time.Instant/parse (:start-time s))
+                      :modified-time (java.time.Instant/parse (:modified-time s))
+                      :remote? (:is-remote s)}
+               (:summary s) (assoc :summary (:summary s)))]
+    (cond-> base
+      (and ctx (seq cwd))
+      (assoc :context (cond-> {:cwd cwd}
+                        (:git-root ctx) (assoc :git-root (:git-root ctx))
+                        (:repository ctx) (assoc :repository (:repository ctx))
+                        (:branch ctx) (assoc :branch (:branch ctx)))))))
 
 (defn list-sessions
   "List all available sessions.

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -77,6 +77,11 @@
                :filter (s/? (s/nilable ::specs/session-list-filter)))
   :ret (s/coll-of ::specs/session-metadata))
 
+(s/fdef github.copilot-sdk.client/get-session-metadata
+  :args (s/cat :client ::specs/client
+               :session-id ::specs/session-id)
+  :ret (s/nilable ::specs/session-metadata))
+
 (s/fdef github.copilot-sdk.client/delete-session!
   :args (s/cat :client ::specs/client
                :session-id ::specs/session-id)
@@ -372,6 +377,7 @@
                       github.copilot-sdk.client/<resume-session
                       github.copilot-sdk.client/join-session
                       github.copilot-sdk.client/list-sessions
+                      github.copilot-sdk.client/get-session-metadata
                       github.copilot-sdk.client/delete-session!
                       github.copilot-sdk.client/get-last-session-id
                       github.copilot-sdk.client/get-foreground-session-id
@@ -445,6 +451,7 @@
                       github.copilot-sdk.client/<resume-session
                       github.copilot-sdk.client/join-session
                       github.copilot-sdk.client/list-sessions
+                      github.copilot-sdk.client/get-session-metadata
                       github.copilot-sdk.client/delete-session!
                       github.copilot-sdk.client/get-last-session-id
                       github.copilot-sdk.client/get-foreground-session-id

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -272,6 +272,36 @@
         (is (= 1 (count filtered)))
         (is (= (sdk/session-id s1) (:session-id (first filtered))))))))
 
+(deftest test-get-session-metadata
+  (testing "Get metadata for an existing session"
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          sid (sdk/session-id session)
+          metadata (sdk/get-session-metadata *test-client* sid)]
+      (is (some? metadata))
+      (is (= sid (:session-id metadata)))
+      (is (instance? java.time.Instant (:start-time metadata)))
+      (is (instance? java.time.Instant (:modified-time metadata)))
+      (is (= false (:remote? metadata))))))
+
+(deftest test-get-session-metadata-with-context
+  (testing "Get session metadata includes context when present"
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          sid (sdk/session-id session)]
+      (mock/set-session-context! *mock-server* sid
+                                 {:cwd "/home/user/project"
+                                  :gitRoot "/home/user/project"
+                                  :repository "owner/repo"
+                                  :branch "main"})
+      (let [metadata (sdk/get-session-metadata *test-client* sid)]
+        (is (some? metadata))
+        (is (= "/home/user/project" (get-in metadata [:context :cwd])))
+        (is (= "owner/repo" (get-in metadata [:context :repository])))
+        (is (= "main" (get-in metadata [:context :branch])))))))
+
+(deftest test-get-session-metadata-not-found
+  (testing "Get metadata for non-existent session returns nil"
+    (is (nil? (sdk/get-session-metadata *test-client* "non-existent-session-id")))))
+
 (deftest test-list-tools
   (testing "List tools returns tool info"
     (let [tools (sdk/list-tools *test-client*)]

--- a/test/github/copilot_sdk/mock_server.clj
+++ b/test/github/copilot_sdk/mock_server.clj
@@ -220,6 +220,17 @@
     (swap! (:sessions server) dissoc session-id)
     {:success true}))
 
+(defn- handle-session-get-metadata [server params]
+  (let [session-id (:sessionId params)
+        session-state (get @(:sessions server) session-id)]
+    (if session-state
+      {:session (cond-> {:sessionId session-id
+                         :startTime (.toString (:created-at session-state))
+                         :modifiedTime (.toString (java.time.Instant/now))
+                         :isRemote false}
+                  (:context session-state) (assoc :context (:context session-state)))}
+      {:session nil})))
+
 (defn- handle-session-get-last-id [server params]
   (let [sessions @(:sessions server)]
     (if (empty? sessions)
@@ -294,6 +305,7 @@
                  "session.abort" (handle-session-abort server params)
                  "session.getMessages" (handle-session-get-messages server params)
                  "session.list" (handle-session-list server params)
+                 "session.getMetadata" (handle-session-get-metadata server params)
                  "session.delete" (handle-session-delete server params)
                  "session.getLastId" (handle-session-get-last-id server params)
                  "tools.list" (handle-tools-list server params)


### PR DESCRIPTION
Ports upstream copilot-sdk PR #899. Supersedes automated PR #74 with improvements:

- **Shared helper**: Extracted `wire->session-metadata` private fn used by both `list-sessions` and `get-session-metadata` (mirrors upstream's `toSessionMetadata` refactor)
- **Integration tests**: 3 tests covering existing session, session with context, and not-found (nil) case
- **Mock server**: Added `session.getMetadata` handler

All 109 tests pass (374 assertions), all examples run successfully, docs validated.

Closes #74