### PR TITLE
chore: release v0.2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.2.1.1] - 2026-04-04
 ### Added
 - **Session RPC wrappers** — new experimental functions for session-level RPCs previously only accessible via `proto/send-request!`:
   - `mode-get`, `mode-set!` — get/set agent mode (interactive/plan/autopilot)
@@ -410,7 +411,8 @@ All notable changes to this project will be documented in this file. This change
 - org.clojure/spec.alpha 0.5.238
 - cheshire/cheshire 5.13.0
 
-[Unreleased]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v0.2.1.0...HEAD
+[Unreleased]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v0.2.1.1...HEAD
+[0.2.1.1]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v0.2.1.0...v0.2.1.1
 [0.2.1.0]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v0.2.1.1-SNAPSHOT...v0.2.1.0
 [0.2.1.1-SNAPSHOT]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v0.2.0.0...v0.2.1.1-SNAPSHOT
 [0.2.0.0]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v0.1.33.0-SNAPSHOT...v0.2.0.0

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Add to your `deps.edn`:
 
 ```clojure
 ;; From Maven Central
-io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "0.2.1.0"}
+io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "0.2.1.1"}
 
 ;; Or git dependency
 io.github.copilot-community-sdk/copilot-sdk-clojure {:git/url "https://github.com/copilot-community-sdk/copilot-sdk-clojure.git"
-                              :git/sha "875da823caca2d0069e37013e4833d9395f00eff"}
+                              :git/sha "1c145f40a991532c68229d4b46596e1174a64927"}
 ```
 
 > **Note:** The Clojars artifact `net.clojars.krukow/copilot-sdk` is deprecated.

--- a/build.clj
+++ b/build.clj
@@ -7,7 +7,7 @@
   (:import [java.io File]))
 
 (def lib 'io.github.copilot-community-sdk/copilot-sdk-clojure)
-(def version "0.2.1.0")
+(def version "0.2.1.1")
 (def class-dir "target/classes")
 
 (defn- try-sh


### PR DESCRIPTION
Automated release PR for v0.2.1.1. Created by the Release workflow (run 23988595061).