### PR TITLE
Plan C Phase 6: deduplicate instrument.clj fdef registry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,10 +90,11 @@ integration tests), every public function call is validated against its spec at 
 This means integration tests run with full spec checking — any argument or return
 value that violates a spec will throw immediately. When adding new public functions:
 
-1. Add an `s/fdef` in `src/github/copilot_sdk/instrument.clj`
-2. Add the function to both `instrument-all!` and `unstrument-all!` lists
-3. Ensure the corresponding specs exist in `src/github/copilot_sdk/specs.clj`
-4. Run `bb test` — if specs are wrong, instrumented tests will catch it
+1. Add a `register-fdef!` form in `src/github/copilot_sdk/instrument.clj` (same syntax as
+   `s/fdef`, but also records the symbol in a single registry so `instrument-all!` /
+   `unstrument-all!` derive their target list automatically — no parallel symbol lists)
+2. Ensure the corresponding specs exist in `src/github/copilot_sdk/specs.clj`
+3. Run `bb test` — if specs are wrong, instrumented tests will catch it
 
 ### Running Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Changed (instrumentation)
+- **Phase 6: instrument deduplication** — `src/github/copilot_sdk/instrument.clj`
+  no longer maintains three parallel symbol lists (one `s/fdef` per public API
+  fn, one symbol list passed to `instrument-all!`, one to `unstrument-all!`).
+  A new private `register-fdef!` macro both delegates to `s/fdef` and records
+  the fully-qualified symbol in a single `registered-fdefs` registry; both
+  `instrument-all!` and `unstrument-all!` now derive their target list from
+  that registry. The macro fail-fast rejects unqualified symbols at
+  macroexpansion time, so a stale or alias-qualified entry is caught
+  immediately rather than silently leaving an instrumentation gap. Net effect:
+  ~162 lines removed from `instrument.clj`, no behavior change, and adding a
+  new public API fn now requires a single edit instead of three.
+
 ## [0.3.0.0-SNAPSHOT] - 2026-04-23
 ### Added (v0.3.0-preview.0 sync)
 - **`defaultAgent.excludedTools` session option** — new `:default-agent {:excluded-tools [...]}` config for create, resume, and join session paths. This hides selected tools from the built-in/default agent while preserving tool availability for custom agents. (upstream commit `b1b0df5c`)

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -17,119 +17,161 @@
             [github.copilot-sdk.specs :as specs]))
 
 ;; -----------------------------------------------------------------------------
+;; Single-source registry for fdefs
+;; -----------------------------------------------------------------------------
+;;
+;; All public-API fdefs in this namespace are declared via `register-fdef!`,
+;; which both registers the spec (delegating to `s/fdef`) and records the
+;; fully-qualified symbol in `registered-fdefs`. `instrument-all!` and
+;; `unstrument-all!` derive their target symbol set from this single registry,
+;; eliminating the previous triplication (one fdef + two parallel symbol
+;; lists). Generated fdefs (planned for future schema-driven codegen) use the
+;; same macro by construction.
+
+(def ^:private registered-fdefs
+  "Set of fully-qualified symbols whose fdefs were declared via
+   `register-fdef!`. `def` (not `defonce`) so REPL reloads of this namespace
+   reset and repopulate the registry deterministically."
+  (atom #{}))
+
+(defmacro ^:private register-fdef!
+  "Like `s/fdef` but also records the fully-qualified symbol in
+   `registered-fdefs`. Returns whatever `s/fdef` returns. Throws at
+   macroexpansion time if `sym` is not fully qualified, so a stale or
+   accidentally unqualified symbol is caught immediately rather than silently
+   leaving an instrumentation gap."
+  [sym & body]
+  (when-not (and (symbol? sym) (namespace sym))
+    (throw (ex-info "register-fdef! requires a fully-qualified symbol"
+                    {:sym sym})))
+  ;; Reject alias-qualified symbols (e.g. `client/start!` where `client` is
+  ;; an `(:require [... :as client])` alias). `s/fdef` would resolve the
+  ;; alias when registering the spec, but `'~sym` below records the
+  ;; UNRESOLVED alias-qualified symbol; `stest/instrument` then receives a
+  ;; symbol that doesn't match any var and silently skips it — exactly the
+  ;; instrumentation gap this macro is meant to prevent. Insist on the full
+  ;; namespace name.
+  (when (contains? (ns-aliases *ns*) (symbol (namespace sym)))
+    (throw (ex-info "register-fdef! requires a fully-qualified namespace, not an alias"
+                    {:sym sym :alias (namespace sym)})))
+  `(let [ret# (s/fdef ~sym ~@body)]
+     (swap! registered-fdefs conj '~sym)
+     ret#))
+
+;; -----------------------------------------------------------------------------
 ;; Function specs for client namespace
 ;; -----------------------------------------------------------------------------
 
-(s/fdef github.copilot-sdk.client/client
+(register-fdef! github.copilot-sdk.client/client
   :args (s/cat :opts (s/? ::specs/client-options))
   :ret ::specs/client)
 
-(s/fdef github.copilot-sdk.client/state
+(register-fdef! github.copilot-sdk.client/state
   :args (s/cat :client ::specs/client)
   :ret ::specs/connection-state)
 
-(s/fdef github.copilot-sdk.client/start!
+(register-fdef! github.copilot-sdk.client/start!
   :args (s/cat :client ::specs/client)
   :ret nil?)
 
-(s/fdef github.copilot-sdk.client/approve-all
+(register-fdef! github.copilot-sdk.client/approve-all
   :args (s/cat :request ::specs/permission-request
                :ctx map?)
   :ret ::specs/permission-result)
 
-(s/fdef github.copilot-sdk.client/stop!
+(register-fdef! github.copilot-sdk.client/stop!
   :args (s/cat :client ::specs/client)
   :ret (s/coll-of any?))
 
-(s/fdef github.copilot-sdk.client/ping
+(register-fdef! github.copilot-sdk.client/ping
   :args (s/cat :client ::specs/client
                :message (s/? (s/nilable string?)))
   :ret (s/keys :opt-un [::specs/message ::specs/timestamp]))
 
-(s/fdef github.copilot-sdk.client/create-session
+(register-fdef! github.copilot-sdk.client/create-session
   :args (s/cat :client ::specs/client
                :config ::specs/session-config)
   :ret ::specs/session)
 
-(s/fdef github.copilot-sdk.client/resume-session
+(register-fdef! github.copilot-sdk.client/resume-session
   :args (s/cat :client ::specs/client
                :session-id ::specs/session-id
                :config ::specs/resume-session-config)
   :ret ::specs/session)
 
-(s/fdef github.copilot-sdk.client/<create-session
+(register-fdef! github.copilot-sdk.client/<create-session
   :args (s/cat :client ::specs/client
                :config ::specs/session-config)
   :ret ::specs/events-ch)
 
-(s/fdef github.copilot-sdk.client/<resume-session
+(register-fdef! github.copilot-sdk.client/<resume-session
   :args (s/cat :client ::specs/client
                :session-id ::specs/session-id
                :config ::specs/resume-session-config)
   :ret ::specs/events-ch)
 
-(s/fdef github.copilot-sdk.client/join-session
+(register-fdef! github.copilot-sdk.client/join-session
   :args (s/cat :config ::specs/join-session-config)
   :ret (s/keys :req-un [::specs/client ::specs/session]))
 
-(s/fdef github.copilot-sdk.client/list-sessions
+(register-fdef! github.copilot-sdk.client/list-sessions
   :args (s/cat :client ::specs/client
                :filter (s/? (s/nilable ::specs/session-list-filter)))
   :ret (s/coll-of ::specs/session-metadata))
 
-(s/fdef github.copilot-sdk.client/get-session-metadata
+(register-fdef! github.copilot-sdk.client/get-session-metadata
   :args (s/cat :client ::specs/client
                :session-id ::specs/session-id)
   :ret (s/nilable ::specs/session-metadata))
 
-(s/fdef github.copilot-sdk.client/delete-session!
+(register-fdef! github.copilot-sdk.client/delete-session!
   :args (s/cat :client ::specs/client
                :session-id ::specs/session-id)
   :ret nil?)
 
-(s/fdef github.copilot-sdk.client/get-last-session-id
+(register-fdef! github.copilot-sdk.client/get-last-session-id
   :args (s/cat :client ::specs/client)
   :ret (s/nilable ::specs/session-id))
 
-(s/fdef github.copilot-sdk.client/get-foreground-session-id
+(register-fdef! github.copilot-sdk.client/get-foreground-session-id
   :args (s/cat :client ::specs/client)
   :ret (s/nilable ::specs/session-id))
 
-(s/fdef github.copilot-sdk.client/set-foreground-session-id!
+(register-fdef! github.copilot-sdk.client/set-foreground-session-id!
   :args (s/cat :client ::specs/client :session-id ::specs/session-id)
   :ret nil?)
 
-(s/fdef github.copilot-sdk.client/get-status
+(register-fdef! github.copilot-sdk.client/get-status
   :args (s/cat :client ::specs/client)
   :ret (s/keys :req-un [::specs/version ::specs/protocol-version]))
 
-(s/fdef github.copilot-sdk.client/get-auth-status
+(register-fdef! github.copilot-sdk.client/get-auth-status
   :args (s/cat :client ::specs/client)
   :ret (s/keys :req-un [::specs/authenticated?]
                :opt-un [::specs/auth-type ::specs/host ::specs/login ::specs/status-message]))
 
-(s/fdef github.copilot-sdk.client/list-models
+(register-fdef! github.copilot-sdk.client/list-models
   :args (s/cat :client ::specs/client)
   :ret (s/coll-of ::specs/model-info))
 
-(s/fdef github.copilot-sdk.client/list-tools
+(register-fdef! github.copilot-sdk.client/list-tools
   :args (s/cat :client ::specs/client
                :model (s/? (s/nilable string?)))
   :ret (s/coll-of ::specs/tool-info-entry))
 
-(s/fdef github.copilot-sdk.client/get-quota
+(register-fdef! github.copilot-sdk.client/get-quota
   :args (s/cat :client ::specs/client)
   :ret ::specs/quota-snapshots)
 
-(s/fdef github.copilot-sdk.client/force-stop!
+(register-fdef! github.copilot-sdk.client/force-stop!
   :args (s/cat :client ::specs/client)
   :ret any?)
 
-(s/fdef github.copilot-sdk.client/notifications
+(register-fdef! github.copilot-sdk.client/notifications
   :args (s/cat :client ::specs/client)
   :ret any?)  ; core.async channel
 
-(s/fdef github.copilot-sdk.client/on-lifecycle-event
+(register-fdef! github.copilot-sdk.client/on-lifecycle-event
   :args (s/alt :wildcard (s/cat :client ::specs/client
                                 :handler ::specs/lifecycle-handler)
                :typed    (s/cat :client ::specs/client
@@ -141,209 +183,209 @@
 ;; Function specs for session namespace
 ;; -----------------------------------------------------------------------------
 
-(s/fdef github.copilot-sdk.session/send!
+(register-fdef! github.copilot-sdk.session/send!
   :args (s/cat :session ::specs/session
                :opts ::specs/send-options)
   :ret string?)  ; message-id
 
-(s/fdef github.copilot-sdk.session/send-and-wait!
+(register-fdef! github.copilot-sdk.session/send-and-wait!
   :args (s/cat :session ::specs/session
                :opts ::specs/send-options
                :timeout-ms (s/? ::specs/strict-timeout-ms))
   :ret (s/nilable map?))
 
-(s/fdef github.copilot-sdk.session/send-async
+(register-fdef! github.copilot-sdk.session/send-async
   :args (s/cat :session ::specs/session
                :opts (s/merge ::specs/send-options
                               (s/keys :opt-un [::specs/timeout-ms])))
   :ret any?)  ; core.async channel
 
-(s/fdef github.copilot-sdk.session/send-async-with-id
+(register-fdef! github.copilot-sdk.session/send-async-with-id
   :args (s/cat :session ::specs/session
                :opts (s/merge ::specs/send-options
                               (s/keys :opt-un [::specs/timeout-ms])))
   :ret (s/keys :req-un [::specs/message-id ::specs/events-ch]))
 
-(s/fdef github.copilot-sdk.session/<send!
+(register-fdef! github.copilot-sdk.session/<send!
   :args (s/cat :session ::specs/session
                :opts (s/merge ::specs/send-options
                               (s/keys :opt-un [::specs/timeout-ms])))
   :ret any?)  ; core.async channel
 
-(s/fdef github.copilot-sdk.session/abort!
+(register-fdef! github.copilot-sdk.session/abort!
   :args (s/cat :session ::specs/session)
   :ret nil?)
 
-(s/fdef github.copilot-sdk.session/get-messages
+(register-fdef! github.copilot-sdk.session/get-messages
   :args (s/cat :session ::specs/session)
   :ret (s/coll-of map?))
 
-(s/fdef github.copilot-sdk.session/destroy!
+(register-fdef! github.copilot-sdk.session/destroy!
   :args (s/alt :handle (s/cat :session ::specs/session)
                :explicit (s/cat :client ::specs/client
                                 :session-id ::specs/session-id))
   :ret nil?)
 
-(s/fdef github.copilot-sdk.session/disconnect!
+(register-fdef! github.copilot-sdk.session/disconnect!
   :args (s/alt :handle (s/cat :session ::specs/session)
                :explicit (s/cat :client ::specs/client
                                 :session-id ::specs/session-id))
   :ret nil?)
 
-(s/fdef github.copilot-sdk.session/session-id
+(register-fdef! github.copilot-sdk.session/session-id
   :args (s/cat :session ::specs/session)
   :ret ::specs/session-id)
 
-(s/fdef github.copilot-sdk.session/workspace-path
+(register-fdef! github.copilot-sdk.session/workspace-path
   :args (s/cat :session ::specs/session)
   :ret ::specs/workspace-path)
 
-(s/fdef github.copilot-sdk.session/events
+(register-fdef! github.copilot-sdk.session/events
   :args (s/cat :session ::specs/session)
   :ret any?)  ; core.async mult
 
-(s/fdef github.copilot-sdk.session/subscribe-events
+(register-fdef! github.copilot-sdk.session/subscribe-events
   :args (s/cat :session ::specs/session)
   :ret any?)  ; core.async channel
 
-(s/fdef github.copilot-sdk.session/unsubscribe-events
+(register-fdef! github.copilot-sdk.session/unsubscribe-events
   :args (s/cat :session ::specs/session
                :ch any?)
   :ret nil?)
 
-(s/fdef github.copilot-sdk.session/events->chan
+(register-fdef! github.copilot-sdk.session/events->chan
   :args (s/cat :session ::specs/session
                :opts (s/? (s/keys :opt-un [::specs/buffer ::specs/xf])))
   :ret any?)  ; core.async channel
 
-(s/fdef github.copilot-sdk.session/get-current-model
+(register-fdef! github.copilot-sdk.session/get-current-model
   :args (s/cat :session ::specs/session)
   :ret ::specs/model-id)
 
-(s/fdef github.copilot-sdk.session/switch-model!
+(register-fdef! github.copilot-sdk.session/switch-model!
   :args (s/cat :session ::specs/session
                :model-id string?
                :opts (s/? (s/nilable (s/keys :opt-un [::specs/reasoning-effort
                                                       ::specs/model-capabilities]))))
   :ret (s/nilable ::specs/model-id))
 
-(s/fdef github.copilot-sdk.session/set-model!
+(register-fdef! github.copilot-sdk.session/set-model!
   :args (s/cat :session ::specs/session
                :model-id string?
                :opts (s/? (s/nilable (s/keys :opt-un [::specs/reasoning-effort
                                                       ::specs/model-capabilities]))))
   :ret (s/nilable ::specs/model-id))
 
-(s/fdef github.copilot-sdk.session/log!
+(register-fdef! github.copilot-sdk.session/log!
   :args (s/cat :session ::specs/session
                :message string?
                :opts (s/? (s/nilable ::specs/log-options)))
   :ret ::specs/event-id)
 
-(s/fdef github.copilot-sdk.session/create-session-fs-adapter
+(register-fdef! github.copilot-sdk.session/create-session-fs-adapter
   :args (s/cat :provider ::specs/session-fs-provider)
   :ret ::specs/session-fs-handler)
 
-(s/fdef github.copilot-sdk.session/adapt-session-fs-handler
+(register-fdef! github.copilot-sdk.session/adapt-session-fs-handler
   :args (s/cat :handler-or-provider (s/or :handler ::specs/session-fs-handler
                                           :provider ::specs/session-fs-provider))
   :ret ::specs/session-fs-handler)
 
 ;; -- Experimental RPC method specs -------------------------------------------
 
-(s/fdef github.copilot-sdk.session/skills-list
+(register-fdef! github.copilot-sdk.session/skills-list
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/skills-enable!
+(register-fdef! github.copilot-sdk.session/skills-enable!
   :args (s/cat :session ::specs/session :skill-name string?)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/skills-disable!
+(register-fdef! github.copilot-sdk.session/skills-disable!
   :args (s/cat :session ::specs/session :skill-name string?)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/skills-reload!
+(register-fdef! github.copilot-sdk.session/skills-reload!
   :args (s/cat :session ::specs/session)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/mcp-list
+(register-fdef! github.copilot-sdk.session/mcp-list
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/mcp-enable!
+(register-fdef! github.copilot-sdk.session/mcp-enable!
   :args (s/cat :session ::specs/session :server-name string?)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/mcp-disable!
+(register-fdef! github.copilot-sdk.session/mcp-disable!
   :args (s/cat :session ::specs/session :server-name string?)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/mcp-reload!
+(register-fdef! github.copilot-sdk.session/mcp-reload!
   :args (s/cat :session ::specs/session)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/extensions-list
+(register-fdef! github.copilot-sdk.session/extensions-list
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/extensions-enable!
+(register-fdef! github.copilot-sdk.session/extensions-enable!
   :args (s/cat :session ::specs/session :extension-id string?)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/extensions-disable!
+(register-fdef! github.copilot-sdk.session/extensions-disable!
   :args (s/cat :session ::specs/session :extension-id string?)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/extensions-reload!
+(register-fdef! github.copilot-sdk.session/extensions-reload!
   :args (s/cat :session ::specs/session)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/plugins-list
+(register-fdef! github.copilot-sdk.session/plugins-list
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/compaction-compact!
+(register-fdef! github.copilot-sdk.session/compaction-compact!
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/history-truncate!
+(register-fdef! github.copilot-sdk.session/history-truncate!
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/sessions-fork!
+(register-fdef! github.copilot-sdk.session/sessions-fork!
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/shell-exec!
+(register-fdef! github.copilot-sdk.session/shell-exec!
   :args (s/cat :session ::specs/session :command string?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/shell-kill!
+(register-fdef! github.copilot-sdk.session/shell-kill!
   :args (s/cat :session ::specs/session :process-id string?)
   :ret any?)
 
-(s/fdef github.copilot-sdk.session/ui-elicitation!
+(register-fdef! github.copilot-sdk.session/ui-elicitation!
   :args (s/cat :session ::specs/session :params ::specs/elicitation-params)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/capabilities
+(register-fdef! github.copilot-sdk.session/capabilities
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/elicitation-supported?
+(register-fdef! github.copilot-sdk.session/elicitation-supported?
   :args (s/cat :session ::specs/session)
   :ret boolean?)
 
-(s/fdef github.copilot-sdk.session/confirm!
+(register-fdef! github.copilot-sdk.session/confirm!
   :args (s/cat :session ::specs/session :message string?)
   :ret boolean?)
 
-(s/fdef github.copilot-sdk.session/select!
+(register-fdef! github.copilot-sdk.session/select!
   :args (s/cat :session ::specs/session :message string? :options (s/coll-of string?))
   :ret (s/nilable string?))
 
-(s/fdef github.copilot-sdk.session/input!
+(register-fdef! github.copilot-sdk.session/input!
   :args (s/cat :session ::specs/session :message string?
                :opts (s/? (s/nilable ::specs/input-options)))
   :ret (s/nilable string?))
@@ -352,22 +394,22 @@
 ;; Function specs for helpers namespace
 ;; -----------------------------------------------------------------------------
 
-(s/fdef github.copilot-sdk.helpers/query
+(register-fdef! github.copilot-sdk.helpers/query
   :args (s/cat :prompt string?
                :opts (s/keys* :opt-un [::specs/client ::specs/session ::specs/timeout-ms]))
   :ret (s/nilable string?))
 
-(s/fdef github.copilot-sdk.helpers/query-seq!
+(register-fdef! github.copilot-sdk.helpers/query-seq!
   :args (s/cat :prompt string?
                :opts (s/keys* :opt-un [::specs/client ::specs/session ::specs/max-events]))
   :ret seqable?)
 
-(s/fdef github.copilot-sdk.helpers/query-chan
+(register-fdef! github.copilot-sdk.helpers/query-chan
   :args (s/cat :prompt string?
                :opts (s/keys* :opt-un [::specs/client ::specs/session ::specs/buffer]))
   :ret any?)  ; core.async channel
 
-(s/fdef github.copilot-sdk.helpers/shutdown!
+(register-fdef! github.copilot-sdk.helpers/shutdown!
   :args (s/cat)
   :ret nil?)
 
@@ -375,105 +417,105 @@
 ;; Session RPC wrapper function specs (experimental)
 ;; -----------------------------------------------------------------------------
 
-(s/fdef github.copilot-sdk.session/mode-get
+(register-fdef! github.copilot-sdk.session/mode-get
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/mode-set!
+(register-fdef! github.copilot-sdk.session/mode-set!
   :args (s/cat :session ::specs/session :mode string?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/plan-read
+(register-fdef! github.copilot-sdk.session/plan-read
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/plan-update!
+(register-fdef! github.copilot-sdk.session/plan-update!
   :args (s/cat :session ::specs/session :content string?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/plan-delete!
+(register-fdef! github.copilot-sdk.session/plan-delete!
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/workspace-list-files
+(register-fdef! github.copilot-sdk.session/workspace-list-files
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/workspace-read-file
+(register-fdef! github.copilot-sdk.session/workspace-read-file
   :args (s/cat :session ::specs/session :path string?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/workspace-create-file!
+(register-fdef! github.copilot-sdk.session/workspace-create-file!
   :args (s/cat :session ::specs/session :path string? :content string?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/agent-list
+(register-fdef! github.copilot-sdk.session/agent-list
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/agent-get-current
+(register-fdef! github.copilot-sdk.session/agent-get-current
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/agent-select!
+(register-fdef! github.copilot-sdk.session/agent-select!
   :args (s/cat :session ::specs/session :agent-name string?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/agent-deselect!
+(register-fdef! github.copilot-sdk.session/agent-deselect!
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/agent-reload!
+(register-fdef! github.copilot-sdk.session/agent-reload!
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/fleet-start!
+(register-fdef! github.copilot-sdk.session/fleet-start!
   :args (s/cat :session ::specs/session :params map?)
   :ret map?)
 
 ;; Session name RPC function specs (upstream CLI 1.0.26, PR #1076)
-(s/fdef github.copilot-sdk.session/session-name-get
+(register-fdef! github.copilot-sdk.session/session-name-get
   :args (s/cat :session ::specs/session)
   :ret map?)
 
-(s/fdef github.copilot-sdk.session/session-name-set!
+(register-fdef! github.copilot-sdk.session/session-name-set!
   :args (s/cat :session ::specs/session :name string?)
   :ret map?)
 
 ;; Workspace extended RPC function specs (upstream CLI 1.0.26, PR #1076)
-(s/fdef github.copilot-sdk.session/workspace-get-workspace
+(register-fdef! github.copilot-sdk.session/workspace-get-workspace
   :args (s/cat :session ::specs/session)
   :ret map?)
 
 ;; MCP discovery RPC function spec (upstream CLI 1.0.22, PR #1055)
-(s/fdef github.copilot-sdk.session/mcp-discover
+(register-fdef! github.copilot-sdk.session/mcp-discover
   :args (s/cat :session ::specs/session :opts (s/? map?))
   :ret map?)
 
 ;; Usage metrics RPC function spec (upstream CLI 1.0.22, PR #1055)
-(s/fdef github.copilot-sdk.session/usage-get-metrics
+(register-fdef! github.copilot-sdk.session/usage-get-metrics
   :args (s/cat :session ::specs/session)
   :ret map?)
 
 ;; convert-mcp-call-tool-result function spec (upstream PR #1049)
-(s/fdef github.copilot-sdk.tools/convert-mcp-call-tool-result
+(register-fdef! github.copilot-sdk.tools/convert-mcp-call-tool-result
   :args (s/cat :call-result map?)
   :ret ::specs/tool-result-object)
 
 ;; Client-level MCP config function specs
-(s/fdef github.copilot-sdk.client/mcp-config-list
+(register-fdef! github.copilot-sdk.client/mcp-config-list
   :args (s/cat :client ::specs/client)
   :ret map?)
 
-(s/fdef github.copilot-sdk.client/mcp-config-add!
+(register-fdef! github.copilot-sdk.client/mcp-config-add!
   :args (s/cat :client ::specs/client :params map?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.client/mcp-config-update!
+(register-fdef! github.copilot-sdk.client/mcp-config-update!
   :args (s/cat :client ::specs/client :params map?)
   :ret map?)
 
-(s/fdef github.copilot-sdk.client/mcp-config-remove!
+(register-fdef! github.copilot-sdk.client/mcp-config-remove!
   :args (s/cat :client ::specs/client :params map?)
   :ret map?)
 
@@ -482,208 +524,14 @@
 ;; -----------------------------------------------------------------------------
 
 (defn instrument-all!
-  "Instrument all public API functions with spec checking."
+  "Instrument every fdef registered via `register-fdef!`."
   []
-  (stest/instrument '[github.copilot-sdk.client/client
-                      github.copilot-sdk.client/state
-                      github.copilot-sdk.client/start!
-                      github.copilot-sdk.client/approve-all
-                      github.copilot-sdk.client/stop!
-                      github.copilot-sdk.client/force-stop!
-                      github.copilot-sdk.client/ping
-                      github.copilot-sdk.client/get-status
-                      github.copilot-sdk.client/get-auth-status
-                      github.copilot-sdk.client/list-models
-                      github.copilot-sdk.client/list-tools
-                      github.copilot-sdk.client/get-quota
-                      github.copilot-sdk.client/create-session
-                      github.copilot-sdk.client/<create-session
-                      github.copilot-sdk.client/resume-session
-                      github.copilot-sdk.client/<resume-session
-                      github.copilot-sdk.client/join-session
-                      github.copilot-sdk.client/list-sessions
-                      github.copilot-sdk.client/get-session-metadata
-                      github.copilot-sdk.client/delete-session!
-                      github.copilot-sdk.client/get-last-session-id
-                      github.copilot-sdk.client/get-foreground-session-id
-                      github.copilot-sdk.client/set-foreground-session-id!
-                      github.copilot-sdk.client/notifications
-                      github.copilot-sdk.client/on-lifecycle-event
-                      github.copilot-sdk.session/send!
-                      github.copilot-sdk.session/send-and-wait!
-                      github.copilot-sdk.session/send-async
-                      github.copilot-sdk.session/send-async-with-id
-                      github.copilot-sdk.session/<send!
-                      github.copilot-sdk.session/abort!
-                      github.copilot-sdk.session/get-messages
-                      github.copilot-sdk.session/destroy!
-                      github.copilot-sdk.session/disconnect!
-                      github.copilot-sdk.session/session-id
-                      github.copilot-sdk.session/workspace-path
-                      github.copilot-sdk.session/get-current-model
-                      github.copilot-sdk.session/switch-model!
-                      github.copilot-sdk.session/set-model!
-                      github.copilot-sdk.session/log!
-                      github.copilot-sdk.session/create-session-fs-adapter
-                      github.copilot-sdk.session/adapt-session-fs-handler
-                      github.copilot-sdk.session/skills-list
-                      github.copilot-sdk.session/skills-enable!
-                      github.copilot-sdk.session/skills-disable!
-                      github.copilot-sdk.session/skills-reload!
-                      github.copilot-sdk.session/mcp-list
-                      github.copilot-sdk.session/mcp-enable!
-                      github.copilot-sdk.session/mcp-disable!
-                      github.copilot-sdk.session/mcp-reload!
-                      github.copilot-sdk.session/extensions-list
-                      github.copilot-sdk.session/extensions-enable!
-                      github.copilot-sdk.session/extensions-disable!
-                      github.copilot-sdk.session/extensions-reload!
-                      github.copilot-sdk.session/plugins-list
-                      github.copilot-sdk.session/compaction-compact!
-                      github.copilot-sdk.session/history-truncate!
-                      github.copilot-sdk.session/sessions-fork!
-                      github.copilot-sdk.session/shell-exec!
-                      github.copilot-sdk.session/shell-kill!
-                      github.copilot-sdk.session/mode-get
-                      github.copilot-sdk.session/mode-set!
-                      github.copilot-sdk.session/plan-read
-                      github.copilot-sdk.session/plan-update!
-                      github.copilot-sdk.session/plan-delete!
-                      github.copilot-sdk.session/workspace-list-files
-                      github.copilot-sdk.session/workspace-read-file
-                      github.copilot-sdk.session/workspace-create-file!
-                      github.copilot-sdk.session/agent-list
-                      github.copilot-sdk.session/agent-get-current
-                      github.copilot-sdk.session/agent-select!
-                      github.copilot-sdk.session/agent-deselect!
-                      github.copilot-sdk.session/agent-reload!
-                      github.copilot-sdk.session/fleet-start!
-                      github.copilot-sdk.session/session-name-get
-                      github.copilot-sdk.session/session-name-set!
-                      github.copilot-sdk.session/workspace-get-workspace
-                      github.copilot-sdk.session/mcp-discover
-                      github.copilot-sdk.session/usage-get-metrics
-                      github.copilot-sdk.tools/convert-mcp-call-tool-result
-                      github.copilot-sdk.client/mcp-config-list
-                      github.copilot-sdk.client/mcp-config-add!
-                      github.copilot-sdk.client/mcp-config-update!
-                      github.copilot-sdk.client/mcp-config-remove!
-                      github.copilot-sdk.session/ui-elicitation!
-                      github.copilot-sdk.session/capabilities
-                      github.copilot-sdk.session/elicitation-supported?
-                      github.copilot-sdk.session/confirm!
-                      github.copilot-sdk.session/select!
-                      github.copilot-sdk.session/input!
-                      github.copilot-sdk.session/events
-                      github.copilot-sdk.session/subscribe-events
-                      github.copilot-sdk.session/unsubscribe-events
-                      github.copilot-sdk.session/events->chan
-                      github.copilot-sdk.helpers/query
-                      github.copilot-sdk.helpers/query-seq!
-                      github.copilot-sdk.helpers/query-chan
-                      github.copilot-sdk.helpers/shutdown!]))
+  (stest/instrument (vec @registered-fdefs)))
 
 (defn unstrument-all!
-  "Remove instrumentation from all public API functions."
+  "Remove instrumentation from every fdef registered via `register-fdef!`."
   []
-  (stest/unstrument '[github.copilot-sdk.client/client
-                      github.copilot-sdk.client/state
-                      github.copilot-sdk.client/start!
-                      github.copilot-sdk.client/approve-all
-                      github.copilot-sdk.client/stop!
-                      github.copilot-sdk.client/force-stop!
-                      github.copilot-sdk.client/ping
-                      github.copilot-sdk.client/get-status
-                      github.copilot-sdk.client/get-auth-status
-                      github.copilot-sdk.client/list-models
-                      github.copilot-sdk.client/list-tools
-                      github.copilot-sdk.client/get-quota
-                      github.copilot-sdk.client/create-session
-                      github.copilot-sdk.client/<create-session
-                      github.copilot-sdk.client/resume-session
-                      github.copilot-sdk.client/<resume-session
-                      github.copilot-sdk.client/join-session
-                      github.copilot-sdk.client/list-sessions
-                      github.copilot-sdk.client/get-session-metadata
-                      github.copilot-sdk.client/delete-session!
-                      github.copilot-sdk.client/get-last-session-id
-                      github.copilot-sdk.client/get-foreground-session-id
-                      github.copilot-sdk.client/set-foreground-session-id!
-                      github.copilot-sdk.client/notifications
-                      github.copilot-sdk.client/on-lifecycle-event
-                      github.copilot-sdk.session/send!
-                      github.copilot-sdk.session/send-and-wait!
-                      github.copilot-sdk.session/send-async
-                      github.copilot-sdk.session/send-async-with-id
-                      github.copilot-sdk.session/<send!
-                      github.copilot-sdk.session/abort!
-                      github.copilot-sdk.session/get-messages
-                      github.copilot-sdk.session/destroy!
-                      github.copilot-sdk.session/disconnect!
-                      github.copilot-sdk.session/session-id
-                      github.copilot-sdk.session/workspace-path
-                      github.copilot-sdk.session/get-current-model
-                      github.copilot-sdk.session/switch-model!
-                      github.copilot-sdk.session/set-model!
-                      github.copilot-sdk.session/log!
-                      github.copilot-sdk.session/create-session-fs-adapter
-                      github.copilot-sdk.session/adapt-session-fs-handler
-                      github.copilot-sdk.session/skills-list
-                      github.copilot-sdk.session/skills-enable!
-                      github.copilot-sdk.session/skills-disable!
-                      github.copilot-sdk.session/skills-reload!
-                      github.copilot-sdk.session/mcp-list
-                      github.copilot-sdk.session/mcp-enable!
-                      github.copilot-sdk.session/mcp-disable!
-                      github.copilot-sdk.session/mcp-reload!
-                      github.copilot-sdk.session/extensions-list
-                      github.copilot-sdk.session/extensions-enable!
-                      github.copilot-sdk.session/extensions-disable!
-                      github.copilot-sdk.session/extensions-reload!
-                      github.copilot-sdk.session/plugins-list
-                      github.copilot-sdk.session/compaction-compact!
-                      github.copilot-sdk.session/history-truncate!
-                      github.copilot-sdk.session/sessions-fork!
-                      github.copilot-sdk.session/shell-exec!
-                      github.copilot-sdk.session/shell-kill!
-                      github.copilot-sdk.session/mode-get
-                      github.copilot-sdk.session/mode-set!
-                      github.copilot-sdk.session/plan-read
-                      github.copilot-sdk.session/plan-update!
-                      github.copilot-sdk.session/plan-delete!
-                      github.copilot-sdk.session/workspace-list-files
-                      github.copilot-sdk.session/workspace-read-file
-                      github.copilot-sdk.session/workspace-create-file!
-                      github.copilot-sdk.session/agent-list
-                      github.copilot-sdk.session/agent-get-current
-                      github.copilot-sdk.session/agent-select!
-                      github.copilot-sdk.session/agent-deselect!
-                      github.copilot-sdk.session/agent-reload!
-                      github.copilot-sdk.session/fleet-start!
-                      github.copilot-sdk.session/session-name-get
-                      github.copilot-sdk.session/session-name-set!
-                      github.copilot-sdk.session/workspace-get-workspace
-                      github.copilot-sdk.session/mcp-discover
-                      github.copilot-sdk.session/usage-get-metrics
-                      github.copilot-sdk.tools/convert-mcp-call-tool-result
-                      github.copilot-sdk.client/mcp-config-list
-                      github.copilot-sdk.client/mcp-config-add!
-                      github.copilot-sdk.client/mcp-config-update!
-                      github.copilot-sdk.client/mcp-config-remove!
-                      github.copilot-sdk.session/ui-elicitation!
-                      github.copilot-sdk.session/capabilities
-                      github.copilot-sdk.session/elicitation-supported?
-                      github.copilot-sdk.session/confirm!
-                      github.copilot-sdk.session/select!
-                      github.copilot-sdk.session/input!
-                      github.copilot-sdk.session/events
-                      github.copilot-sdk.session/subscribe-events
-                      github.copilot-sdk.session/unsubscribe-events
-                      github.copilot-sdk.session/events->chan
-                      github.copilot-sdk.helpers/query
-                      github.copilot-sdk.helpers/query-seq!
-                      github.copilot-sdk.helpers/query-chan
-                      github.copilot-sdk.helpers/shutdown!]))
+  (stest/unstrument (vec @registered-fdefs)))
 
 ;; Auto-instrument when this namespace is loaded
 (instrument-all!)


### PR DESCRIPTION
## Plan C Phase 6: deduplicate `instrument.clj` fdef registry

Eliminates the three-parallel-list maintenance burden in
`src/github/copilot_sdk/instrument.clj`.

### Problem

Adding a public API function previously required edits in **three places**:

1. The `(s/fdef sym ...)` declaration in `instrument.clj`
2. The symbol list passed to `stest/instrument` in `instrument-all!`
3. The symbol list passed to `stest/unstrument` in `unstrument-all!`

This triplication was documented in `AGENTS.md` as a known weakness.
Drift between the three lists would silently leave an instrumentation gap
for the missing symbol.

### Solution

A single private `register-fdef!` macro records each fdef into a single
private registry; both `(un)instrument-all!` derive from it.

```clojure
(def ^:private registered-fdefs (atom #{}))

(defmacro ^:private register-fdef!
  [sym & body]
  ;; Reject unqualified symbols
  (when-not (and (symbol? sym) (namespace sym))
    (throw (ex-info "register-fdef! requires a fully-qualified symbol"
                    {:sym sym})))
  ;; Reject alias-qualified symbols — `s/fdef` would resolve the alias when
  ;; registering the spec, but `'~sym` would record the unresolved alias
  ;; symbol; `stest/instrument` would then silently skip it.
  (when (contains? (ns-aliases *ns*) (symbol (namespace sym)))
    (throw (ex-info "register-fdef! requires a fully-qualified namespace, not an alias"
                    {:sym sym :alias (namespace sym)})))
  `(let [ret# (s/fdef ~sym ~@body)]
     (swap! registered-fdefs conj '~sym)
     ret#))

(defn instrument-all! []
  (stest/instrument (vec @registered-fdefs)))

(defn unstrument-all! []
  (stest/unstrument (vec @registered-fdefs)))
```

All 98 hand-written fdefs were mechanically migrated from `s/fdef` to
`register-fdef!`. The trailing `(instrument-all!)` call still works because
all 98 `register-fdef!` forms run (and populate the atom) before it.

### Net effect

* **`instrument.clj`**: 689 → 527 lines (~162 lines of pure repetition removed)
* **Workflow**: adding a public API fn now requires **one** edit, not three
* **No behavior change** — symbol set passed to `stest/instrument` is
  identical to the old hard-coded vector
* **AGENTS.md** workflow doc updated accordingly

### Defense in depth

The macro fail-fast at macroexpansion time:

* rejects unqualified symbols (would otherwise be silently mis-registered)
* rejects alias-qualified symbols (e.g. `client/foo` where `client` is a
  `(:require ... :as client)` alias). `s/fdef` resolves aliases at
  registration time, but `'~sym` records the unresolved symbol — so
  `stest/instrument` would receive a symbol that doesn't match any var.
  This was caught by both the rubber-duck critique (pre-impl) and the
  GPT-5.5 round-1 review.

### Validation

* `bb test`: 188 tests, 605 assertions, 0 failures, 0 errors
* `bb ci:full` (on the codegen-pipeline branch where this work was
  initially developed before being moved to its own branch): exit 0
* Reviewed in parallel by Claude Opus 4.7, GPT-5.5 (extra-high reasoning),
  and GPT-5.3-Codex (extra-high reasoning). Round 1: one Medium finding
  (alias guard) raised by GPT-5.5; fixed. Round 2: clean.

### Files changed

* `src/github/copilot_sdk/instrument.clj` — registry + macro + 98 form rewrites + simplified (un)instrument-all!
* `.github/copilot-instructions.md` — workflow updated from 4 steps to 3 (single edit replaces "add to fdef list AND instrument-all! AND unstrument-all!")
* `CHANGELOG.md` — Unreleased entry under "### Changed (instrumentation)"

### Plan C progress

This is Phase 6 of Plan C. Phase 1+3+3.5 (codegen pipeline + three-tier
wire/coerce/idiom architecture) is in #93. Phase 7 (mock v3 coverage) and
Phase 5 (RPC fdef codegen — blocked on upstream `api.schema.json`) remain.

This branch is independent of #93 — it's branched directly from `main` so
it can land independently.
