### PR TITLE
Upstream sync: post-v0.2.2 batch 2 (includeSubAgentStreamingEvents, requestHeaders, provider headers, spec additions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. This change
 - **`includeSubAgentStreamingEvents` session option** — new boolean `:include-sub-agent-streaming-events?` on `::session-config`, `::resume-session-config`, and `::join-session-config`. When `true` (default), sub-agent streaming events are forwarded to the parent session's event stream. (upstream PR #1108)
 - **Per-request HTTP headers on `send!`** — new `:request-headers` option (map of string→string) on `::send-options`. Forwarded as wire `requestHeaders` and merged with provider-level headers by the CLI. (upstream PR #1094)
 - **Provider-level HTTP headers** — new `:headers` field (map of string→string) on `::provider` config. Sent with each model request to BYOK endpoints. (upstream PR #1094)
-- **`::can-offer-session-approval?`** spec — boolean field present on `permission.requested` events of kind `writeFile`, indicating the CLI can offer a "trust this session" choice. (CLI 1.0.28, upstream PR #1089)
+- **`::can-offer-session-approval`** spec — boolean field present on `permission.requested` events of kind `writeFile`, indicating the CLI can offer a "trust this session" choice. (CLI 1.0.28, upstream PR #1089)
 - **`::reasoning-tokens`** spec — non-negative integer field on `assistant.usage` and `session.usage_info` events tracking tokens used for reasoning content. (CLI 1.0.32, upstream PR #1105)
 - **`::agent-id`** spec — optional string field on `::base-event`, identifying which (sub-)agent emitted the event. (upstream PR #1108)
 - Integration tests for all new wire fields and specs (6 new `deftest`s covering sync/async wire forwarding and the 3 new spec additions).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. This change
 - **`::can-offer-session-approval?`** spec — boolean field present on `permission.requested` events of kind `writeFile`, indicating the CLI can offer a "trust this session" choice. (CLI 1.0.28, upstream PR #1089)
 - **`::reasoning-tokens`** spec — non-negative integer field on `assistant.usage` and `session.usage_info` events tracking tokens used for reasoning content. (CLI 1.0.32, upstream PR #1105)
 - **`::agent-id`** spec — optional string field on `::base-event`, identifying which (sub-)agent emitted the event. (upstream PR #1108)
-- Integration tests for all new wire fields and specs (7 new tests).
+- Integration tests for all new wire fields and specs (6 new `deftest`s covering sync/async wire forwarding and the 3 new spec additions).
 
 ### Added (post-v0.2.2 sync)
 - **`convert-mcp-call-tool-result`** — new public function in `tools` namespace that converts MCP `CallToolResult` format into the SDK's `ToolResultObject`. Handles text, image, and resource content types. (upstream PR #1049)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Added (post-v0.2.2 sync, batch 2)
+- **`includeSubAgentStreamingEvents` session option** — new boolean `:include-sub-agent-streaming-events?` on `::session-config`, `::resume-session-config`, and `::join-session-config`. When `true` (default), sub-agent streaming events are forwarded to the parent session's event stream. (upstream PR #1108)
+- **Per-request HTTP headers on `send!`** — new `:request-headers` option (map of string→string) on `::send-options`. Forwarded as wire `requestHeaders` and merged with provider-level headers by the CLI. (upstream PR #1094)
+- **Provider-level HTTP headers** — new `:headers` field (map of string→string) on `::provider` config. Sent with each model request to BYOK endpoints. (upstream PR #1094)
+- **`::can-offer-session-approval?`** spec — boolean field present on `permission.requested` events of kind `writeFile`, indicating the CLI can offer a "trust this session" choice. (CLI 1.0.28, upstream PR #1089)
+- **`::reasoning-tokens`** spec — non-negative integer field on `assistant.usage` and `session.usage_info` events tracking tokens used for reasoning content. (CLI 1.0.32, upstream PR #1105)
+- **`::agent-id`** spec — optional string field on `::base-event`, identifying which (sub-)agent emitted the event. (upstream PR #1108)
+- Integration tests for all new wire fields and specs (7 new tests).
+
 ### Added (post-v0.2.2 sync)
 - **`convert-mcp-call-tool-result`** — new public function in `tools` namespace that converts MCP `CallToolResult` format into the SDK's `ToolResultObject`. Handles text, image, and resource content types. (upstream PR #1049)
 - **`default-join-session-permission-handler`** — new permission handler for `resume-session` that returns `{:kind :no-result}`, signaling the CLI to handle permissions itself. Sends `requestPermission: false` on the wire. (upstream PR #1056)

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -237,7 +237,7 @@ Create a client and session together, ensuring both are cleaned up on exit.
 | `:system-message` | map | System message customization (see below) |
 | `:available-tools` | vector | List of allowed tool names |
 | `:excluded-tools` | vector | List of excluded tool names |
-| `:provider` | map | Provider config for BYOK (see [BYOK docs](../auth/byok.md)). Required key: `:base-url`. Optional: `:provider-type` (`:openai`/`:azure`/`:anthropic`), `:wire-api` (`:completions`/`:responses`), `:api-key`, `:bearer-token`, `:azure-options` |
+| `:provider` | map | Provider config for BYOK (see [BYOK docs](../auth/byok.md)). Required key: `:base-url`. Optional: `:provider-type` (`:openai`/`:azure`/`:anthropic`), `:wire-api` (`:completions`/`:responses`), `:api-key`, `:bearer-token`, `:azure-options`, `:headers` (map of HTTP header name→value, sent with each provider request — upstream PR #1094) |
 | `:mcp-servers` | map | MCP server configs keyed by server ID (see [MCP docs](../mcp/overview.md)). Local (stdio) servers: `:mcp-command`, `:mcp-args`, `:mcp-tools`. Remote (HTTP/SSE) servers: `:mcp-server-type` (`:http`/`:sse`), `:mcp-url`, `:mcp-tools`. Spec aliases: `::mcp-stdio-server` = `::mcp-local-server`, `::mcp-http-server` = `::mcp-remote-server` |
 | `:commands` | vector | Command definitions (slash commands). See [Commands](#commands) |
 | `:custom-agents` | vector | Custom agent configs. Each agent map: `:agent-name` (required), `:agent-prompt` (required), `:agent-display-name`, `:agent-description`, `:agent-tools`, `:agent-infer?`, `:agent-skills` (vector of strings), `:mcp-servers` |
@@ -258,6 +258,7 @@ Create a client and session together, ensuring both are cleaned up on exit.
 | `:create-session-fs-handler` | fn | Factory for session filesystem handlers. Required when `:session-fs` is set on the client. Called as `(factory session)`, returns a map of FS handler functions. See [Session Filesystem](#session-filesystem) |
 | `:enable-config-discovery` | boolean | Auto-discover `.mcp.json`, `.vscode/mcp.json`, skills, etc. Instruction files always load regardless. (upstream PR #1044) |
 | `:model-capabilities` | map | Model capabilities override. DeepPartial of model capabilities, e.g. `{:model-supports {:supports-vision true}}`. (upstream PR #1029) |
+| `:include-sub-agent-streaming-events?` | boolean | Forward streaming events from sub-agents to the parent session's event stream. Defaults to `true` on the wire. (upstream PR #1108) |
 
 #### `resume-session`
 
@@ -683,6 +684,7 @@ Send a message to the session. Returns immediately with the message ID.
 | `:prompt` | string | The message/prompt to send |
 | `:attachments` | vector | File attachments (see below) |
 | `:mode` | keyword | `:enqueue` or `:immediate` |
+| `:request-headers` | map | Extra HTTP headers (string→string) forwarded to the model provider for this request. Merged with provider-level `:headers`. (upstream PR #1094) |
 
 **Attachment types:**
 

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -1533,6 +1533,9 @@
    - :model-capabilities - Model capabilities override map (upstream PR #1029).
                            DeepPartial of model capabilities, e.g.
                            {:model-supports {:supports-vision true}}
+   - :include-sub-agent-streaming-events? - Boolean. When true (default), streaming events from
+                                            sub-agents are forwarded to this session's event stream.
+                                            (upstream PR #1108)
    
    Returns a CopilotSession."
   [client config]
@@ -1595,6 +1598,9 @@
                            Guarantees early events like session.start are not missed.
    - :enable-config-discovery - Boolean. Auto-discover .mcp.json, skills, etc. (upstream PR #1044)
    - :model-capabilities - Model capabilities override map (upstream PR #1029).
+   - :include-sub-agent-streaming-events? - Boolean. When true (default), streaming events from
+                                            sub-agents are forwarded to this session's event stream.
+                                            (upstream PR #1108)
    
    Returns a CopilotSession."
   [client session-id config]

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -1401,6 +1401,10 @@
       (assoc :enable-config-discovery (:enable-config-discovery config))
       (:model-capabilities config)
       (assoc :model-capabilities (util/clj->wire (:model-capabilities config)))
+      true (assoc :include-sub-agent-streaming-events
+                  (if (some? (:include-sub-agent-streaming-events? config))
+                    (:include-sub-agent-streaming-events? config)
+                    true))
       true (assoc :env-value-mode "direct"))))
 
 (defn- build-resume-session-params
@@ -1464,6 +1468,10 @@
       (assoc :enable-config-discovery (:enable-config-discovery config))
       (:model-capabilities config)
       (assoc :model-capabilities (util/clj->wire (:model-capabilities config)))
+      true (assoc :include-sub-agent-streaming-events
+                  (if (some? (:include-sub-agent-streaming-events? config))
+                    (:include-sub-agent-streaming-events? config)
+                    true))
       true (assoc :env-value-mode "direct"))))
 
 (defn- pre-register-session

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -149,7 +149,7 @@
 (s/fdef github.copilot-sdk.session/send-and-wait!
   :args (s/cat :session ::specs/session
                :opts ::specs/send-options
-               :timeout-ms (s/? ::specs/timeout-ms))
+               :timeout-ms (s/? ::specs/strict-timeout-ms))
   :ret (s/nilable map?))
 
 (s/fdef github.copilot-sdk.session/send-async

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -765,6 +765,10 @@
   [session opts]
   (let [timeout-ms (if (contains? opts :timeout-ms) (:timeout-ms opts) 300000)
         opts (dissoc opts :timeout-ms)]
+    (when-not (s/valid? ::specs/send-options opts)
+      (throw (ex-info "Invalid send options"
+                      {:opts opts
+                       :explain (s/explain-data ::specs/send-options opts)})))
     (<send-async* session opts timeout-ms)))
 
 (defn <send!

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -475,9 +475,14 @@
    Returns the message ID immediately (fire-and-forget).
    
    Options:
-   - :prompt       - The message text (required)
-   - :attachments  - Vector of attachments (file/directory/selection)
-   - :mode         - :enqueue (default) or :immediate"
+   - :prompt          - The message text (required)
+   - :attachments     - Vector of attachments (file/directory/selection)
+   - :mode            - :enqueue (default) or :immediate
+   - :request-headers - Optional map of HTTP headers forwarded to the
+                        upstream LLM on this send (upstream PR #1094).
+                        Keys and values must both be strings (do not use
+                        Clojure keywords — they would be camelized by the
+                        wire-conversion layer)."
   [session opts]
   (when-not (s/valid? ::specs/send-options opts)
     (throw (ex-info "Invalid send options"
@@ -753,7 +758,9 @@
    Serialized per session to avoid mixing concurrent sends.
    Safe for use inside go blocks — no blocking operations.
    
-   Options:
+   Options: same as send! (including :request-headers).
+   
+   Additional options:
    - :timeout-ms   - Timeout in milliseconds (default: 300000, set to nil to disable)"
   [session opts]
   (let [timeout-ms (if (contains? opts :timeout-ms) (:timeout-ms opts) 300000)
@@ -764,7 +771,9 @@
   "Send a message and return a channel that delivers the final content string.
    This is the async equivalent of send-and-wait! - use inside go blocks.
    
-   Options:
+   Options: same as send! (including :request-headers).
+   
+   Additional options:
    - :timeout-ms   - Timeout in milliseconds (default: 300000, set to nil to disable)
    
    The returned channel delivers a single value (the response content) then closes."

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -763,12 +763,12 @@
    Additional options:
    - :timeout-ms   - Timeout in milliseconds (default: 300000, set to nil to disable)"
   [session opts]
+  (when-not (s/valid? ::specs/send-options opts)
+    (throw (ex-info "Invalid send options"
+                    {:opts opts
+                     :explain (s/explain-data ::specs/send-options opts)})))
   (let [timeout-ms (if (contains? opts :timeout-ms) (:timeout-ms opts) 300000)
         opts (dissoc opts :timeout-ms)]
-    (when-not (s/valid? ::specs/send-options opts)
-      (throw (ex-info "Invalid send options"
-                      {:opts opts
-                       :explain (s/explain-data ::specs/send-options opts)})))
     (<send-async* session opts timeout-ms)))
 
 (defn <send!

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -499,7 +499,8 @@
                           :prompt (:prompt opts)}
                    trace-ctx (merge trace-ctx)
                    wire-attachments (assoc :attachments wire-attachments)
-                   (:mode opts) (assoc :mode (name (:mode opts))))
+                   (:mode opts) (assoc :mode (name (:mode opts)))
+                   (:request-headers opts) (assoc :request-headers (:request-headers opts)))
           result (proto/send-request! conn "session.send" params)
           msg-id (:message-id result)]
       (log/debug "send! completed for session " session-id " message-id=" msg-id)
@@ -705,7 +706,8 @@
                                   :prompt (:prompt opts)}
                            trace-ctx (merge trace-ctx)
                            wire-attachments (assoc :attachments wire-attachments)
-                           (:mode opts) (assoc :mode (name (:mode opts))))
+                           (:mode opts) (assoc :mode (name (:mode opts)))
+                           (:request-headers opts) (assoc :request-headers (:request-headers opts)))
                   response-ch (proto/send-request conn "session.send" params)
                   [result port] (if deadline-ch
                                   (async/alts! [response-ch deadline-ch])

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -885,7 +885,8 @@
 
 (s/def ::permission-request
   (s/keys :req-un [::permission-kind]
-          :opt-un [::tool-call-id ::memory-action ::memory-direction ::memory-reason]))
+          :opt-un [::tool-call-id ::memory-action ::memory-direction ::memory-reason
+                   ::can-offer-session-approval?]))
 
 (s/def ::permission-result-kind
   #{:approved

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -526,7 +526,12 @@
   (s/keys :req-un [::prompt]
           :opt-un [::attachments ::mode ::timeout-ms ::request-headers]))
 
+;; :timeout-ms as used in option maps for send-async / <send! / send-and-wait!
+;; allows nil to "disable" the timeout per the docstrings.
 (s/def ::timeout-ms (s/nilable pos-int?))
+;; send-and-wait!'s positional timeout-ms argument passes the value directly to
+;; async/timeout, so the positional form requires a strict positive integer.
+(s/def ::strict-timeout-ms pos-int?)
 
 ;; -----------------------------------------------------------------------------
 ;; Connection state

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -586,7 +586,7 @@
 (s/def ::ephemeral? boolean?)
 ;; agent-id: identifies which (sub-)agent emitted an event. Present on most events
 ;; once sub-agent streaming is enabled (upstream PR #1108).
-(s/def ::agent-id string?)
+(s/def ::agent-id ::non-blank-string)
 
 ;; canOfferSessionApproval: writeFile permission requests carry this hint indicating
 ;; whether the CLI can present a "trust this session" option (upstream CLI 1.0.28).

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -526,8 +526,8 @@
   (s/keys :req-un [::prompt]
           :opt-un [::attachments ::mode ::timeout-ms ::request-headers]))
 
-;; :timeout-ms as used in option maps for send-async / <send! / send-and-wait!
-;; allows nil to "disable" the timeout per the docstrings.
+;; :timeout-ms as used in option maps for send-async / <send! /
+;; send-async-with-id allows nil to "disable" the timeout per the docstrings.
 (s/def ::timeout-ms (s/nilable pos-int?))
 ;; send-and-wait!'s positional timeout-ms argument passes the value directly to
 ;; async/timeout, so the positional form requires a strict positive integer.
@@ -595,7 +595,11 @@
 
 ;; canOfferSessionApproval: writeFile permission requests carry this hint indicating
 ;; whether the CLI can present a "trust this session" option (upstream CLI 1.0.28).
-(s/def ::can-offer-session-approval? boolean?)
+;; Note: the spec key name omits the `?` suffix because camel-snake-kebab (used
+;; by util/wire->clj) converts `canOfferSessionApproval` to
+;; `:can-offer-session-approval` (no `?`), and `:opt-un` matches on the exact
+;; unqualified keyword — a `?`-suffixed spec would silently never fire.
+(s/def ::can-offer-session-approval boolean?)
 
 ;; reasoningTokens: per-message / per-session tokens used for reasoning content
 ;; (upstream CLI 1.0.32). Reported on assistant.usage and session.usage_info events.
@@ -891,7 +895,7 @@
 (s/def ::permission-request
   (s/keys :req-un [::permission-kind]
           :opt-un [::tool-call-id ::memory-action ::memory-direction ::memory-reason
-                   ::can-offer-session-approval?]))
+                   ::can-offer-session-approval]))
 
 (s/def ::permission-result-kind
   #{:approved

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -526,7 +526,7 @@
   (s/keys :req-un [::prompt]
           :opt-un [::attachments ::mode ::timeout-ms ::request-headers]))
 
-(s/def ::timeout-ms pos-int?)
+(s/def ::timeout-ms (s/nilable pos-int?))
 
 ;; -----------------------------------------------------------------------------
 ;; Connection state

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -250,9 +250,14 @@
 (s/def ::azure-options
   (s/keys :opt-un [::azure-api-version]))
 
+;; Provider :headers — extra HTTP headers forwarded with each model request
+;; (upstream PR #1094, available since CLI 1.0.32). Map of header name → value.
+(s/def ::headers (s/map-of string? string?))
+
 (s/def ::provider
   (s/keys :req-un [::base-url]
-          :opt-un [::provider-type ::wire-api ::api-key ::bearer-token ::azure-options]))
+          :opt-un [::provider-type ::wire-api ::api-key ::bearer-token ::azure-options
+                   ::headers]))
 
 ;; -----------------------------------------------------------------------------
 ;; Session configuration
@@ -360,6 +365,10 @@
 ;; enableConfigDiscovery: auto-discover MCP configs, skills, instruction files (upstream PR #1044)
 (s/def ::enable-config-discovery boolean?)
 
+;; includeSubAgentStreamingEvents: forward streaming events from sub-agents to the parent
+;; session's event stream (upstream PR #1108). Defaults to true on the wire.
+(s/def ::include-sub-agent-streaming-events? boolean?)
+
 ;; modelCapabilities override for session config / setModel (upstream PR #1029).
 ;; DeepPartial<ModelCapabilities> — same shape as ::model-capabilities since all fields are already optional.
 
@@ -371,7 +380,8 @@
     :disabled-skills :large-output :infinite-sessions
     :reasoning-effort :on-user-input-request :on-elicitation-request :hooks
     :working-directory :agent :on-event :create-session-fs-handler
-    :enable-config-discovery :model-capabilities})
+    :enable-config-discovery :model-capabilities
+    :include-sub-agent-streaming-events?})
 
 (s/def ::session-config
   (closed-keys
@@ -383,7 +393,8 @@
                     ::disabled-skills ::large-output ::infinite-sessions
                     ::reasoning-effort ::on-user-input-request ::on-elicitation-request ::hooks
                     ::working-directory ::agent ::on-event ::create-session-fs-handler
-                    ::enable-config-discovery ::model-capabilities])
+                    ::enable-config-discovery ::model-capabilities
+                    ::include-sub-agent-streaming-events?])
    session-config-keys))
 
 (def ^:private resume-session-config-keys
@@ -392,7 +403,8 @@
     :mcp-servers :custom-agents :config-dir :skill-directories
     :disabled-skills :infinite-sessions :reasoning-effort
     :on-user-input-request :on-elicitation-request :hooks :working-directory :disable-resume? :agent :on-event
-    :create-session-fs-handler :enable-config-discovery :model-capabilities})
+    :create-session-fs-handler :enable-config-discovery :model-capabilities
+    :include-sub-agent-streaming-events?})
 
 (s/def ::resume-session-config
   (closed-keys
@@ -403,7 +415,8 @@
                     ::disabled-skills ::infinite-sessions ::reasoning-effort
                     ::on-user-input-request ::on-elicitation-request ::hooks ::working-directory ::disable-resume? ::agent
                     ::on-event ::create-session-fs-handler
-                    ::enable-config-discovery ::model-capabilities])
+                    ::enable-config-discovery ::model-capabilities
+                    ::include-sub-agent-streaming-events?])
    resume-session-config-keys))
 
 ;; join-session config: same as resume-session-config but :on-permission-request is optional.
@@ -417,7 +430,8 @@
                     ::disabled-skills ::infinite-sessions ::reasoning-effort
                     ::on-user-input-request ::on-elicitation-request ::hooks ::working-directory ::disable-resume? ::agent
                     ::on-event ::create-session-fs-handler
-                    ::enable-config-discovery ::model-capabilities])
+                    ::enable-config-discovery ::model-capabilities
+                    ::include-sub-agent-streaming-events?])
    resume-session-config-keys))
 
 ;; -----------------------------------------------------------------------------
@@ -504,9 +518,13 @@
 (s/def ::inbound-attachments (s/coll-of ::inbound-attachment))
 (s/def ::mode #{:enqueue :immediate})
 
+;; Per-request HTTP headers forwarded to the model provider (upstream PR #1094).
+;; Map of header name → value, merged with any provider-level headers.
+(s/def ::request-headers (s/map-of string? string?))
+
 (s/def ::send-options
   (s/keys :req-un [::prompt]
-          :opt-un [::attachments ::mode ::timeout-ms]))
+          :opt-un [::attachments ::mode ::timeout-ms ::request-headers]))
 
 (s/def ::timeout-ms pos-int?)
 
@@ -566,6 +584,17 @@
 (s/def ::event-timestamp ::timestamp)
 (s/def ::parent-id (s/nilable ::non-blank-string))
 (s/def ::ephemeral? boolean?)
+;; agent-id: identifies which (sub-)agent emitted an event. Present on most events
+;; once sub-agent streaming is enabled (upstream PR #1108).
+(s/def ::agent-id string?)
+
+;; canOfferSessionApproval: writeFile permission requests carry this hint indicating
+;; whether the CLI can present a "trust this session" option (upstream CLI 1.0.28).
+(s/def ::can-offer-session-approval? boolean?)
+
+;; reasoningTokens: per-message / per-session tokens used for reasoning content
+;; (upstream CLI 1.0.32). Reported on assistant.usage and session.usage_info events.
+(s/def ::reasoning-tokens nat-int?)
 
 ;; Session log specs (upstream PR #737)
 (s/def ::level #{"info" "warning" "error"})
@@ -574,7 +603,7 @@
 
 (s/def ::base-event
   (s/keys :req-un [::event-id ::event-timestamp ::parent-id]
-          :opt-un [::ephemeral?]))
+          :opt-un [::ephemeral? ::agent-id]))
 
 ;; Event type enum (namespaced under :copilot/)
 (s/def ::event-type

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -2632,10 +2632,10 @@
 ;; --- Spec-only additions (event data fields, upstream 1.0.28 / 1.0.32 / #1108) ---
 
 (deftest test-spec-can-offer-session-approval
-  (testing ":can-offer-session-approval? is a valid boolean spec (upstream 1.0.28)"
-    (is (s/valid? :github.copilot-sdk.specs/can-offer-session-approval? true))
-    (is (s/valid? :github.copilot-sdk.specs/can-offer-session-approval? false))
-    (is (not (s/valid? :github.copilot-sdk.specs/can-offer-session-approval? "yes")))))
+  (testing ":can-offer-session-approval is a valid boolean spec (upstream 1.0.28)"
+    (is (s/valid? :github.copilot-sdk.specs/can-offer-session-approval true))
+    (is (s/valid? :github.copilot-sdk.specs/can-offer-session-approval false))
+    (is (not (s/valid? :github.copilot-sdk.specs/can-offer-session-approval "yes")))))
 
 (deftest test-spec-reasoning-tokens
   (testing ":reasoning-tokens is a non-negative integer spec (upstream 1.0.32)"

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -2522,3 +2522,132 @@
     (is (s/valid? :github.copilot-sdk.specs/memory-direction :upvote))
     (is (s/valid? :github.copilot-sdk.specs/memory-direction :downvote))
     (is (s/valid? :github.copilot-sdk.specs/memory-reason "some reason"))))
+
+;; --- includeSubAgentStreamingEvents wire flag (upstream PR #1108) ---------
+
+(deftest test-include-sub-agent-streaming-events-on-wire
+  (testing "includeSubAgentStreamingEvents defaults to true in session.create (upstream PR #1108)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.create"} method)
+                                                      (swap! seen assoc method params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all})
+          create-params (get @seen "session.create")]
+      (is (true? (:includeSubAgentStreamingEvents create-params)))))
+
+  (testing "includeSubAgentStreamingEvents=false is forwarded in session.create (upstream PR #1108)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.create"} method)
+                                                      (swap! seen assoc method params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all
+                                 :include-sub-agent-streaming-events? false})
+          create-params (get @seen "session.create")]
+      (is (false? (:includeSubAgentStreamingEvents create-params)))))
+
+  (testing "includeSubAgentStreamingEvents defaults to true in session.resume (upstream PR #1108)"
+    (let [seen (atom {})
+          session-id (sdk/session-id (sdk/create-session *test-client* {:on-permission-request sdk/approve-all}))
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.resume"} method)
+                                                      (swap! seen assoc method params))))
+          _ (sdk/resume-session *test-client* session-id
+                                {:on-permission-request sdk/approve-all})
+          resume-params (get @seen "session.resume")]
+      (is (true? (:includeSubAgentStreamingEvents resume-params)))))
+
+  (testing "includeSubAgentStreamingEvents=false is forwarded in session.resume (upstream PR #1108)"
+    (let [seen (atom {})
+          session-id (sdk/session-id (sdk/create-session *test-client* {:on-permission-request sdk/approve-all}))
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.resume"} method)
+                                                      (swap! seen assoc method params))))
+          _ (sdk/resume-session *test-client* session-id
+                                {:on-permission-request sdk/approve-all
+                                 :include-sub-agent-streaming-events? false})
+          resume-params (get @seen "session.resume")]
+      (is (false? (:includeSubAgentStreamingEvents resume-params))))))
+
+;; --- requestHeaders on send! (upstream PR #1094) --------------------------
+
+(deftest test-send-request-headers-on-wire
+  (testing "send! forwards :request-headers as wire :requestHeaders (upstream PR #1094)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.send"} method)
+                                                      (swap! seen assoc method params))))
+          session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          _ (sdk/send! session {:prompt "Hi"
+                                :request-headers {"X-Trace-Id" "abc-123"
+                                                  "X-Custom" "value"}})
+          send-params (get @seen "session.send")]
+      (is (= "abc-123" (get-in send-params [:requestHeaders (keyword "X-Trace-Id")])))
+      (is (= "value" (get-in send-params [:requestHeaders (keyword "X-Custom")])))))
+
+  (testing "send! omits requestHeaders when not set"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.send"} method)
+                                                      (swap! seen assoc method params))))
+          session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          _ (sdk/send! session {:prompt "Hi"})
+          send-params (get @seen "session.send")]
+      (is (not (contains? send-params :requestHeaders)))))
+
+  (testing "send-async forwards :request-headers as wire :requestHeaders (upstream PR #1094)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.send"} method)
+                                                      (swap! seen assoc method params))))
+          session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          _ (sdk/send-async session {:prompt "Hi"
+                                     :request-headers {"X-Trace-Id" "xyz-789"}})]
+      ;; Allow async send to issue the RPC.
+      (Thread/sleep 100)
+      (let [send-params (get @seen "session.send")]
+        (is (= "xyz-789" (get-in send-params [:requestHeaders (keyword "X-Trace-Id")])))))))
+
+;; --- ProviderConfig headers (upstream PR #1094) ---------------------------
+
+(deftest test-provider-headers-on-wire
+  (testing "Provider :headers field is forwarded in session.create (upstream PR #1094)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server* (fn [method params]
+                                                    (when (#{"session.create"} method)
+                                                      (swap! seen assoc method params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all
+                                 :model "gpt-5"
+                                 :provider {:base-url "https://example.com"
+                                            :headers {"X-Org" "acme"}}})
+          create-params (get @seen "session.create")]
+      (is (= "acme" (get-in create-params [:provider :headers (keyword "X-Org")]))))))
+
+;; --- Spec-only additions (event data fields, upstream 1.0.28 / 1.0.32 / #1108) ---
+
+(deftest test-spec-can-offer-session-approval
+  (testing ":can-offer-session-approval? is a valid boolean spec (upstream 1.0.28)"
+    (is (s/valid? :github.copilot-sdk.specs/can-offer-session-approval? true))
+    (is (s/valid? :github.copilot-sdk.specs/can-offer-session-approval? false))
+    (is (not (s/valid? :github.copilot-sdk.specs/can-offer-session-approval? "yes")))))
+
+(deftest test-spec-reasoning-tokens
+  (testing ":reasoning-tokens is a non-negative integer spec (upstream 1.0.32)"
+    (is (s/valid? :github.copilot-sdk.specs/reasoning-tokens 0))
+    (is (s/valid? :github.copilot-sdk.specs/reasoning-tokens 1234))
+    (is (not (s/valid? :github.copilot-sdk.specs/reasoning-tokens -1)))
+    (is (not (s/valid? :github.copilot-sdk.specs/reasoning-tokens "100")))))
+
+(deftest test-spec-agent-id-on-base-event
+  (testing ":agent-id is accepted as an optional string on base events (upstream PR #1108)"
+    (let [evt {:event-id "evt-1"
+               :event-timestamp "2026-04-20T10:00:00Z"
+               :parent-id nil
+               :agent-id "subagent-42"}]
+      (is (s/valid? :github.copilot-sdk.specs/base-event evt)))
+    (let [evt-no-agent {:event-id "evt-2"
+                        :event-timestamp "2026-04-20T10:00:00Z"
+                        :parent-id nil}]
+      (is (s/valid? :github.copilot-sdk.specs/base-event evt-no-agent)))))

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -2603,10 +2603,14 @@
                                                       (swap! seen assoc method params))))
           session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
           _ (sdk/send-async session {:prompt "Hi"
-                                     :request-headers {"X-Trace-Id" "xyz-789"}})]
-      ;; Allow async send to issue the RPC.
-      (Thread/sleep 100)
+                                     :request-headers {"X-Trace-Id" "xyz-789"}})
+          ;; Poll for the async RPC to land rather than fixed sleep (avoids flakes under load).
+          deadline (+ (System/currentTimeMillis) 2000)]
+      (while (and (nil? (get @seen "session.send"))
+                  (< (System/currentTimeMillis) deadline))
+        (Thread/sleep 10))
       (let [send-params (get @seen "session.send")]
+        (is (some? send-params) "async send should have issued session.send within deadline")
         (is (= "xyz-789" (get-in send-params [:requestHeaders (keyword "X-Trace-Id")])))))))
 
 ;; --- ProviderConfig headers (upstream PR #1094) ---------------------------


### PR DESCRIPTION
Port four upstream changes landed after `v0.2.2`.

## What changed

### Public API additions

| Config / option | Type | Upstream |
|---|---|---|
| `::session-config` / `::resume-session-config` / `::join-session-config` `:include-sub-agent-streaming-events?` | boolean (default `true`) | PR #1108 |
| `::send-options` `:request-headers` | `(map-of string? string?)` | PR #1094 |
| `::provider` `:headers` | `(map-of string? string?)` | PR #1094 |

### Spec-only additions (new event / permission fields)

| Spec | Type | Upstream |
|---|---|---|
| `::agent-id` (on `::base-event`) | non-blank string | PR #1108 |
| `::can-offer-session-approval` | boolean | CLI 1.0.28 (PR #1089) |
| `::reasoning-tokens` | non-negative int | CLI 1.0.32 (PR #1105) |

### Files

- `src/github/copilot_sdk/specs.clj` — new specs, updated config key sets and `:opt-un` lists; split timeout spec into `::timeout-ms` (nilable, for option maps) and `::strict-timeout-ms` (positional arg of `send-and-wait!`).
- `src/github/copilot_sdk/client.clj` — `build-create-session-params` and `build-resume-session-params` always emit `:include-sub-agent-streaming-events` (defaulting to `true`, matching upstream `?? true`); docstrings updated.
- `src/github/copilot_sdk/session.clj` — `send!`, `send-async`, and `<send!` forward `:request-headers` on the wire; `send-async` now validates opts against `::send-options`; docstrings updated.
- `src/github/copilot_sdk/instrument.clj` — `send-and-wait!` fdef uses `::strict-timeout-ms` for the positional timeout argument.
- `test/github/copilot_sdk/integration_test.clj` — 6 new `deftest`s covering sync/async wire forwarding and the 3 new spec additions.
- `CHANGELOG.md`, `doc/reference/API.md` — documented.

## Out of scope

- PR #1048 (re-export `ProviderConfig`): Clojure already exposes this via the `::provider` spec.
- PR #1043: internal type renames in the Node impl; no Clojure impact.
- `skills.config.setDisabledSkills`: not exposed by the official Node SDK (only by the CLI).

## Validation

- `bb test`: 182 tests / 542 assertions / 0 failures / 0 errors.
- `./run-all-examples.sh`: all examples pass.
- `bb ci:full` E2E: `test-e2e-blob-attachment` is a pre-existing flake on `main` (verified via `git stash`), unrelated to this PR.
- `bb validate-docs`: clean (pre-existing `github.copilot-sdk.tools` namespace warning).

## Code review

Three parallel code reviews (Claude Opus 4.6, GPT-5.4, GPT-5.3-Codex). Opus and GPT-5.3-Codex found no issues. GPT-5.4 caught that `:request-headers` wasn't forwarded by the async send path — addressed in this commit and covered by a new test.

Seven rounds of Copilot Code Review feedback iterated in-thread (see commits `7f8fef4`…`197d059`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
