### PR TITLE
Port upstream PRs #908, #916, #917, #970: elicitation provider, sessionFs, event fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 
 ### Added (v0.2.1 sync)
-- **`steerable` field on `session.start` events** — `session.start` event data now includes optional `:steerable?` boolean field indicating whether the session supports remote steering via Mission Control. New `::steerable?` spec added (upstream PR #927).
+- **`remote-steerable?` field on `session.start` and `session.resume` events** — event data now includes optional `:remote-steerable?` boolean field indicating whether the session supports remote steering via Mission Control. Replaces previous `:steerable?` (upstream PRs #927, #908).
 - **`get-session-metadata`** — new function on client for efficient O(1) session lookup by ID. Returns session metadata map if found, or `nil` if not found. Sends `session.getMetadata` JSON-RPC call. Shared `wire->session-metadata` helper extracted from `list-sessions` to eliminate duplication (upstream PR #899).
 - **Elicitation provider support** — new `:on-elicitation-request` handler on `SessionConfig` and `ResumeSessionConfig`. When provided, sends `requestElicitation: true` in the session create/resume RPC. The runtime routes `elicitation.requested` broadcast events to the handler, and results are sent back via `session.ui.handlePendingElicitation` RPC. Handler errors automatically send a cancel response. New `::elicitation-request` and `::on-elicitation-request` specs (upstream PR #908).
 - **`capabilities.changed` event handling** — session capabilities are dynamically updated when `capabilities.changed` broadcast events are received, e.g. when another client joins with elicitation support (upstream PR #908).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@ All notable changes to this project will be documented in this file. This change
 ### Added (v0.2.1 sync)
 - **`steerable` field on `session.start` events** — `session.start` event data now includes optional `:steerable?` boolean field indicating whether the session supports remote steering via Mission Control. New `::steerable?` spec added (upstream PR #927).
 - **`get-session-metadata`** — new function on client for efficient O(1) session lookup by ID. Returns session metadata map if found, or `nil` if not found. Sends `session.getMetadata` JSON-RPC call. Shared `wire->session-metadata` helper extracted from `list-sessions` to eliminate duplication (upstream PR #899).
+- **Elicitation provider support** — new `:on-elicitation-request` handler on `SessionConfig` and `ResumeSessionConfig`. When provided, sends `requestElicitation: true` in the session create/resume RPC. The runtime routes `elicitation.requested` broadcast events to the handler, and results are sent back via `session.ui.handlePendingElicitation` RPC. Handler errors automatically send a cancel response. New `::elicitation-request` and `::on-elicitation-request` specs (upstream PR #908).
+- **`capabilities.changed` event handling** — session capabilities are dynamically updated when `capabilities.changed` broadcast events are received, e.g. when another client joins with elicitation support (upstream PR #908).
+- **New event types** — `sampling.requested`, `sampling.completed`, `session.remote_steerable_changed`, `capabilities.changed` added to event type enum and event sets (upstream PRs #908, #916).
+- **Subagent event data fields** — `subagent.started`, `subagent.completed`, `subagent.failed` events now include optional `:model`, `:total-tool-calls`, `:total-tokens`, `:duration-ms` fields. New `::subagent.started-data`, `::subagent.completed-data`, `::subagent.failed-data` specs (upstream PR #916).
+- **`skill.invoked` event `:description` field** — optional `:description` from SKILL.md frontmatter (upstream PR #916).
+- **`session.custom_agents_updated` payload spec** — full `::session.custom_agents_updated-data` spec with `:agents` (array of agent metadata), `:warnings`, `:errors`. New `::custom-agent-info` spec (upstream PR #916).
+- **SessionFs virtual filesystem** — new `:session-fs` client option with `:initial-cwd`, `:session-state-path`, `:conventions`. Client calls `sessionFs.setProvider` RPC on connect. New `:create-session-fs-handler` on session config provides a per-session FS handler factory. The SDK dispatches incoming `sessionFs.*` RPC requests (10 operations: `readFile`, `writeFile`, `appendFile`, `exists`, `stat`, `mkdir`, `readdir`, `readdirWithTypes`, `rm`, `rename`) to the session's handler. Enables custom session storage backends (upstream PR #917).
+- **`aborted?` on `session.task_complete`** — optional boolean indicating the preceding agentic loop was cancelled via abort signal. New `::aborted?` spec (upstream PR #917).
+- **`timeout` tool result type** — `::result-type` now accepts `:timeout` / `"timeout"` for tool calls that timed out (upstream PR #970).
+- Integration tests for elicitation provider routing, handler error→cancel fallback, capabilities.changed updates, and requestElicitation wire flag.
 
 ### Changed (v0.2.1 sync)
+- **BREAKING**: `::steerable?` renamed to `::remote-steerable?` on `session.start` and `session.resume` event data, matching upstream wire field rename from `steerable` to `remoteSteerable` (upstream PR #908).
 - **`session.idle` is now ephemeral** — the runtime no longer persists `session.idle` events in session history. `get-messages` will no longer return `session.idle` events. Live event listeners (used by `send-and-wait!` and `send!`) are unaffected and still receive it (upstream PR #927).
 
 ## [0.2.1.1-SNAPSHOT] - 2026-03-26

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -130,6 +130,7 @@ Get information about the current shared client state. Returns `nil` if no share
 | `:use-logged-in-user?` | boolean | `true` | Use logged-in user auth. Defaults to `false` when `:github-token` is provided. Cannot be used with `:cli-url` |
 | `:on-list-models` | fn | nil | Zero-arg function returning model info maps. Bypasses `models.list` RPC; does not require `start!`. Results are cached the same way as RPC results |
 | `:is-child-process?` | boolean | `false` | When `true`, connect via own stdio to a parent Copilot CLI process (no process spawning). Requires `:use-stdio?` `true`; mutually exclusive with `:cli-url` |
+| `:session-fs` | map | nil | Session filesystem provider config. Keys: `:initial-cwd` (string, required), `:session-state-path` (string, required), `:conventions` (`"windows"` or `"posix"`, required). When set, the client calls `sessionFs.setProvider` on connect and routes filesystem operations through per-session handlers. See [Session Filesystem](#session-filesystem) |
 
 ### Methods
 
@@ -254,6 +255,8 @@ Create a client and session together, ensuring both are cleaned up on exit.
 | `:hooks` | map | Lifecycle hooks (see below) |
 | `:agent` | string | Name of a custom agent to activate at session start. Must match a name in `:custom-agents`. Equivalent to calling `agent.select` after creation. |
 | `:on-event` | fn | Event handler (1-arg fn receiving event maps). Registered before the RPC call, guaranteeing early events like `session.start` are not missed. |
+| `:on-elicitation-request` | fn | Handler for elicitation requests from the agent. When provided, advertises `requestElicitation=true` and handles `elicitation.requested` broadcast events. Receives `(request ctx)` where request has `:message`, `:requested-schema`, `:mode`, `:elicitation-source`, `:url`. Returns an `ElicitationResult` map `{:action "accept"/"decline"/"cancel" :content {...}}`. See [Elicitation Provider](#elicitation-provider) |
+| `:create-session-fs-handler` | fn | Factory for session filesystem handlers. Required when `:session-fs` is set on the client. Called as `(factory session)`, returns a map of FS handler functions. See [Session Filesystem](#session-filesystem) |
 
 #### `resume-session`
 
@@ -1135,8 +1138,8 @@ Convert an unqualified event keyword to a namespace-qualified `:copilot/` keywor
 | `:copilot/session.mode_changed` | Session agent mode changed; data: `{:previous-mode "...", :new-mode "..."}` |
 | `:copilot/session.plan_changed` | Session plan created/updated/deleted; data: `{:operation "create"/"update"/"delete"}` |
 | `:copilot/session.workspace_file_changed` | Workspace file created or updated; data: `{:path "...", :operation "create"/"update"}` |
-| `:copilot/session.task_complete` | Task completed by the session agent; data: `{:summary "..."}` (optional) |
-| `:copilot/skill.invoked` | Skill invocation triggered |
+| `:copilot/session.task_complete` | Task completed by the session agent; data: `{:summary "..." :aborted? false}` (both optional) |
+| `:copilot/skill.invoked` | Skill invocation triggered; data includes :name, :path, :content, optional :description, :plugin-name, :plugin-version |
 | `:copilot/user.message` | User message added |
 | `:copilot/pending_messages.modified` | Pending message queue updated |
 | `:copilot/assistant.turn_start` | Assistant turn started |
@@ -1154,9 +1157,9 @@ Convert an unqualified event keyword to a namespace-qualified `:copilot/` keywor
 | `:copilot/tool.execution_progress` | Tool execution progress update |
 | `:copilot/tool.execution_partial_result` | Tool execution partial result |
 | `:copilot/tool.execution_complete` | Tool execution completed |
-| `:copilot/subagent.started` | Subagent started |
-| `:copilot/subagent.completed` | Subagent completed |
-| `:copilot/subagent.failed` | Subagent failed |
+| `:copilot/subagent.started` | Subagent started; data includes :tool-call-id, :agent-name, :agent-display-name, :agent-description |
+| `:copilot/subagent.completed` | Subagent completed; data includes :tool-call-id, :agent-name, :agent-display-name, optional :model, :total-tool-calls, :total-tokens, :duration-ms |
+| `:copilot/subagent.failed` | Subagent failed; data includes :tool-call-id, :agent-name, :agent-display-name, :error, optional :model, :total-tool-calls, :total-tokens, :duration-ms |
 | `:copilot/subagent.selected` | Subagent selected |
 | `:copilot/subagent.deselected` | Subagent deselected |
 | `:copilot/hook.start` | Hook invocation started |
@@ -1186,6 +1189,10 @@ Convert an unqualified event keyword to a namespace-qualified `:copilot/` keywor
 | `:copilot/session.mcp_server_status_changed` | MCP server status changed |
 | `:copilot/session.extensions_loaded` | Extensions loaded for the session |
 | `:copilot/session.custom_agents_updated` | Custom agents list updated |
+| `:copilot/sampling.requested` | MCP sampling request initiated; ephemeral |
+| `:copilot/sampling.completed` | MCP sampling request completed; ephemeral |
+| `:copilot/session.remote_steerable_changed` | Session remote steering capability changed; data: `{:remote-steerable true/false}` |
+| `:copilot/capabilities.changed` | Session capabilities dynamically changed (e.g., elicitation support); ephemeral. Data: `{:ui {:elicitation true/false}}` |
 
 ### Example: Handling Events
 
@@ -1672,6 +1679,95 @@ The request map includes:
 The response map should include:
 - `:answer` - The user's answer (string, required). `:response` is also accepted for convenience.
 - `:was-freeform` - Whether the answer was freeform (boolean, defaults to true)
+
+### Elicitation Provider
+
+Provide a handler for elicitation requests from the agent. This enables the SDK client to act as a UI provider for form-based dialogs.
+
+```clojure
+(require '[github.copilot-sdk :as copilot])
+
+(def session
+  (copilot/create-session client
+    {:on-permission-request copilot/approve-all
+     :on-elicitation-request
+     (fn [request {:keys [session-id]}]
+       ;; request keys: :message, :requested-schema, :mode, :elicitation-source, :url
+       (println "Elicitation:" (:message request))
+       {:action "accept"
+        :content {:name "user-input"}})}))
+```
+
+The handler receives two arguments:
+
+| Argument | Description |
+|----------|-------------|
+| `request` | Map with `:message` (string), optional `:requested-schema` (JSON Schema map), `:mode` (`"form"` or `"url"`), `:elicitation-source` (string), `:url` (string) |
+| `ctx` | Map with `:session-id` (string) |
+
+Return an `ElicitationResult` map:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `:action` | string | `"accept"`, `"decline"`, or `"cancel"` |
+| `:content` | map | Field values when action is `"accept"` |
+
+If the handler throws, the SDK sends `{:action "cancel"}` to prevent the request from hanging.
+
+When `:on-elicitation-request` is set, the session advertises `requestElicitation=true` in the create/resume RPC. Capabilities are updated dynamically via `capabilities.changed` events.
+
+### Session Filesystem
+
+Virtualize per-session storage with custom filesystem handlers. The runtime routes all session-scoped file I/O (event logs, large outputs, checkpoints) through the provided callbacks.
+
+Configure the client with `:session-fs`:
+
+```clojure
+(require '[github.copilot-sdk :as copilot])
+
+(def client
+  (copilot/client {:session-fs {:initial-cwd "/home/user/project"
+                                :session-state-path "/sessions"
+                                :conventions "posix"}}))
+```
+
+Provide a handler factory per session:
+
+```clojure
+(def session
+  (copilot/create-session client
+    {:on-permission-request copilot/approve-all
+     :create-session-fs-handler
+     (fn [session]
+       (let [store (atom {})]
+         {:read-file    (fn [{:keys [path]}] {:content (get @store path "")})
+          :write-file   (fn [{:keys [path content]}] (swap! store assoc path content) nil)
+          :append-file  (fn [{:keys [path content]}] (swap! store update path str content) nil)
+          :exists       (fn [{:keys [path]}] {:exists (contains? @store path)})
+          :stat         (fn [{:keys [path]}] {:is-file true :is-directory false :size (count (get @store path "")) :mtime "2026-01-01T00:00:00Z"})
+          :mkdir        (fn [_] nil)
+          :readdir      (fn [_] {:entries []})
+          :readdir-with-types (fn [_] {:entries []})
+          :rm           (fn [{:keys [path]}] (swap! store dissoc path) nil)
+          :rename       (fn [{:keys [old-path new-path]}] (swap! store (fn [s] (-> s (assoc new-path (get s old-path "")) (dissoc old-path)))) nil)}))}))
+```
+
+The handler map requires all 10 operations:
+
+| Key | Params | Returns |
+|-----|--------|---------|
+| `:read-file` | `{:session-id :path}` | `{:content "..."}` |
+| `:write-file` | `{:session-id :path :content :mode}` | nil |
+| `:append-file` | `{:session-id :path :content}` | nil |
+| `:exists` | `{:session-id :path}` | `{:exists true/false}` |
+| `:stat` | `{:session-id :path}` | `{:is-file :is-directory :size :mtime}` |
+| `:mkdir` | `{:session-id :path :recursive}` | nil |
+| `:readdir` | `{:session-id :path}` | `{:entries [...]}` |
+| `:readdir-with-types` | `{:session-id :path}` | `{:entries [...]}` |
+| `:rm` | `{:session-id :path :recursive :force}` | nil |
+| `:rename` | `{:session-id :old-path :new-path}` | nil |
+
+Handler functions may return values directly or via core.async channels.
 
 ### Session Hooks
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -812,6 +812,39 @@ clojure -A:examples -X ask-user-failure/run
 
 ---
 
+## Example 18: Elicitation Provider (`elicitation_provider.clj`)
+
+**Difficulty:** Intermediate  
+**Concepts:** Elicitation requests, provider callbacks, MCP OAuth, capabilities
+
+Demonstrates how to act as an elicitation provider — handling form-based or URL-based input requests from MCP servers and sub-agents.
+
+### What It Demonstrates
+
+- Registering an `:on-elicitation-request` handler
+- Inspecting elicitation mode (`"form"` vs `"url"`)
+- Auto-filling form fields from a JSON Schema
+- Observing `elicitation.requested` and `capabilities.changed` events
+
+### Usage
+
+```bash
+clojure -A:examples -X elicitation-provider/run
+```
+
+### Code Walkthrough
+
+The handler receives a request map with `:message`, optional `:requested-schema` (JSON Schema), `:mode` (`"form"` or `"url"`), `:elicitation-source`, and `:url`. It returns an `ElicitationResult`:
+
+```clojure
+{:action "accept"   ;; or "decline" or "cancel"
+ :content {:field-name "value"}}
+```
+
+If the handler throws, the SDK sends `{:action "cancel"}` to prevent hanging. In a real application, the handler would render a UI dialog or open a browser for OAuth flows.
+
+---
+
 ## Clojure vs JavaScript Comparison
 
 Here's how common patterns compare between the Clojure and JavaScript SDKs:

--- a/examples/elicitation_provider.clj
+++ b/examples/elicitation_provider.clj
@@ -1,0 +1,113 @@
+(ns elicitation-provider
+  "Example: Acting as an elicitation provider.
+
+   When an MCP server or sub-agent needs user input (e.g., OAuth consent,
+   configuration choices), the runtime sends an elicitation request to the
+   SDK client. This example shows how to handle those requests.
+
+   The example simulates a scenario where an MCP server triggers an OAuth
+   consent flow — the handler prints the request and auto-approves it."
+  (:require [clojure.core.async :refer [chan tap go-loop <!]]
+            [github.copilot-sdk :as copilot :refer [evt]]))
+
+;; See examples/README.md for usage
+
+(defn handle-elicitation
+  "Handle an elicitation request from the runtime.
+   In a real app this would render a UI dialog or open a browser.
+   Here we print the request and auto-approve."
+  [request {:keys [session-id]}]
+  (println "\n📋 Elicitation request received!")
+  (println "   Session:" session-id)
+  (println "   Message:" (:message request))
+  (when-let [mode (:mode request)]
+    (println "   Mode:" mode))
+  (when-let [source (:elicitation-source request)]
+    (println "   Source:" source))
+  (when-let [url (:url request)]
+    (println "   URL:" url))
+  (when-let [schema (:requested-schema request)]
+    (println "   Schema:" (pr-str schema)))
+
+  ;; Decide how to respond based on mode
+  (case (:mode request)
+    ;; URL mode: the server wants us to open a browser
+    "url"
+    (do
+      (println "   → Auto-approving URL-based elicitation (would open browser)")
+      {:action "accept"})
+
+    ;; Form mode (or nil): the server wants form field values
+    (if-let [props (get-in request [:requested-schema :properties])]
+      (do
+        (println "   → Auto-filling form fields:")
+        (let [content (reduce-kv
+                        (fn [acc field-name field-schema]
+                          (let [field-type (get field-schema "type" (:type field-schema))
+                                value (case field-type
+                                        "boolean" true
+                                        "string" "auto-filled"
+                                        ("number" "integer") 42
+                                        "auto-filled")]
+                            (println (str "     " field-name " (" field-type "): " value))
+                            (assoc acc (keyword field-name) value)))
+                        {}
+                        props)]
+          {:action "accept" :content content}))
+      (do
+        (println "   → No schema provided, approving without content")
+        {:action "accept"}))))
+
+(defn run
+  "Run a session configured as an elicitation provider.
+
+   The agent is asked to interact with an MCP server that may trigger
+   elicitation requests. Even if no elicitation is triggered (model's
+   choice), the handler is registered and ready."
+  [_]
+  (println "=== Elicitation Provider Example ===")
+  (println "This example shows how to handle elicitation requests from MCP servers.\n")
+  (println "The session registers an :on-elicitation-request handler that auto-approves")
+  (println "any elicitation requests (OAuth consent, form inputs, etc.).\n")
+
+  (copilot/with-client-session [session {:on-permission-request copilot/approve-all
+                                         :model "claude-haiku-4.5"
+                                         :on-elicitation-request handle-elicitation}]
+    ;; Check if elicitation capability is advertised
+    (println "Elicitation supported:" (copilot/elicitation-supported? session))
+
+    (let [events-ch (chan 256)
+          done (promise)]
+      (tap (copilot/events session) events-ch)
+
+      (go-loop []
+        (when-let [event (<! events-ch)]
+          (condp = (:type event)
+            (evt :assistant.message)
+            (println "\n🤖 Agent:" (get-in event [:data :content]))
+
+            (evt :elicitation.requested)
+            (println "\n🔔 Elicitation event observed:" (get-in event [:data :message]))
+
+            (evt :capabilities.changed)
+            (println "\n🔄 Capabilities changed:" (:data event))
+
+            (evt :session.idle)
+            (deliver done true)
+
+            (evt :session.error)
+            (do
+              (println "❌ Error:" (get-in event [:data :message]))
+              (deliver done (ex-info "Session error" {:event event})))
+
+            nil)
+          (recur)))
+
+      (let [prompt "Say hello and tell me what capabilities this session has."]
+        (println "📤 You:" prompt)
+        (copilot/send! session {:prompt prompt}))
+
+      (let [result @done]
+        (when (instance? Exception result)
+          (throw result))
+        (println "\n=== Session Complete ===")))))

--- a/run-all-examples.sh
+++ b/run-all-examples.sh
@@ -61,3 +61,7 @@ clojure -A:examples -X lifecycle-hooks/run
 echo ""
 echo "=== reasoning-effort ==="
 clojure -A:examples -X reasoning-effort/run
+
+echo ""
+echo "=== elicitation-provider ==="
+clojure -A:examples -X elicitation-provider/run

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -111,7 +111,11 @@
     :copilot/session.mcp_servers_loaded
     :copilot/session.mcp_server_status_changed
     :copilot/session.extensions_loaded
-    :copilot/session.custom_agents_updated})
+    :copilot/session.custom_agents_updated
+    :copilot/sampling.requested
+    :copilot/sampling.completed
+    :copilot/session.remote_steerable_changed
+    :copilot/capabilities.changed})
 
 (def session-events
   "Session lifecycle and state management events."
@@ -141,7 +145,9 @@
     :copilot/session.mcp_servers_loaded
     :copilot/session.mcp_server_status_changed
     :copilot/session.extensions_loaded
-    :copilot/session.custom_agents_updated})
+    :copilot/session.custom_agents_updated
+    :copilot/session.remote_steerable_changed
+    :copilot/capabilities.changed})
 
 (def assistant-events
   "Assistant response events."
@@ -164,7 +170,7 @@
     :copilot/tool.execution_complete})
 
 (def interaction-events
-  "Events related to permission, user input, elicitation, and external tool flows."
+  "Events related to permission, user input, elicitation, sampling, and external tool flows."
   #{:copilot/permission.requested :copilot/permission.completed
     :copilot/user_input.requested :copilot/user_input.completed
     :copilot/elicitation.requested :copilot/elicitation.completed
@@ -172,7 +178,8 @@
     :copilot/mcp.oauth_required :copilot/mcp.oauth_completed
     :copilot/command.queued :copilot/command.execute :copilot/command.completed
     :copilot/commands.changed
-    :copilot/exit_plan_mode.requested :copilot/exit_plan_mode.completed})
+    :copilot/exit_plan_mode.requested :copilot/exit_plan_mode.completed
+    :copilot/sampling.requested :copilot/sampling.completed})
 
 (defn evt
   "Convert an unqualified event keyword to a namespace-qualified event keyword.

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -214,7 +214,9 @@
         (:on-list-models opts)
         (assoc :on-list-models (:on-list-models opts))
         (:on-get-trace-context opts)
-        (assoc :on-get-trace-context (:on-get-trace-context opts))))))
+        (assoc :on-get-trace-context (:on-get-trace-context opts))
+        (:session-fs opts)
+        (assoc :session-fs (:session-fs opts))))))
 
 (defn state
   "Get the current connection state."
@@ -351,8 +353,44 @@
                                           :error (ex-message e)}))))
               (catch Exception _ nil))))))))
 
+(defn- handle-v3-elicitation-requested!
+  "Handle v3 elicitation.requested broadcast event.
+   Calls the session's elicitation handler and responds via the
+   session.ui.handlePendingElicitation RPC method.
+   If the handler fails, sends a cancel response to avoid hanging."
+  [client session-id event]
+  (let [data (:data event)
+        request-id (:request-id data)]
+    (when request-id
+      (go
+        (try
+          (let [request {:message (:message data)
+                         :requested-schema (:requested-schema data)
+                         :mode (:mode data)
+                         :elicitation-source (:elicitation-source data)
+                         :url (:url data)}
+                result (<! (session/handle-elicitation-request! client session-id request))]
+            (when result
+              (let [conn (:connection-io @(:state client))]
+                (when conn
+                  (<! (proto/send-request conn "session.ui.handlePendingElicitation"
+                                         {:session-id session-id
+                                          :request-id request-id
+                                          :result result}))))))
+          (catch Exception e
+            (log/debug "v3 elicitation request error for " request-id ": " (ex-message e))
+            (try
+              (let [conn (:connection-io @(:state client))]
+                (when conn
+                  (<! (proto/send-request conn "session.ui.handlePendingElicitation"
+                                         {:session-id session-id
+                                          :request-id request-id
+                                          :result {:action "cancel"}}))))
+              (catch Exception _ nil))))))))
+
 (defn- handle-v3-broadcast-event!
-  "Protocol v3: intercept broadcast events for external tools, permissions, and commands.
+  "Protocol v3: intercept broadcast events for external tools, permissions,
+   commands, elicitation, and capabilities.
    In v3, tool.call and permission.request server→client RPC methods are replaced
    by broadcast events that the SDK handles and responds to via new RPC methods."
   [client session-id event]
@@ -366,6 +404,13 @@
 
       :copilot/command.execute
       (handle-v3-command-execute! client session-id event)
+
+      :copilot/elicitation.requested
+      (handle-v3-elicitation-requested! client session-id event)
+
+      ;; capabilities.changed state update is applied before event publish
+      ;; in the notification router (so observers see consistent state)
+      :copilot/capabilities.changed nil
 
       nil)))
 
@@ -421,9 +466,14 @@
                     (log/warn "Model mismatch for session " session-id
                               ": requested " requested-model ", server selected " selected-model))))
               (when-not (:destroyed? (get-in @(:state client) [:sessions session-id]))
+                ;; Protocol v3: apply state-mutating broadcast handlers before publishing,
+                ;; so event observers see consistent state (e.g. capabilities.changed)
+                (when (>= (negotiated-protocol-version client) 3)
+                  (when (= event-type :copilot/capabilities.changed)
+                    (session/update-capabilities! client session-id (:data normalized-event))))
                 (when-let [{:keys [event-chan]} (get-in @(:state client) [:session-io session-id])]
                   (>! event-chan normalized-event))
-                ;; Protocol v3: handle broadcast events for tools and permissions
+                ;; Protocol v3: handle broadcast events for tools, permissions, elicitation
                 (when (>= (negotiated-protocol-version client) 3)
                   (handle-v3-broadcast-event! client session-id normalized-event))))
 
@@ -532,7 +582,7 @@
         (str/join "\n" lines)))))
 
 (defn- setup-request-handler!
-  "Set up handler for incoming requests (tool calls, permission requests, hooks, user input)."
+  "Set up handler for incoming requests (tool calls, permission requests, hooks, user input, sessionFs)."
   [client]
   (let [{:keys [connection-io]} @(:state client)]
     (proto/set-request-handler! connection-io
@@ -585,6 +635,17 @@
                                           {:error {:code -32001 :message (str "Unknown session: " session-id)}}
                                           {:result (session/handle-system-message-transform
                                                     client session-id sections)}))
+
+                                      ;; SessionFs operations (upstream PR #917)
+                                      ("sessionFs.readFile" "sessionFs.writeFile" "sessionFs.appendFile"
+                                       "sessionFs.exists" "sessionFs.stat" "sessionFs.mkdir"
+                                       "sessionFs.readdir" "sessionFs.readdirWithTypes"
+                                       "sessionFs.rm" "sessionFs.rename")
+                                      (let [{:keys [session-id]} params]
+                                        (if-not (get-in @(:state client) [:sessions session-id])
+                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
+                                          (<! (session/handle-session-fs-request!
+                                               client session-id method params))))
 
                                       {:error {:code -32601 :message (str "Unknown method: " method)}}))))))
 
@@ -790,6 +851,14 @@
 
       ;; Verify protocol version
       (verify-protocol-version! client)
+
+      ;; Register sessionFs provider if configured
+      (when-let [sf-config (:session-fs client)]
+        (let [{:keys [connection-io]} @(:state client)]
+          (proto/send-request! connection-io "sessionFs.setProvider"
+                               {:initial-cwd (:initial-cwd sf-config)
+                                :session-state-path (:session-state-path sf-config)
+                                :conventions (:conventions sf-config)})))
 
       ;; Set up notification routing and request handling
       (start-notification-router! client)
@@ -1263,6 +1332,7 @@
       (:reasoning-effort config) (assoc :reasoning-effort (:reasoning-effort config))
       (:agent config) (assoc :agent (:agent config))
       true (assoc :request-user-input (boolean (:on-user-input-request config)))
+      true (assoc :request-elicitation (boolean (:on-elicitation-request config)))
       true (assoc :hooks (boolean (:hooks config)))
       true (assoc :env-value-mode "direct"))))
 
@@ -1317,6 +1387,7 @@
       (:reasoning-effort config) (assoc :reasoning-effort (:reasoning-effort config))
       (:agent config) (assoc :agent (:agent config))
       true (assoc :request-user-input (boolean (:on-user-input-request config)))
+      true (assoc :request-elicitation (boolean (:on-elicitation-request config)))
       true (assoc :hooks (boolean (:hooks config)))
       (:working-directory config) (assoc :working-directory (:working-directory config))
       (:disable-resume? config) (assoc :disable-resume (:disable-resume? config))
@@ -1332,6 +1403,7 @@
                            :commands (:commands config)
                            :on-permission-request (:on-permission-request config)
                            :on-user-input-request (:on-user-input-request config)
+                           :on-elicitation-request (:on-elicitation-request config)
                            :hooks (:hooks config)
                            :on-event (:on-event config)
                            :config config}))
@@ -1365,6 +1437,10 @@
                             :buffer-exhaustion-threshold (0.0-1.0, default 0.95)}
    - :reasoning-effort   - Reasoning effort level: \"low\", \"medium\", \"high\", or \"xhigh\" (PR #302)
    - :on-user-input-request - Handler for ask_user requests (PR #269)
+   - :on-elicitation-request - Handler for elicitation requests from the agent (upstream PR #908).
+                               When provided, sends requestElicitation=true and enables the
+                               elicitation capability. Handler is (fn [request ctx]) returning
+                               an ElicitationResult map ({:action \"accept\" :content {...}}).
    - :hooks              - Lifecycle hooks map (PR #269):
                            {:on-pre-tool-use, :on-post-tool-use, :on-user-prompt-submitted,
                             :on-session-start, :on-session-end, :on-error-occurred}
@@ -1386,6 +1462,13 @@
     ;; Register transform callbacks on session before RPC
     (session/register-transform-callbacks! client session-id transform-callbacks)
     (try
+      ;; Attach sessionFs handler if sessionFs is configured
+      (when (:session-fs client)
+        (if-let [factory (:create-session-fs-handler config)]
+          (session/set-session-fs-handler! client session-id (factory session))
+          (throw (ex-info (str ":create-session-fs-handler is required in session config "
+                               "when :session-fs is enabled in client options.")
+                          {:config config}))))
       (let [result (proto/send-request! connection-io "session.create" params)]
         (session/set-workspace-path! client session-id (:workspace-path result))
         (session/set-capabilities! client session-id (:capabilities result))
@@ -1416,6 +1499,7 @@
    - :infinite-sessions  - Infinite session configuration
    - :reasoning-effort   - Reasoning effort level: \"low\", \"medium\", \"high\", or \"xhigh\"
    - :on-user-input-request - Handler for ask_user requests
+   - :on-elicitation-request - Handler for elicitation requests (upstream PR #908)
    - :hooks              - Lifecycle hooks map
    - :on-event           - Event handler (1-arg fn) registered before the RPC call.
                            Guarantees early events like session.start are not missed.
@@ -1444,6 +1528,13 @@
     ;; Register transform callbacks on session before RPC
     (session/register-transform-callbacks! client session-id transform-callbacks)
     (try
+      ;; Attach sessionFs handler if sessionFs is configured
+      (when (:session-fs client)
+        (if-let [factory (:create-session-fs-handler config)]
+          (session/set-session-fs-handler! client session-id (factory session))
+          (throw (ex-info (str ":create-session-fs-handler is required in session config "
+                               "when :session-fs is enabled in client options.")
+                          {:config config}))))
       (let [result (proto/send-request! connection-io "session.resume" params)]
         (session/set-workspace-path! client session-id (:workspace-path result))
         (session/set-capabilities! client session-id (:capabilities result))
@@ -1482,6 +1573,17 @@
         ;; Pre-register session before RPC so early events are captured
         session (pre-register-session client session-id config)
         _ (session/register-transform-callbacks! client session-id transform-callbacks)
+        ;; Attach sessionFs handler if sessionFs is configured (synchronously, before RPC)
+        _ (try
+            (when (:session-fs client)
+              (if-let [factory (:create-session-fs-handler config)]
+                (session/set-session-fs-handler! client session-id (factory session))
+                (throw (ex-info (str ":create-session-fs-handler is required in session config "
+                                     "when :session-fs is enabled in client options.")
+                                {:config config}))))
+            (catch Throwable t
+              (session/remove-session! client session-id)
+              (throw t)))
         rpc-ch (proto/send-request connection-io "session.create" params)]
     (go
       (let [response (<! rpc-ch)]
@@ -1539,6 +1641,17 @@
         ;; Pre-register session before RPC so early events are captured
         session (pre-register-session client session-id config)
         _ (session/register-transform-callbacks! client session-id transform-callbacks)
+        ;; Attach sessionFs handler if sessionFs is configured (synchronously, before RPC)
+        _ (try
+            (when (:session-fs client)
+              (if-let [factory (:create-session-fs-handler config)]
+                (session/set-session-fs-handler! client session-id (factory session))
+                (throw (ex-info (str ":create-session-fs-handler is required in session config "
+                                     "when :session-fs is enabled in client options.")
+                                {:config config}))))
+            (catch Throwable t
+              (session/remove-session! client session-id)
+              (throw t)))
         rpc-ch (proto/send-request connection-io "session.resume" params)]
     (go
       (let [response (<! rpc-ch)]
@@ -1715,6 +1828,13 @@
       (let [conn (proto/connect in out (:state client))]
         (swap! (:state client) assoc :connection-io conn))
       (verify-protocol-version! client)
+      ;; Register sessionFs provider if configured
+      (when-let [sf-config (:session-fs client)]
+        (let [{:keys [connection-io]} @(:state client)]
+          (proto/send-request! connection-io "sessionFs.setProvider"
+                               {:initial-cwd (:initial-cwd sf-config)
+                                :session-state-path (:session-state-path sf-config)
+                                :conventions (:conventions sf-config)})))
       (start-notification-router! client)
       (setup-request-handler! client)
       (swap! (:state client) assoc :status :connected)

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -50,7 +50,7 @@
    If :on-event is provided, taps a subscriber that forwards events to the handler
    on a dedicated thread. Uses a sliding buffer, so events may be dropped under
    extreme backpressure if the handler cannot keep up with the event rate."
-  [client session-id {:keys [tools on-permission-request on-user-input-request hooks workspace-path on-event config commands]}]
+  [client session-id {:keys [tools on-permission-request on-user-input-request on-elicitation-request hooks workspace-path on-event config commands]}]
   (log/debug "Creating session: " session-id)
   (let [event-chan (chan (async/sliding-buffer 4096))
         event-mult (mult event-chan)
@@ -66,6 +66,7 @@
                              :command-handlers command-handlers
                              :permission-handler on-permission-request
                              :user-input-handler on-user-input-request
+                             :elicitation-handler on-elicitation-request
                              :hooks hooks
                              :destroyed? false
                              :workspace-path workspace-path
@@ -118,6 +119,47 @@
   [client session-id callbacks]
   (when callbacks
     (swap! (:state client) assoc-in [:sessions session-id :transform-callbacks] callbacks)))
+
+(defn set-session-fs-handler!
+  "Store a sessionFs handler map on a session. Called by client during create/resume
+   when :session-fs is enabled. Handler is a map of keyword→fn for FS operations."
+  [client session-id handler]
+  (swap! (:state client) assoc-in [:sessions session-id :session-fs-handler] handler))
+
+(def ^:private session-fs-method->handler-key
+  "Map RPC method names to handler map keys."
+  {"sessionFs.readFile"        :read-file
+   "sessionFs.writeFile"       :write-file
+   "sessionFs.appendFile"      :append-file
+   "sessionFs.exists"          :exists
+   "sessionFs.stat"            :stat
+   "sessionFs.mkdir"           :mkdir
+   "sessionFs.readdir"         :readdir
+   "sessionFs.readdirWithTypes" :readdir-with-types
+   "sessionFs.rm"              :rm
+   "sessionFs.rename"          :rename})
+
+(defn handle-session-fs-request!
+  "Handle an incoming sessionFs.* RPC request. Dispatches to the session's
+   FS handler and returns a channel with {:result ...} or {:error ...}."
+  [client session-id method params]
+  (async/thread-call
+   (fn []
+     (let [handler-map (:session-fs-handler (session-state client session-id))
+           handler-key (session-fs-method->handler-key method)]
+       (if-not handler-map
+         {:error {:code -32001 :message (str "No sessionFs handler for session: " session-id)}}
+         (if-let [handler-fn (get handler-map handler-key)]
+           (try
+             (let [result (handler-fn params)
+                   result (if (instance? clojure.core.async.impl.channels.ManyToManyChannel result)
+                            (<!! result) result)]
+               {:result (or result {})})
+             (catch Throwable t
+               (log/warn t "sessionFs handler error" {:method method :session-id session-id})
+               {:error {:code -32603 :message (str "sessionFs error: " (ex-message t))}}))
+           {:error {:code -32601 :message (str "Unknown sessionFs method: " method)}}))))
+   :io))
 
 (defn handle-system-message-transform
   "Handle a systemMessage.transform RPC request from the CLI runtime.
@@ -384,6 +426,36 @@
            (catch Exception e
              {:error (ex-message e)})))))
    :io))
+
+(defn handle-elicitation-request!
+  "Handle an incoming elicitation.requested broadcast event.
+   Calls the session's elicitation handler and returns a channel with the result.
+   If the handler fails, returns {:action \"cancel\"} to avoid hanging requests."
+  [client session-id request]
+  (async/thread-call
+   (fn []
+     (let [handler (:elicitation-handler (session-state client session-id))]
+       (when handler
+         (try
+           (let [result (handler request {:session-id session-id})
+                 result (if (channel? result) (<!! result) result)]
+             (or result {:action "cancel"}))
+           (catch Throwable t
+             (log/warn t "Elicitation handler threw" {:session-id session-id})
+             {:action "cancel"})))))
+   :io))
+
+(defn- deep-merge
+  "Recursively merge maps, preserving nested keys."
+  [a b]
+  (merge-with (fn [x y] (if (and (map? x) (map? y)) (deep-merge x y) y)) a b))
+
+(defn update-capabilities!
+  "Deep-merge capability changes into the session's capabilities map.
+   Called when a capabilities.changed broadcast event is received."
+  [client session-id capability-changes]
+  (swap! (:state client) update-in [:sessions session-id :capabilities]
+         (fn [caps] (deep-merge (or caps {}) capability-changes))))
 
 ;; -----------------------------------------------------------------------------
 ;; Public API - functions that take CopilotSession handle

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -126,41 +126,6 @@
   [client session-id handler]
   (swap! (:state client) assoc-in [:sessions session-id :session-fs-handler] handler))
 
-(def ^:private session-fs-method->handler-key
-  "Map RPC method names to handler map keys."
-  {"sessionFs.readFile"        :read-file
-   "sessionFs.writeFile"       :write-file
-   "sessionFs.appendFile"      :append-file
-   "sessionFs.exists"          :exists
-   "sessionFs.stat"            :stat
-   "sessionFs.mkdir"           :mkdir
-   "sessionFs.readdir"         :readdir
-   "sessionFs.readdirWithTypes" :readdir-with-types
-   "sessionFs.rm"              :rm
-   "sessionFs.rename"          :rename})
-
-(defn handle-session-fs-request!
-  "Handle an incoming sessionFs.* RPC request. Dispatches to the session's
-   FS handler and returns a channel with {:result ...} or {:error ...}."
-  [client session-id method params]
-  (async/thread-call
-   (fn []
-     (let [handler-map (:session-fs-handler (session-state client session-id))
-           handler-key (session-fs-method->handler-key method)]
-       (if-not handler-map
-         {:error {:code -32001 :message (str "No sessionFs handler for session: " session-id)}}
-         (if-let [handler-fn (get handler-map handler-key)]
-           (try
-             (let [result (handler-fn params)
-                   result (if (instance? clojure.core.async.impl.channels.ManyToManyChannel result)
-                            (<!! result) result)]
-               {:result (or result {})})
-             (catch Throwable t
-               (log/warn t "sessionFs handler error" {:method method :session-id session-id})
-               {:error {:code -32603 :message (str "sessionFs error: " (ex-message t))}}))
-           {:error {:code -32601 :message (str "Unknown sessionFs method: " method)}}))))
-   :io))
-
 (defn handle-system-message-transform
   "Handle a systemMessage.transform RPC request from the CLI runtime.
    Dispatches each section to its registered transform callback.
@@ -247,6 +212,40 @@
   "Check if x is a core.async channel."
   [x]
   (instance? clojure.core.async.impl.channels.ManyToManyChannel x))
+
+(def ^:private session-fs-method->handler-key
+  "Map RPC method names to handler map keys."
+  {"sessionFs.readFile"        :read-file
+   "sessionFs.writeFile"       :write-file
+   "sessionFs.appendFile"      :append-file
+   "sessionFs.exists"          :exists
+   "sessionFs.stat"            :stat
+   "sessionFs.mkdir"           :mkdir
+   "sessionFs.readdir"         :readdir
+   "sessionFs.readdirWithTypes" :readdir-with-types
+   "sessionFs.rm"              :rm
+   "sessionFs.rename"          :rename})
+
+(defn handle-session-fs-request!
+  "Handle an incoming sessionFs.* RPC request. Dispatches to the session's
+   FS handler and returns a channel with {:result ...} or {:error ...}."
+  [client session-id method params]
+  (async/thread-call
+   (fn []
+     (let [handler-map (:session-fs-handler (session-state client session-id))
+           handler-key (session-fs-method->handler-key method)]
+       (if-not handler-map
+         {:error {:code -32001 :message (str "No sessionFs handler for session: " session-id)}}
+         (if-let [handler-fn (get handler-map handler-key)]
+           (try
+             (let [result (handler-fn params)
+                   result (if (channel? result) (<!! result) result)]
+               {:result result})
+             (catch Throwable t
+               (log/warn t "sessionFs handler error" {:method method :session-id session-id})
+               {:error {:code -32603 :message (str "sessionFs error: " (ex-message t))}}))
+           {:error {:code -32601 :message (str "Unknown sessionFs method: " method)}}))))
+   :io))
 
 (defn handle-tool-call!
   "Handle an incoming tool call request. Returns a channel with the result wrapper."

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -638,6 +638,7 @@
 
 (s/def ::agent-mode #{:interactive :plan :autopilot :shell})
 (s/def ::interaction-id string?)
+(s/def ::source string?)
 
 ;; user.message event data — attachments can include blobs (inbound-only types)
 (s/def ::user.message-data

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -74,6 +74,17 @@
 
 ;; SessionFs handler — map of keyword→fn for each FS operation.
 ;; Each fn receives a params map (with :session-id, :path, etc.) and returns a result map (or nil for void ops).
+(s/def ::read-file fn?)
+(s/def ::write-file fn?)
+(s/def ::append-file fn?)
+(s/def ::exists fn?)
+(s/def ::stat fn?)
+(s/def ::mkdir fn?)
+(s/def ::readdir fn?)
+(s/def ::readdir-with-types fn?)
+(s/def ::rm fn?)
+(s/def ::rename fn?)
+
 (s/def ::session-fs-handler
   (s/keys :req-un [::read-file ::write-file ::append-file ::exists ::stat
                    ::mkdir ::readdir ::readdir-with-types ::rm ::rename]))
@@ -611,7 +622,7 @@
 (s/def ::event-count nat-int?)
 (s/def ::session.resume-data
   (s/keys :req-un [::event-count]
-          :opt-un [::selected-model ::reasoning-effort ::already-in-use?
+          :opt-un [::selected-model ::reasoning-effort ::already-in-use? ::remote-steerable?
                    ::host-type ::head-commit ::base-commit]))
 
 (s/def ::session.error-data

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -65,12 +65,29 @@
 ;; Trace context provider: 0-arity fn returning {:traceparent ... :tracestate ...}
 (s/def ::on-get-trace-context fn?)
 
+;; Session filesystem provider (upstream PR #917)
+(s/def ::initial-cwd ::non-blank-string)
+(s/def ::session-state-path ::non-blank-string)
+(s/def ::conventions #{"windows" "posix"})
+(s/def ::session-fs
+  (s/keys :req-un [::initial-cwd ::session-state-path ::conventions]))
+
+;; SessionFs handler — map of keyword→fn for each FS operation.
+;; Each fn receives a params map (with :session-id, :path, etc.) and returns a result map (or nil for void ops).
+(s/def ::session-fs-handler
+  (s/keys :req-un [::read-file ::write-file ::append-file ::exists ::stat
+                   ::mkdir ::readdir ::readdir-with-types ::rm ::rename]))
+
+;; Factory fn: (session) → session-fs-handler
+(s/def ::create-session-fs-handler fn?)
+
 (def client-options-keys
   #{:cli-path :cli-args :cli-url :cwd :port
     :use-stdio? :log-level :auto-start? :auto-restart?
     :notification-queue-size :router-queue-size
     :tool-timeout-ms :env :github-token :use-logged-in-user?
-    :is-child-process? :on-list-models :telemetry :on-get-trace-context})
+    :is-child-process? :on-list-models :telemetry :on-get-trace-context
+    :session-fs})
 
 (s/def ::client-options
   (closed-keys
@@ -78,7 +95,8 @@
                     ::use-stdio? ::log-level ::auto-start? ::auto-restart?
                     ::notification-queue-size ::router-queue-size
                     ::tool-timeout-ms ::env ::github-token ::use-logged-in-user?
-                    ::is-child-process? ::on-list-models ::telemetry ::on-get-trace-context])
+                    ::is-child-process? ::on-list-models ::telemetry ::on-get-trace-context
+                    ::session-fs])
    client-options-keys))
 
 ;; -----------------------------------------------------------------------------
@@ -298,6 +316,20 @@
 (s/def ::elicitation-params
   (s/keys :req-un [::message ::requested-schema]))
 
+;; Elicitation request — inbound from server when this client is an elicitation provider
+;; Note: :mode here is "form"/"url" (different from message-options ::mode which is :enqueue/:immediate)
+;; We validate with s/and to avoid spec name collision.
+(s/def ::elicitation-source string?)
+(s/def ::url string?)
+(s/def ::elicitation-request
+  (s/and (s/keys :req-un [::message]
+                 :opt-un [::requested-schema ::elicitation-source ::url])
+         #(if-let [m (:mode %)]
+            (contains? #{"form" "url"} m)
+            true)))
+
+(s/def ::on-elicitation-request fn?)
+
 ;; Input options for the input! convenience method
 (s/def ::title string?)
 (s/def ::min-length nat-int?)
@@ -315,8 +347,8 @@
     :on-permission-request :streaming? :mcp-servers
     :custom-agents :config-dir :skill-directories
     :disabled-skills :large-output :infinite-sessions
-    :reasoning-effort :on-user-input-request :hooks
-    :working-directory :agent :on-event})
+    :reasoning-effort :on-user-input-request :on-elicitation-request :hooks
+    :working-directory :agent :on-event :create-session-fs-handler})
 
 (s/def ::session-config
   (closed-keys
@@ -326,8 +358,8 @@
                     ::streaming? ::mcp-servers
                     ::custom-agents ::config-dir ::skill-directories
                     ::disabled-skills ::large-output ::infinite-sessions
-                    ::reasoning-effort ::on-user-input-request ::hooks
-                    ::working-directory ::agent ::on-event])
+                    ::reasoning-effort ::on-user-input-request ::on-elicitation-request ::hooks
+                    ::working-directory ::agent ::on-event ::create-session-fs-handler])
    session-config-keys))
 
 (def ^:private resume-session-config-keys
@@ -335,7 +367,8 @@
     :provider :streaming? :on-permission-request
     :mcp-servers :custom-agents :config-dir :skill-directories
     :disabled-skills :infinite-sessions :reasoning-effort
-    :on-user-input-request :hooks :working-directory :disable-resume? :agent :on-event})
+    :on-user-input-request :on-elicitation-request :hooks :working-directory :disable-resume? :agent :on-event
+    :create-session-fs-handler})
 
 (s/def ::resume-session-config
   (closed-keys
@@ -344,8 +377,8 @@
                     ::provider ::streaming?
                     ::mcp-servers ::custom-agents ::config-dir ::skill-directories
                     ::disabled-skills ::infinite-sessions ::reasoning-effort
-                    ::on-user-input-request ::hooks ::working-directory ::disable-resume? ::agent
-                    ::on-event])
+                    ::on-user-input-request ::on-elicitation-request ::hooks ::working-directory ::disable-resume? ::agent
+                    ::on-event ::create-session-fs-handler])
    resume-session-config-keys))
 
 ;; join-session config: same as resume-session-config but :on-permission-request is optional.
@@ -357,8 +390,8 @@
                     ::provider ::streaming?
                     ::mcp-servers ::custom-agents ::config-dir ::skill-directories
                     ::disabled-skills ::infinite-sessions ::reasoning-effort
-                    ::on-user-input-request ::hooks ::working-directory ::disable-resume? ::agent
-                    ::on-event])
+                    ::on-user-input-request ::on-elicitation-request ::hooks ::working-directory ::disable-resume? ::agent
+                    ::on-event ::create-session-fs-handler])
    resume-session-config-keys))
 
 ;; -----------------------------------------------------------------------------
@@ -555,11 +588,17 @@
     :copilot/session.tools_updated :copilot/session.background_tasks_changed
     :copilot/session.skills_loaded :copilot/session.mcp_servers_loaded
     :copilot/session.mcp_server_status_changed :copilot/session.extensions_loaded
-    :copilot/session.custom_agents_updated})
+    :copilot/session.custom_agents_updated
+    ;; Sampling events (upstream PR #908)
+    :copilot/sampling.requested :copilot/sampling.completed
+    ;; Session remote steerable (upstream PR #908)
+    :copilot/session.remote_steerable_changed
+    ;; Capabilities changed (upstream PR #908)
+    :copilot/capabilities.changed})
 
 ;; Session events
 (s/def ::already-in-use? boolean?)
-(s/def ::steerable? boolean?)
+(s/def ::remote-steerable? boolean?)
 (s/def ::host-type string?)
 (s/def ::head-commit string?)
 (s/def ::base-commit string?)
@@ -567,7 +606,7 @@
 (s/def ::session.start-data
   (s/keys :req-un [::session-id]
           :opt-un [::version ::producer ::copilot-version ::start-time ::selected-model
-                   ::reasoning-effort ::already-in-use? ::steerable? ::host-type ::head-commit ::base-commit]))
+                   ::reasoning-effort ::already-in-use? ::remote-steerable? ::host-type ::head-commit ::base-commit]))
 
 (s/def ::event-count nat-int?)
 (s/def ::session.resume-data
@@ -684,17 +723,55 @@
          #(contains? #{"create" "update"} (:operation %))))
 
 ;; Session task complete event
+(s/def ::aborted? boolean?)
 (s/def ::session.task_complete-data
-  (s/keys :opt-un [::summary]))
+  (s/keys :opt-un [::summary ::aborted?]))
 
 ;; Skill invoked event
 (s/def ::allowed-tools (s/coll-of string?))
 (s/def ::plugin-name string?)
 (s/def ::plugin-version string?)
+;; ::description already defined above
 
 (s/def ::skill.invoked-data
   (s/keys :req-un [::name ::path ::content]
-          :opt-un [::allowed-tools ::plugin-name ::plugin-version]))
+          :opt-un [::allowed-tools ::plugin-name ::plugin-version ::description]))
+
+;; Subagent event data (upstream PR #916)
+(s/def ::agent-display-name string?)
+(s/def ::agent-description string?)
+(s/def ::total-tool-calls nat-int?)
+(s/def ::total-tokens nat-int?)
+(s/def ::duration-ms nat-int?)
+
+(s/def ::subagent.started-data
+  (s/keys :req-un [::tool-call-id ::agent-name ::agent-display-name]
+          :opt-un [::agent-description]))
+
+(s/def ::subagent.completed-data
+  (s/keys :req-un [::tool-call-id ::agent-name ::agent-display-name]
+          :opt-un [::model ::total-tool-calls ::total-tokens ::duration-ms]))
+
+(s/def ::subagent.failed-data
+  (s/keys :req-un [::tool-call-id ::agent-name ::agent-display-name ::error]
+          :opt-un [::model ::total-tool-calls ::total-tokens ::duration-ms]))
+
+;; session.custom_agents_updated event data (upstream PR #916)
+(s/def ::user-invocable? boolean?)
+(s/def ::agent-tool-names (s/coll-of string?))
+
+(s/def ::custom-agent-info
+  (s/and (s/keys :req-un [::id ::name ::display-name ::description ::source ::user-invocable?]
+                 :opt-un [::model])
+         #(contains? #{"user" "project" "inherited" "remote" "plugin"} (:source %))
+         #(s/valid? ::agent-tool-names (:tools %))))
+
+(s/def ::agents (s/coll-of ::custom-agent-info))
+(s/def ::warnings (s/coll-of string?))
+(s/def ::errors (s/coll-of string?))
+
+(s/def ::session.custom_agents_updated-data
+  (s/keys :req-un [::agents ::warnings ::errors]))
 
 ;; Generic session event
 (s/def ::session-event
@@ -707,8 +784,8 @@
 
 (s/def ::tool-call-id ::non-blank-string)
 (s/def ::result-type
-  (s/or :keyword #{:success :failure :rejected :denied}
-        :string #{"success" "failure" "rejected" "denied"}))
+  (s/or :keyword #{:success :failure :rejected :denied :timeout}
+        :string #{"success" "failure" "rejected" "denied" "timeout"}))
 (s/def ::text-result-for-llm string?)
 (s/def ::session-log string?)
 (s/def ::tool-telemetry map?)

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -1390,3 +1390,145 @@
                                       {:on-permission-request sdk/approve-all})]
       (is (= {} (get-in @(:state *test-client*)
                         [:sessions (sdk/session-id session) :command-handlers]))))))
+
+;; -----------------------------------------------------------------------------
+;; Elicitation Provider Tests (upstream PR #908)
+;; -----------------------------------------------------------------------------
+
+(deftest test-request-elicitation-wire-flag
+  (testing "requestElicitation is true when :on-elicitation-request is provided"
+    (let [requests (atom [])
+          _ (mock/set-request-hook! *mock-server*
+              (fn [method params]
+                (swap! requests conj {:method method :params params})))
+          session (sdk/create-session *test-client*
+                                      {:on-permission-request sdk/approve-all
+                                       :on-elicitation-request (fn [_req _ctx] {:action "cancel"})})
+          create-rpcs (filter #(= "session.create" (:method %)) @requests)]
+      (is (= 1 (count create-rpcs)))
+      (when (seq create-rpcs)
+        (is (true? (:requestElicitation (:params (first create-rpcs))))))))
+
+  (testing "requestElicitation is false when :on-elicitation-request is not provided"
+    (let [requests (atom [])
+          _ (mock/set-request-hook! *mock-server*
+              (fn [method params]
+                (swap! requests conj {:method method :params params})))
+          session (sdk/create-session *test-client*
+                                      {:on-permission-request sdk/approve-all})
+          create-rpcs (filter #(= "session.create" (:method %)) @requests)]
+      (is (= 1 (count create-rpcs)))
+      (when (seq create-rpcs)
+        (is (false? (:requestElicitation (:params (first create-rpcs)))))))))
+
+(deftest test-elicitation-requested-v3
+  (testing "v3 elicitation.requested event routes to handler and sends RPC response"
+    (let [requests (atom [])
+          handler-called (atom nil)
+          rpc-latch (java.util.concurrent.CountDownLatch. 1)
+          _ (mock/set-request-hook! *mock-server*
+              (fn [method params]
+                (swap! requests conj {:method method :params params})
+                (when (= "session.ui.handlePendingElicitation" method)
+                  (.countDown rpc-latch))))
+          session (sdk/create-session *test-client*
+                                      {:on-permission-request sdk/approve-all
+                                       :on-elicitation-request
+                                       (fn [request ctx]
+                                         (reset! handler-called {:request request :ctx ctx})
+                                         {:action "accept"
+                                          :content {:name "test-value"}})})
+          session-id (sdk/session-id session)]
+      (swap! (:state *test-client*) assoc :negotiated-protocol-version 3)
+      (reset! requests [])
+      ;; Inject elicitation.requested event
+      (mock/send-session-event! *mock-server* session-id
+                                "elicitation.requested"
+                                {:requestId "elicit-req-1"
+                                 :message "Enter your name"
+                                 :requestedSchema {:type "object"
+                                                   :properties {"name" {:type "string"}}}
+                                 :mode "form"
+                                 :elicitationSource "mcp-server"})
+      (is (.await rpc-latch 5 java.util.concurrent.TimeUnit/SECONDS))
+      ;; Handler was called
+      (is (some? @handler-called))
+      (is (= "Enter your name" (:message (:request @handler-called))))
+      (is (= session-id (:session-id (:ctx @handler-called))))
+      ;; handlePendingElicitation RPC was sent with handler's result
+      (let [rpcs (filter #(= "session.ui.handlePendingElicitation" (:method %)) @requests)]
+        (is (= 1 (count rpcs)))
+        (when (seq rpcs)
+          (is (= "elicit-req-1" (:requestId (:params (first rpcs)))))
+          (is (= "accept" (get-in (first rpcs) [:params :result :action]))))))))
+
+(deftest test-elicitation-handler-error-sends-cancel
+  (testing "handler exception sends cancel response to avoid hanging"
+    (let [requests (atom [])
+          rpc-latch (java.util.concurrent.CountDownLatch. 1)
+          _ (mock/set-request-hook! *mock-server*
+              (fn [method params]
+                (swap! requests conj {:method method :params params})
+                (when (= "session.ui.handlePendingElicitation" method)
+                  (.countDown rpc-latch))))
+          session (sdk/create-session *test-client*
+                                      {:on-permission-request sdk/approve-all
+                                       :on-elicitation-request
+                                       (fn [_req _ctx]
+                                         (throw (Exception. "UI unavailable")))})
+          session-id (sdk/session-id session)]
+      (swap! (:state *test-client*) assoc :negotiated-protocol-version 3)
+      (reset! requests [])
+      (mock/send-session-event! *mock-server* session-id
+                                "elicitation.requested"
+                                {:requestId "elicit-req-2"
+                                 :message "Prompt"})
+      (is (.await rpc-latch 5 java.util.concurrent.TimeUnit/SECONDS))
+      (let [rpcs (filter #(= "session.ui.handlePendingElicitation" (:method %)) @requests)]
+        (is (= 1 (count rpcs)))
+        (when (seq rpcs)
+          (is (= "cancel" (get-in (first rpcs) [:params :result :action]))))))))
+
+(deftest test-capabilities-changed-event
+  (testing "capabilities.changed broadcast updates session capabilities"
+    (let [session (sdk/create-session *test-client*
+                                      {:on-permission-request sdk/approve-all})
+          session-id (sdk/session-id session)]
+      (is (false? (sdk/elicitation-supported? session)))
+      ;; Force protocol v3
+      (swap! (:state *test-client*) assoc :negotiated-protocol-version 3)
+      ;; Inject capabilities.changed event
+      (mock/send-session-event! *mock-server* session-id
+                                "capabilities.changed"
+                                {:ui {:elicitation true}}
+                                :ephemeral? true)
+      ;; Give event routing time to process
+      (Thread/sleep 200)
+      (is (true? (sdk/elicitation-supported? session))))))
+
+;; -----------------------------------------------------------------------------
+;; SessionFs Tests (upstream PR #917)
+;; -----------------------------------------------------------------------------
+
+(deftest test-session-fs-handler-stored
+  (testing "session-fs-handler is stored in session state when provided"
+    (let [fs-handler {:read-file (fn [_] {:content "hello"})
+                      :write-file (fn [_] nil)
+                      :append-file (fn [_] nil)
+                      :exists (fn [_] {:exists true})
+                      :stat (fn [_] {:is-file true :is-directory false :size 5 :mtime "2026-01-01T00:00:00Z"})
+                      :mkdir (fn [_] nil)
+                      :readdir (fn [_] {:entries []})
+                      :readdir-with-types (fn [_] {:entries []})
+                      :rm (fn [_] nil)
+                      :rename (fn [_] nil)}
+          session (sdk/create-session *test-client*
+                                      {:on-permission-request sdk/approve-all})
+          session-id (sdk/session-id session)]
+      ;; Set handler directly (as client code would do after factory call)
+      (session/set-session-fs-handler! (:client session) session-id fs-handler)
+      (let [stored (get-in @(:state *test-client*)
+                          [:sessions session-id :session-fs-handler])]
+        (is (some? stored))
+        (is (fn? (:read-file stored)))
+        (is (= {:content "hello"} ((:read-file stored) {:path "/test.txt"})))))))


### PR DESCRIPTION
## Summary

Ports four upstream `github/copilot-sdk` PRs in a single batch, with 3 rounds of multi-model code review (Opus 4.6, GPT-5.4, Goldeneye) that caught and fixed 11 issues before submission.

## Upstream Changes Ported

### PR #908 — Elicitation Provider Support
- **`:on-elicitation-request`** handler on `SessionConfig` and `ResumeSessionConfig`
- Sends `requestElicitation: true` in session create/resume RPC when handler is provided
- Handles `elicitation.requested` broadcast events → invokes handler → responds via `session.ui.handlePendingElicitation` RPC
- Handler errors automatically send `{:action "cancel"}` to prevent hanging
- **`capabilities.changed`** broadcast handling with deep-merge (state updated before event publish so observers see consistent state)
- **BREAKING**: `::steerable?` renamed to `::remote-steerable?` (upstream wire field rename)
- New event types: `sampling.requested`, `sampling.completed`, `session.remote_steerable_changed`, `capabilities.changed`

### PR #916 — Event Payload Field Updates
- `skill.invoked`: optional `:description` field
- `subagent.started/completed/failed`: `:agent-name`, `:agent-display-name`, `:agent-description`, `:model`, `:total-tool-calls`, `:total-tokens`, `:duration-ms`
- `session.custom_agents_updated`: full payload spec with `:agents` array, `:warnings`, `:errors`

### PR #917 — SessionFs Virtual Filesystem
- **`:session-fs`** client option (`{:initial-cwd :session-state-path :conventions}`)
- Calls `sessionFs.setProvider` RPC on connect (both `start!` and `connect-with-streams!`)
- **`:create-session-fs-handler`** on session config — factory `(fn [session] → handler-map)` required when sessionFs is enabled
- Dispatches 10 `sessionFs.*` RPC operations (`readFile`, `writeFile`, `appendFile`, `exists`, `stat`, `mkdir`, `readdir`, `readdirWithTypes`, `rm`, `rename`) to per-session handler maps
- `aborted?` field on `session.task_complete` event data
- All 4 session creation paths (sync/async × create/resume) handle sessionFs with proper cleanup on failure

### PR #970 — Timeout Result Type
- Added `:timeout`/`"timeout"` to `::result-type` spec

## Code Review Process

3 rounds of parallel multi-model review (Claude Opus 4.6, GPT-5.4, Goldeneye):

| Round | Issues Found | Fixed |
|-------|-------------|-------|
| R1 | 6 (double clj->wire, spec mismatch, shallow merge, async gaps, zombie sessions, wrong field names) | 6 |
| R2 | 4 (agent-name redefinition, tools spec clash, event ordering, startup race) | 3 (1 skipped — matches upstream) |
| R3 | 2 (async factory leak, connect-with-streams missing setProvider) | 2 |

## Supersedes

This PR supersedes the following automated upstream-sync draft PRs:
- #78 (elicitation provider) — our implementation is more robust (deep-merge, state-before-publish, async path coverage, cleanup on failure)
- #79 (sessionFs) — our implementation has try/catch cleanup, async path parity, `connect-with-streams!` coverage
- #80 (timeout result-type) — incorporated

## Testing

- **114 tests, 366 assertions, 0 failures**
- **12 doc files validated, 0 warnings**
- **All 18 examples pass** (including new `elicitation_provider.clj`)
- Integration tests cover: elicitation handler routing, error→cancel fallback, capabilities.changed state updates, requestElicitation wire flag, sessionFs handler storage

## Files Changed

| File | Changes |
|------|---------|
| `src/github/copilot_sdk/client.clj` | Elicitation broadcast handler, sessionFs dispatch, capabilities.changed, wire params |
| `src/github/copilot_sdk/session.clj` | Elicitation/sessionFs handlers, deep-merge capabilities, handler storage |
| `src/github/copilot_sdk/specs.clj` | New specs for all features, corrected subagent/custom-agent specs |
| `src/github/copilot_sdk.clj` | New event types in event sets |
| `doc/reference/API.md` | Elicitation Provider and Session Filesystem sections, updated event reference |
| `test/.../integration_test.clj` | 5 new tests for elicitation provider, capabilities, sessionFs |
| `examples/elicitation_provider.clj` | New example with auto-approve handler |
| `CHANGELOG.md` | All changes documented under [Unreleased] |
