### PR TITLE
Upstream sync: copilot-sdk v1.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
-### Added (post-v1.0.0-beta.3 CLI sync)
+### Notes (v1.0.0-beta.4 sync)
+Upstream `v1.0.0-beta.4` shipped no new Node.js SDK API surface relative to
+`v1.0.0-beta.3` — every SDK-visible change in the upstream diff
+(`ModelBilling.multiplier` optional, extension permission kinds,
+`detachedFromSpawningParentSessionId`, advisor block fields on
+`assistant.message`, `model` on `assistant.message`, model-picker categories,
+`session.commands.respondToQueuedCommand`) was already brought in by the
+earlier CLI 1.0.48 schema sync (PR #103), whose entries appear below.
+`session.tasks.sendMessage` and the C#/Go-only changes from beta.4 are
+deliberately out of scope per the API-parity rule (see Tracked-but-not-ported).
+This release bumps the upstream marker from `1.0.0-beta.3` to `1.0.0-beta.4`.
+
+### Added (v1.0.0-beta.4 sync)
 - **Schema bump** — `.copilot-schema-version` advanced from `1.0.46` to
   `1.0.48` (the latest GA on npm).
   Generated wire specs and coercions regenerated.
@@ -83,7 +95,7 @@ All notable changes to this project will be documented in this file. This change
   `?` suffix — csk does not append `?` for booleans). (upstream PR #1288,
   CLI 1.0.48-1)
 
-### Tracked-but-not-ported (post-v1.0.0-beta.3 CLI sync)
+### Tracked-but-not-ported (v1.0.0-beta.4 sync)
 - **`session.tasks.sendMessage` (experimental)** — the upstream Tasks API
   (`session.tasks.*`) is intentionally not surfaced in the Clojure SDK
   yet; the new `sendMessage` RPC is tracked here for a future port.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add to your `deps.edn`:
 
 ```clojure
 ;; From Maven Central
-io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "1.0.0-beta.3.0"}
+io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "1.0.0-beta.4.0"}
 
 ;; Or git dependency
 io.github.copilot-community-sdk/copilot-sdk-clojure {:git/url "https://github.com/copilot-community-sdk/copilot-sdk-clojure.git"

--- a/build.clj
+++ b/build.clj
@@ -7,7 +7,7 @@
   (:import [java.io File]))
 
 (def lib 'io.github.copilot-community-sdk/copilot-sdk-clojure)
-(def version "1.0.0-beta.3.0")
+(def version "1.0.0-beta.4.0")
 (def class-dir "target/classes")
 
 (defn- try-sh


### PR DESCRIPTION
Bumps the upstream marker from `1.0.0-beta.3` to `1.0.0-beta.4` (released [2026-05-13](https://github.com/github/copilot-sdk/releases/tag/v1.0.0-beta.4)). Version: `1.0.0-beta.3.0` → `1.0.0-beta.4.0`.

## TL;DR

**No new code or specs needed.** Every SDK-visible change in the upstream `v1.0.0-beta.3..v1.0.0-beta.4` diff was already brought in by the earlier CLI 1.0.48 schema sync (#103), whose entries appear in `[Unreleased]` and are now relabelled `(v1.0.0-beta.4 sync)`.

## Gap analysis

Upstream diff (`nodejs/src/`):

| Upstream change | Status |
|---|---|
| `ModelBilling.multiplier` becomes optional | already `:opt-un` in `::model-billing` |
| `extension-management` / `extension-permission-access` permission kinds | in `::permission-kind`; integration tests cover both |
| `StartData.detachedFromSpawningParentSessionId` | idiom + wire specs + test |
| `AssistantMessageData.{anthropicAdvisorBlocks,anthropicAdvisorModel,model}` | idiom + wire specs + test |
| `Model.modelPickerCategory` / `modelPickerPriceCategory` | `parse-model-info` surfaces both; test |
| `session.commands.respondToQueuedCommand` RPC | exposed as `session/respond-to-queued-command!` (experimental) |
| `session.tasks.sendMessage` RPC | Tracked-but-not-ported (upstream Tasks API not surfaced) |
| `WorkspacesGetWorkspaceResult` field removals | never surfaced; no change needed |

Upstream `client.ts`, `session.ts`, `index.ts` had no changes between beta.3 and beta.4. The release was primarily Go union typing + cross-language `@experimental` annotations.

## Changes

- `build.clj`, `README.md` — version bump `1.0.0-beta.3.0` → `1.0.0-beta.4.0`.
- `CHANGELOG.md` — rename `### Added (post-v1.0.0-beta.3 CLI sync)` and `### Tracked-but-not-ported (post-v1.0.0-beta.3 CLI sync)` to `(v1.0.0-beta.4 sync)`; add a top-of-section note recording that beta.4's nodejs/src diff was pre-covered by the 1.0.48 schema sync.

## Validation

- `bb ci` — 254 tests, 1197 assertions, **0 failures, 0 errors**.
- `bb validate-docs` — 13 files, 0 warnings.

## Skipped phases

Red/green TDD and multi-model code review are skipped because this change is metadata-only — no source under `src/` or `test/` is modified.
