### PR TITLE
Port upstream PR #1428: Client Mode (Empty) — multitenancy hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,64 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Added (Client Mode Empty — upstream PR #1428)
+- **`:mode` client option** — `#{:copilot-cli :empty}`, default
+  `:copilot-cli`. Selects between historical CLI behavior and a hardened
+  multitenancy posture for SaaS hosts that must isolate sessions from
+  the local machine. Validated on `copilot/client`.
+- **`:empty` mode constructor enforcement** — In `:empty` mode the
+  client requires at least one tenant-scoped storage root
+  (`:copilot-home`, `:session-fs`, `:cli-url`, or `:is-child-process?`)
+  so the CLI never falls back to the user's home directory, and forces
+  `COPILOT_DISABLE_KEYTAR=1` on the spawned CLI so the headless server
+  never touches the host keychain.
+- **Required `:available-tools` in `:empty` mode** —
+  `create-session` / `resume-session` (sync and async) now reject
+  empty-mode sessions that don't supply a tool allow-list. An empty
+  vector `[]` is legitimate (it means "no tools") — the key just has
+  to be present so silently-empty filters can't happen.
+- **9 mode-default session config fields** — In `:empty` mode the SDK
+  spreads safe defaults UNDER the caller's session config (caller
+  always wins): `:enable-session-telemetry? false`,
+  `:mcp-oauth-token-storage :in-memory`, `:skip-embedding-retrieval true`,
+  `:embedding-cache-storage :in-memory`,
+  `:enable-on-demand-instruction-discovery false`,
+  `:enable-file-hooks false`, `:enable-host-git-operations false`,
+  `:enable-session-store false`, `:enable-skills false`.
+- **`session.options.update` plumbing** — After a successful
+  `session.create` / `session.resume`, the SDK now issues a follow-up
+  `session.options.update` RPC carrying the four overridable feature
+  flags (and, in `:empty` mode, `installedPlugins: []`):
+  - `:skip-custom-instructions` (default `true` in `:empty`)
+  - `:custom-agents-local-only` (default `true` in `:empty`)
+  - `:coauthor-enabled` (default `false` in `:empty`)
+  - `:manage-schedule-enabled` (default `false` in `:empty`)
+  In `:copilot-cli` mode only flags the caller explicitly set are
+  forwarded; if the patch ends up empty the RPC is skipped. On failure
+  the SDK disconnects and removes the half-configured session before
+  rethrowing. Wired into all four entry points (`create-session`,
+  `resume-session`, `<create-session`, `<resume-session`).
+- **System message normalization in `:empty` mode** — Mirrors upstream
+  `getSystemMessageConfigForMode`: if the caller did not provide a
+  `:system-message`, the SDK emits `{:mode "customize" :sections
+  {:environment_context {:action "remove"}}}`. If the caller provided
+  `:append`, the SDK promotes it to `:customize` (preserving the
+  content) and adds the env-context removal. If the caller used
+  `:customize` and supplied their own `:environment-context` section,
+  the SDK leaves it untouched. `:replace` mode is passed through
+  unchanged. `:copilot-cli` mode keeps the legacy behavior — no
+  normalization.
+- **Always-emit `:tool-filter-precedence "excluded"`** — Both modes now
+  always send `toolFilterPrecedence: "excluded"` on `session.create`
+  and `session.resume`. Makes the ordering between
+  `:available-tools` and `:excluded-tools` deterministic regardless of
+  CLI version.
+- **`github.copilot-sdk.tool-set` namespace** — Source-qualified tool
+  filter constructors (`builtin`, `mcp`, `custom`, `builtins`) plus
+  `isolated-builtins` / `isolated` — the parity equivalents of
+  upstream `BuiltInTools.Isolated`. Bare `"*"` (no source) is rejected
+  at the SDK boundary and at construction time.
+
 ### Added (post-v1.0.0-beta.4 sync, round 6)
 - **`:agent-mode` and `:display-prompt` send options** — `session/send!`
   (and async/streaming variants) now accept:
@@ -92,10 +150,6 @@ All notable changes to this project will be documented in this file. This change
   the three new event types above.
 
 ### Deferred (round 6)
-- **Multitenancy Client Mode (upstream PR #1428)** — Substantial new
-  public API surface (`mode = "empty" | "copilot-cli"`, `ToolSet`,
-  `toolFilterPrecedence`, ambient flags via `session.options.update`).
-  Tracked for a dedicated future sync round with its own plan.
 - **Removal of the legacy `:config-dir` / `:output-dir` option keys
   (upstream PR #1482 follow-up)** — The new `:config-directory` /
   `:output-directory` aliases ship in this release (see Added). The

--- a/doc/index.md
+++ b/doc/index.md
@@ -5,7 +5,7 @@ Clojure SDK for programmatic control of the GitHub Copilot CLI via JSON-RPC.
 ## Getting Started
 
 - [Getting Started](getting-started.md) — Step-by-step tutorial building a weather assistant
-- [Examples](../examples/README.md) — 19 working examples with walkthroughs
+- [Examples](../examples/README.md) — 20 working examples with walkthroughs
 
 ## Guides
 

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -134,6 +134,7 @@ Get information about the current shared client state. Returns `nil` if no share
 | `:on-list-models` | fn | nil | Zero-arg function returning model info maps. Bypasses `models.list` RPC; does not require `start!`. Results are cached the same way as RPC results |
 | `:is-child-process?` | boolean | `false` | When `true`, connect via own stdio to a parent Copilot CLI process (no process spawning). Requires `:use-stdio?` `true`; mutually exclusive with `:cli-url` |
 | `:session-fs` | map | nil | Session filesystem provider config. Keys: `:initial-cwd` (string, required), `:session-state-path` (string, required), `:conventions` (`"windows"` or `"posix"`, required). When set, the client calls `sessionFs.setProvider` on connect and routes filesystem operations through per-session handlers. See [Session Filesystem](#session-filesystem) |
+| `:mode` | keyword | `:copilot-cli` | Client multitenancy mode: `:copilot-cli` (default — preserve historical CLI behavior) or `:empty` (multi-tenant SaaS hosts that must isolate sessions from local machine state). In `:empty` mode the SDK requires at least one tenant-scoped storage root (`:copilot-home`, `:session-fs`, `:cli-url`, or `:is-child-process?`), sets `COPILOT_DISABLE_KEYTAR=1` on the spawned CLI, spreads 9 safe defaults under caller session config, forces `installedPlugins []`, and normalizes `:system-message` to strip `environment_context`. See [Client Mode](#client-mode-empty). (upstream PR #1428) |
 
 ### Methods
 
@@ -279,6 +280,10 @@ Create a client and session together, ensuring both are cleaned up on exit.
 | `:plugin-directories` | vector | Extra plugin directories loaded even when `:enable-config-discovery` is `false`. Wire-encoded as `pluginDirectories`. (upstream PR #1482) |
 | `:reasoning-summary` | string | `"none"` / `"concise"` / `"detailed"`. Controls inclusion/granularity of reasoning summaries on assistant turns. Wire-encoded as `reasoningSummary`. String-valued for consistency with `:reasoning-effort`. |
 | `:context-tier` | keyword \| `nil` | `#{:default :long-context}` selects the long-context model variant; `nil` explicitly clears any prior tier (wire-encoded as JSON `null`). Omit the key entirely to leave the current setting untouched. Wire-encoded as `contextTier` with values `"default"` / `"long_context"`. |
+| `:skip-custom-instructions` | boolean | Skip loading user-level custom instruction files. Forwarded via `session.options.update` (NOT `session.create`). Defaulted to `true` in `:empty` mode. (upstream PR #1428) |
+| `:custom-agents-local-only` | boolean | Restrict custom-agent loading to caller-supplied configs only (no on-disk discovery). Forwarded via `session.options.update`. Defaulted to `true` in `:empty` mode. (upstream PR #1428) |
+| `:coauthor-enabled` | boolean | Add a Copilot Co-authored-by trailer to commits made by the CLI. Forwarded via `session.options.update`. Defaulted to `false` in `:empty` mode. (upstream PR #1428) |
+| `:manage-schedule-enabled` | boolean | Enable the built-in schedule-management tools. Forwarded via `session.options.update`. Defaulted to `false` in `:empty` mode. (upstream PR #1428) |
 
 #### `resume-session`
 
@@ -1544,6 +1549,101 @@ When `:streaming? true`:
 ;; Stop manually
 (copilot/stop! client)
 ```
+
+### Client Mode (Empty)
+
+`:mode :empty` configures the client for multi-tenant SaaS hosts that must
+isolate sessions from the local machine — no on-disk state from a
+specific user account leaks into a session. The default `:copilot-cli`
+mode preserves historical CLI behavior. (upstream PR #1428)
+
+```clojure
+(require '[github.copilot-sdk :as copilot]
+         '[github.copilot-sdk.tool-set :as tool-set])
+
+(def client
+  (copilot/client
+    {:mode :empty
+     ;; At least ONE of :copilot-home / :session-fs / :cli-url /
+     ;; :is-child-process? is required so the CLI has a tenant-scoped
+     ;; storage root. Using both is fine and common:
+     :copilot-home "/srv/tenants/acme/copilot-home"
+     :session-fs   {:initial-cwd "/srv/tenants/acme/cwd"
+                    :session-state-path "/srv/tenants/acme/state"
+                    :conventions "posix"}}))
+
+(def session
+  (copilot/create-session client
+    {:on-permission-request copilot/approve-all
+     ;; Required in :empty mode (use [] to allow nothing — the key must
+     ;; be present so silently-empty filters can't happen):
+     :available-tools tool-set/isolated
+     ;; Required when client has :session-fs:
+     :create-session-fs-handler (fn [_session] my-fs-handler)}))
+```
+
+What `:empty` mode enforces (vs `:copilot-cli`):
+
+- **Constructor validation**: at least one of `:copilot-home`,
+  `:session-fs`, `:cli-url`, or `:is-child-process?` must be supplied
+  (so the CLI never falls back to the user's home directory). The SDK
+  also forces `COPILOT_DISABLE_KEYTAR=1` on the spawned CLI.
+- **Session validation**: every `create-session` / `resume-session` call
+  must provide `:available-tools` (an empty vector is legitimate). When
+  the client has `:session-fs`, `:create-session-fs-handler` is also
+  required (this applies to both modes).
+- **Safe session defaults** (spread UNDER caller config — caller always wins):
+  `:enable-session-telemetry? false`, `:mcp-oauth-token-storage :in-memory`,
+  `:skip-embedding-retrieval true`, `:embedding-cache-storage :in-memory`,
+  `:enable-on-demand-instruction-discovery false`, `:enable-file-hooks false`,
+  `:enable-host-git-operations false`, `:enable-session-store false`,
+  `:enable-skills false`.
+- **System message normalization**: the SDK strips the `environment_context`
+  section from the system message (or promotes `:append` to `:customize`) so
+  no host-environment context leaks. If the caller already provides their own
+  `environment_context` override in `:customize` mode, it is preserved verbatim.
+- **Post-create options**: a follow-up `session.options.update` RPC sets
+  `:skip-custom-instructions true`, `:custom-agents-local-only true`,
+  `:coauthor-enabled false`, `:manage-schedule-enabled false`, and forces
+  `:installed-plugins []`. On failure, the SDK cleans up the half-configured
+  session before propagating the error.
+
+Both modes always emit `:tool-filter-precedence "excluded"` on
+`session.create` and `session.resume`, and reject bare `"*"` in
+`:available-tools` / `:excluded-tools` at the SDK boundary.
+
+### Tool Sets
+
+Use [`github.copilot-sdk.tool-set`](#tool-sets) to construct `:available-tools` /
+`:excluded-tools` lists with built-in helpers. Mirrors the upstream
+`BuiltInTools` constants. (upstream PR #1428)
+
+```clojure
+(require '[github.copilot-sdk.tool-set :as tool-set])
+
+;; Source-qualified single tool — patterns are "<source>:<name>",
+;; source is one of "builtin", "mcp", or "custom":
+(tool-set/builtin "ask_user")     ; => "builtin:ask_user"
+(tool-set/builtin "*")            ; => "builtin:*"   (all built-ins)
+(tool-set/mcp "*")                ; => "mcp:*"      (all MCP tools)
+(tool-set/custom "my_tool")       ; => "custom:my_tool"
+
+;; Vector of patterns:
+(tool-set/builtins ["task" "skill"])
+;; => ["builtin:task" "builtin:skill"]
+
+;; The "Isolated" preset matches BuiltInTools.Isolated upstream —
+;; every built-in that is safely session-bounded (no host I/O):
+tool-set/isolated
+;; => ["builtin:ask_user" "builtin:task_complete" "builtin:exit_plan_mode" ...]
+```
+
+The constructors enforce well-formed entries: a bare `"*"` is rejected (the SDK
+also rejects it in `:available-tools` / `:excluded-tools` at the session
+boundary — apps must explicitly opt into a source so an absent source can
+never silently grant access to unexpected tools). The runtime always receives
+`:tool-filter-precedence "excluded"` on `session.create` / `session.resume`
+so the ordering between allow and deny lists is deterministic.
 
 ### Tools
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -85,6 +85,9 @@ clojure -A:examples -X lifecycle-hooks/run
 
 # Reasoning effort
 clojure -A:examples -X reasoning-effort/run
+
+# Empty (multitenancy) mode
+clojure -A:examples -X empty-mode/run
 ```
 
 Or run all examples:
@@ -93,7 +96,7 @@ Or run all examples:
 ```
 
 > **Note:** `run-all-examples.sh` runs 16 examples that need only the Copilot CLI (examples 1–9, 12–16, 18, and 19).
-> Examples 10 (BYOK) and 11 (MCP) require external dependencies (API keys, Node.js), and example 17 (ask-user-failure) is excluded for reliability. Run these manually.
+> Examples 10 (BYOK), 11 (MCP), and 20 (empty-mode — uses BYOK) require external dependencies (API keys, Node.js), and example 17 (ask-user-failure) is excluded for reliability. Run these manually.
 
 With a custom CLI path:
 ```bash
@@ -876,6 +879,39 @@ Commands are registered by passing them in the session config:
                :command-handler handle-status}]
    :on-permission-request copilot/approve-all})
 ```
+
+---
+
+## Example 20: Empty (Multitenancy) Mode (`empty_mode.clj`)
+
+**Description**: Run a session under `:mode :empty` — the hardened
+posture for SaaS hosts that run sessions on behalf of multiple users.
+
+**Features**: `:mode :empty`, `:copilot-home`, `:session-fs` with an
+in-memory provider, `tool-set/isolated`, BYOK provider.
+
+Demonstrates the multitenancy hardening introduced in upstream PR #1428.
+The example creates fresh temp directories for `:copilot-home`, the
+session's `cwd`, and the session state path, supplies an in-memory
+`:session-fs` provider, and runs a single query through a BYOK provider
+(empty mode disables the local keychain, so the host must bring its own
+auth). In `:empty` mode the SDK forces `COPILOT_DISABLE_KEYTAR=1` on the
+spawned CLI, spreads safe session defaults (telemetry off, embeddings
+in-memory, host-git off, skills off, ...), strips `environment_context`
+from the system message, and sends a follow-up `session.options.update`
+RPC turning off coauthor / manage-schedule and forcing
+`installedPlugins []`.
+
+**Prerequisites**: Set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. Excluded
+from `run-all-examples.sh` because it requires an external API key.
+
+```bash
+OPENAI_API_KEY=sk-... clojure -A:examples -X empty-mode/run
+OPENAI_API_KEY=sk-... clojure -A:examples -X empty-mode/run :prompt '"What is Clojure?"'
+```
+
+See [`doc/reference/API.md`](../doc/reference/API.md#client-mode-empty)
+for the full Client Mode reference.
 
 ---
 

--- a/examples/empty_mode.clj
+++ b/examples/empty_mode.clj
@@ -1,0 +1,133 @@
+(ns empty-mode
+  "Demonstrates `:mode :empty` — the multitenancy posture for SaaS hosts
+   that run sessions on behalf of multiple users and must keep each
+   session isolated from the local machine.
+
+   Compared to the default `:copilot-cli` mode, `:empty` mode:
+
+   - Requires a tenant-scoped storage root (here we use a temp dir as
+     `:copilot-home` plus an in-memory `:session-fs`).
+   - Forces `COPILOT_DISABLE_KEYTAR=1` on the spawned CLI so the host
+     keychain is never touched.
+   - Spreads 9 safe defaults under each session's config (telemetry off,
+     host-git operations off, embeddings in-memory, skills off, ...).
+   - Strips the `environment_context` section from the system message.
+   - Sends a follow-up `session.options.update` RPC turning off
+     coauthor / manage-schedule and forcing `installedPlugins []`.
+   - Requires `:available-tools` on every session (use `[]` to opt into
+     no tools, or `tool-set/isolated` for the safely session-bounded
+     built-in preset).
+
+   The session itself needs auth — since the local keychain is disabled,
+   this example uses a BYOK provider (OpenAI or Anthropic). Set ONE of:
+
+     OPENAI_API_KEY    — for OpenAI
+     ANTHROPIC_API_KEY — for Anthropic
+
+   before running. The example is intentionally NOT in
+   `run-all-examples.sh` for this reason."
+  (:require [clojure.java.io :as io]
+            [github.copilot-sdk :as copilot]
+            [github.copilot-sdk.helpers :as h]
+            [github.copilot-sdk.tool-set :as tool-set]))
+
+(def defaults
+  {:prompt "What is 2+2? Answer in one sentence."})
+
+(defn- temp-dir
+  "Create a fresh temp directory under java.io.tmpdir."
+  [prefix]
+  (let [path (java.nio.file.Files/createTempDirectory
+              prefix
+              (into-array java.nio.file.attribute.FileAttribute []))]
+    (.toString path)))
+
+(defn- in-memory-fs-provider
+  "Build a minimal in-memory filesystem provider for a single session.
+   The runtime routes session-scoped file I/O (event logs, large outputs,
+   checkpoints) through these callbacks."
+  []
+  (let [store (atom {})]
+    {:read-file (fn [path]
+                  (or (get @store path)
+                      (throw (ex-info "missing file" {:code "ENOENT"}))))
+     :write-file (fn [path content _mode]
+                   (swap! store assoc path content))
+     :append-file (fn [path content _mode]
+                    (swap! store update path (fnil str "") content))
+     :exists (fn [path] (contains? @store path))
+     :stat (fn [path]
+             {:is-file true
+              :is-directory false
+              :size (count (get @store path ""))
+              :mtime "2026-01-01T00:00:00Z"
+              :birthtime "2026-01-01T00:00:00Z"})
+     :mkdir (fn [_path _recursive _mode] nil)
+     :readdir (fn [_path] [])
+     :readdir-with-types (fn [_path] [])
+     :rm (fn [path _recursive _force] (swap! store dissoc path))
+     :rename (fn [src dest]
+               (swap! store (fn [s] (-> s
+                                        (assoc dest (get s src ""))
+                                        (dissoc src)))))}))
+
+(defn- byok-config
+  "Pick a BYOK provider config based on which API key is set."
+  []
+  (let [openai (System/getenv "OPENAI_API_KEY")
+        anthropic (System/getenv "ANTHROPIC_API_KEY")]
+    (cond
+      openai    {:model "gpt-5.4"
+                 :provider {:provider-type :openai
+                            :base-url "https://api.openai.com/v1"
+                            :api-key openai}}
+      anthropic {:model "claude-sonnet-4"
+                 :provider {:provider-type :anthropic
+                            :base-url "https://api.anthropic.com"
+                            :api-key anthropic}}
+      :else
+      (throw (ex-info
+              (str "Empty mode disables the local keychain — set "
+                   "OPENAI_API_KEY or ANTHROPIC_API_KEY before running.")
+              {})))))
+
+(defn run
+  "Issue a single query against a session created in `:empty` mode.
+
+  Usage:
+    OPENAI_API_KEY=sk-xxx    clojure -A:examples -X empty-mode/run
+    ANTHROPIC_API_KEY=sk-xxx clojure -A:examples -X empty-mode/run :prompt '\"What is Clojure?\"'"
+  [{:keys [prompt] :or {prompt (:prompt defaults)}}]
+  (let [{:keys [model provider]} (byok-config)
+        copilot-home (temp-dir "copilot-home-")
+        cwd (temp-dir "tenant-cwd-")
+        state (temp-dir "tenant-state-")]
+    (println "Tenant storage:")
+    (println "  copilot-home:" copilot-home)
+    (println "  cwd:        " cwd)
+    (println "  state:      " state)
+    (println "Provider:    " (:provider-type provider))
+    (println "Model:       " model)
+    (println)
+    (try
+      (copilot/with-client
+        [client {:mode :empty
+                 :copilot-home copilot-home
+                 :session-fs {:initial-cwd cwd
+                              :session-state-path state
+                              :conventions "posix"}}]
+        (copilot/with-session
+          [session client
+           {:on-permission-request copilot/approve-all
+            :model model
+            :provider provider
+            ;; Required in :empty mode. Use tool-set/isolated for the
+            ;; safely session-bounded built-in preset, or [] for none.
+            :available-tools tool-set/isolated
+            :create-session-fs-handler
+            (fn [_session] (in-memory-fs-provider))}]
+          (println "Q:" prompt)
+          (println "🤖:" (h/query prompt :session session))))
+      (finally
+        (doseq [d [state cwd copilot-home]]
+          (try (.delete (io/file d)) (catch Exception _)))))))

--- a/script/validate_docs.clj
+++ b/script/validate_docs.clj
@@ -42,6 +42,7 @@
     "github.copilot-sdk.specs"
     "github.copilot-sdk.instrument"
     "github.copilot-sdk.tools"
+    "github.copilot-sdk.tool-set"
     "github.copilot-sdk.generated.event-specs"
     "github.copilot-sdk.generated.coerce"})
 

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -144,7 +144,17 @@
     - :remote?       - **Experimental**. Enable remote session support (Mission Control). When true,
                        the SDK appends `--remote` to the spawned CLI; sessions in a GitHub repository
                        working directory become accessible from GitHub web and mobile. Ignored when
-                       `:cli-url` is set. (upstream PR #1192)"
+                       `:cli-url` is set. (upstream PR #1192)
+   - :mode          - Client mode (upstream PR #1428). One of:
+                       - `:copilot-cli` (default) — preserves historical CLI behavior.
+                       - `:empty` — multitenancy hardening for hosts running sessions on behalf of
+                         multiple users. Empty mode REQUIRES one of `:copilot-home`, `:session-fs`,
+                         `:cli-url`, or `:is-child-process?` so the runtime has a tenant-scoped
+                         storage root. It also forces `COPILOT_DISABLE_KEYTAR=1` on the spawned
+                         CLI, spreads safe defaults under each session's config (telemetry off,
+                         host-git operations disabled, ...), strips the `:environment-context`
+                         section from system messages unless the caller already controls it,
+                         and requires every session to specify `:available-tools`."
   ([]
    (client {}))
   ([opts]
@@ -171,6 +181,19 @@
    (when (and (some? (:tcp-connection-token opts)) (= true (:use-stdio? opts)))
      (throw (ex-info "tcp-connection-token cannot be used with use-stdio? true (stdio is pre-authenticated by transport)"
                      {:tcp-connection-token "***" :use-stdio? true})))
+   ;; Empty mode requires a tenant-scoped storage root (upstream PR #1428).
+   (when (and (= :empty (:mode opts))
+              (not (or (:copilot-home opts)
+                       (:session-fs opts)
+                       (:cli-url opts)
+                       (:is-child-process? opts))))
+     (throw (ex-info
+             (str "Mode :empty requires one of :copilot-home, :session-fs, "
+                  ":cli-url, or :is-child-process? so the spawned CLI has a "
+                  "tenant-scoped storage root.")
+             {:mode :empty
+              :provided-storage-keys (select-keys opts [:copilot-home :session-fs
+                                                        :cli-url :is-child-process?])})))
    (when-not (s/valid? ::specs/client-options opts)
      (let [unknown (specs/unknown-keys opts specs/client-options-keys)
            explain (s/explain-data ::specs/client-options opts)
@@ -1369,6 +1392,44 @@
     (throw (ex-info "Invalid session config: :model is required when :provider (BYOK) is specified"
                     {:config config}))))
 
+(defn- validate-tool-filter-list!
+  "Reject bare `\"*\"` in a tool filter list (mirrors upstream
+   `validateToolFilterList`). The runtime treats a bare wildcard as a
+   literal name match for a tool whose name is the single character `*`,
+   which never matches anything — so a silent empty filter is worse than
+   an explicit error pointing the developer at the source-qualified
+   `tool-set/builtin`/`mcp`/`custom` helpers."
+  [field tools]
+  (when tools
+    (doseq [entry tools]
+      (when (= "*" entry)
+        (throw (ex-info
+                (format "Invalid %s entry '*': there is no bare wildcard. Use a source-qualified pattern like \"builtin:*\", \"mcp:*\", or \"custom:*\" (see github.copilot-sdk.tool-set)."
+                        field)
+                {:field field :entry entry :tools tools}))))))
+
+(defn- validate-tool-filters!
+  "Run [[validate-tool-filter-list!]] on both `:available-tools` and
+   `:excluded-tools`."
+  [config]
+  (validate-tool-filter-list! "availableTools" (:available-tools config))
+  (validate-tool-filter-list! "excludedTools" (:excluded-tools config)))
+
+(defn- validate-empty-mode-session-requirements!
+  "Empty mode requires every session to opt into its tools explicitly. The
+   caller may pass `:available-tools []` to mean \"no tools\", but the key
+   must be PRESENT — undefined is rejected so silently-empty filters can't
+   happen (upstream PR #1428, mirrors `resolveToolFilterOptions`)."
+  [client config]
+  (when (and (= :empty (:mode (options client)))
+             (not (contains? config :available-tools)))
+    (throw (ex-info
+            (str "Mode :empty requires every session to specify :available-tools. "
+                 "Pass an explicit list of source-qualified patterns (e.g. "
+                 "tool-set/isolated, or [\"builtin:*\"]) — or [] to opt into no tools.")
+            {:mode :empty
+             :session-config-keys (vec (keys config))}))))
+
 ;; Section keyword → wire string mapping for system message customize mode.
 ;; Delegates to shared mapping in util.clj.
 
@@ -1420,6 +1481,43 @@
     ;; default: append mode
     {:mode "append" :content (:content sm)}))
 
+(defn- apply-empty-mode-system-message
+  "In :empty mode, normalize the session config's :system-message so the
+   `environment_context` section is always stripped (CWD/OS/git-root leak)
+   unless the app has already taken control of it. No-op in :copilot-cli
+   mode. Mirrors upstream `getSystemMessageConfigForMode` (PR #1428).
+
+   - No caller :system-message → emit `:customize` with
+     `:environment-context {:action :remove}`.
+   - Caller `:replace` → pass through (app fully replaces system message).
+   - Caller `:customize` → add `:environment-context {:action :remove}` to
+     :sections unless the app already specified an env-context override.
+   - Caller `:append` (or `:mode` absent) → promote to `:customize`,
+     preserve `:content` (still appended as additional instructions),
+     and strip `environment_context`."
+  [client config]
+  (if (not= :empty (:mode (options client)))
+    config
+    (let [sm (:system-message config)
+          ec-remove {:environment-context {:action :remove}}]
+      (cond
+        (nil? sm)
+        (assoc config :system-message {:mode :customize :sections ec-remove})
+
+        (= :replace (:mode sm))
+        config
+
+        (= :customize (:mode sm))
+        (if (contains? (:sections sm) :environment-context)
+          config
+          (update-in config [:system-message :sections]
+                     (fnil assoc {}) :environment-context {:action :remove}))
+
+        :else
+        (assoc config :system-message
+               (cond-> {:mode :customize :sections ec-remove}
+                 (:content sm) (assoc :content (:content sm))))))))
+
 (defn- provider->wire
   "Convert a Clojure ProviderConfig map to its JSON-RPC wire shape.
 
@@ -1456,6 +1554,123 @@
   (let [dir (or (:output-directory lo) (:output-dir lo))]
     (cond-> (dissoc lo :output-directory)
       dir (assoc :output-dir dir))))
+
+(defn- config-defaults-for-mode
+  "Mode-specific session config defaults spread UNDER the caller's config
+   (caller's values always win). Mirrors upstream `configDefaultsForMode`
+   in `client.ts` (upstream PR #1428).
+
+   In `:empty` mode this returns the 9 safe defaults that enable
+   multitenancy hardening (no telemetry, in-memory token + embedding
+   storage, no host filesystem / git / skills). In `:copilot-cli`
+   mode this returns `{}` so the historical behavior is preserved."
+  [mode]
+  (if (= mode :empty)
+    {:enable-session-telemetry? false
+     :mcp-oauth-token-storage :in-memory
+     :skip-embedding-retrieval true
+     :embedding-cache-storage :in-memory
+     :enable-on-demand-instruction-discovery false
+     :enable-file-hooks false
+     :enable-host-git-operations false
+     :enable-session-store false
+     :enable-skills false}
+    {}))
+
+(defn- normalize-config-for-mode
+  "Apply mode-specific normalizations to session config (upstream PR #1428):
+   1. Spread `config-defaults-for-mode` UNDER caller config (caller wins).
+   2. In `:empty` mode, normalize `:system-message` so the
+      `environment_context` section is stripped unless the app has taken
+      control of it (see `apply-empty-mode-system-message`).
+   No-op in `:copilot-cli` mode beyond returning the caller config as-is."
+  [client config]
+  (->> config
+       (merge (config-defaults-for-mode (-> client options :mode)))
+       (apply-empty-mode-system-message client)))
+
+(defn- build-session-options-update-patch
+  "Compute the params for session.options.update (upstream PR #1428).
+
+   In `:empty` mode, defaults the 4 overridable feature flags to safe values
+   (caller wins) and forces `installedPlugins: []` — apps that need custom
+   plugins must switch modes. In `:copilot-cli` mode, only forwards the 4
+   flags that the caller explicitly set.
+
+   Returns nil if the resulting patch is empty (no RPC needed)."
+  [client config]
+  (let [mode (-> client options :mode)
+        with-flag (fn [patch wire-key kw default-empty]
+                    (cond
+                      (contains? config kw) (assoc patch wire-key (get config kw))
+                      (= mode :empty) (assoc patch wire-key default-empty)
+                      :else patch))
+        patch (-> {}
+                  (with-flag :skip-custom-instructions :skip-custom-instructions true)
+                  (with-flag :custom-agents-local-only :custom-agents-local-only true)
+                  (with-flag :coauthor-enabled :coauthor-enabled false)
+                  (with-flag :manage-schedule-enabled :manage-schedule-enabled false))
+        patch (cond-> patch
+                (= mode :empty) (assoc :installed-plugins []))]
+    (when (seq patch) patch)))
+
+(defn- cleanup-failed-options-update!
+  "Best-effort cleanup after a failed session.options.update. Disconnects
+   the runtime session (`session.destroy` RPC) and removes it from the
+   in-memory registry so the SDK doesn't leak a half-configured session."
+  [client session-id]
+  (try (session/disconnect! client session-id)
+       (catch Throwable t (log/debug "disconnect! during options.update cleanup failed: " (.getMessage t))))
+  (try (session/remove-session! client session-id)
+       (catch Throwable t (log/debug "remove-session! during options.update cleanup failed: " (.getMessage t)))))
+
+(defn- apply-session-options-update!
+  "Sync: issue session.options.update with the mode-derived patch. No-op
+   when the patch is empty. On RPC failure, cleans up the half-configured
+   session and rethrows."
+  [client session config]
+  (when-let [patch (build-session-options-update-patch client config)]
+    (let [session-id (:session-id session)
+          {:keys [connection-io]} @(:state client)
+          params (assoc patch :session-id session-id)]
+      (try
+        (proto/send-request! connection-io "session.options.update" params 30000)
+        (catch Throwable t
+          (log/warn "session.options.update failed; cleaning up session " session-id)
+          (cleanup-failed-options-update! client session-id)
+          (throw t))))))
+
+(defn- <apply-session-options-update!
+  "Async variant of `apply-session-options-update!`. Returns a channel that
+   yields `:ok` on success (including the no-op case) or a Throwable on
+   failure (after cleanup). The channel always closes after one value."
+  [client session config]
+  (let [out (async/chan 1)]
+    (if-let [patch (build-session-options-update-patch client config)]
+      (let [session-id (:session-id session)
+            {:keys [connection-io]} @(:state client)
+            params (assoc patch :session-id session-id)
+            rpc-ch (proto/send-request connection-io "session.options.update" params)]
+        (go
+          (let [response (<! rpc-ch)
+                err (cond
+                      (nil? response)
+                      (ex-info "session.options.update failed: RPC channel closed"
+                               {:session-id session-id})
+                      (:error response)
+                      (ex-info (str "session.options.update failed: "
+                                    (get-in response [:error :message] "RPC error"))
+                               {:session-id session-id :error (:error response)}))]
+            (if err
+              (do
+                (log/warn "session.options.update failed; cleaning up session " session-id)
+                (cleanup-failed-options-update! client session-id)
+                (>! out err))
+              (>! out :ok))
+            (close! out))))
+      (do (async/put! out :ok)
+          (close! out)))
+    out))
 
 (defn- build-create-session-params
   "Build wire params for session.create from config."
@@ -1502,6 +1717,12 @@
       wire-sys-msg (assoc :system-message wire-sys-msg)
       (:available-tools config) (assoc :available-tools (:available-tools config))
       (:excluded-tools config) (assoc :excluded-tools (:excluded-tools config))
+      ;; SDK always sends `toolFilterPrecedence: "excluded"` so callers can
+      ;; compose include + exclude lists naturally (upstream PR #1428).
+      ;; Behavioral change for CLI mode: prior to PR #1428 the CLI default
+      ;; precedence was forwarded as-is. Allowlist-precedence is not exposed
+      ;; on the SDK boundary by design (mirrors upstream `resolveToolFilterOptions`).
+      true (assoc :tool-filter-precedence "excluded")
       wire-provider (assoc :provider wire-provider)
       true (assoc :request-permission true)
       (:streaming? config) (assoc :streaming (:streaming? config))
@@ -1612,6 +1833,9 @@
       wire-sys-msg (assoc :system-message wire-sys-msg)
       (:available-tools config) (assoc :available-tools (:available-tools config))
       (:excluded-tools config) (assoc :excluded-tools (:excluded-tools config))
+      ;; SDK always sends `toolFilterPrecedence: "excluded"` (upstream PR #1428).
+      ;; See `build-create-session-params` for rationale.
+      true (assoc :tool-filter-precedence "excluded")
       wire-provider (assoc :provider wire-provider)
       true (assoc :request-permission
                   (not (identical? (:on-permission-request config)
@@ -1853,9 +2077,12 @@
   [client config]
   (log/debug "Creating session with config: " (select-keys config [:model :session-id]))
   (validate-session-config! config)
+  (validate-tool-filters! config)
+  (validate-empty-mode-session-requirements! client config)
   (ensure-connected! client)
   (ensure-session-fs-handler-factory! client config)
-  (let [{:keys [connection-io]} @(:state client)
+  (let [config (normalize-config-for-mode client config)
+        {:keys [connection-io]} @(:state client)
         trace-ctx (get-trace-context (:on-get-trace-context client))
         {:keys [transform-callbacks]} (extract-transform-callbacks (:system-message config))
         cloud? (some? (:cloud config))
@@ -1887,6 +2114,8 @@
                 session-id (:session-id session)]
             (session/set-workspace-path! client session-id (:workspace-path result))
             (session/set-capabilities! client session-id (:capabilities result))
+            ;; Mode-specific post-create options patch (upstream PR #1428).
+            (apply-session-options-update! client session config)
             (log/info "Session created (cloud, server-assigned id): " session-id)
             session)))
       ;; Standard path: client supplies (or generates) the sessionId up front.
@@ -1907,6 +2136,11 @@
                               {:requested session-id :returned returned-id})))
             (session/set-workspace-path! client session-id (:workspace-path result))
             (session/set-capabilities! client session-id (:capabilities result))
+            ;; Mode-specific post-create options patch (upstream PR #1428).
+            ;; Helper handles its own cleanup on failure (disconnect! +
+            ;; remove-session!) before rethrowing; the outer catch's
+            ;; remove-session! is then a safe no-op.
+            (apply-session-options-update! client session config)
             (log/info "Session created: " session-id)
             session)
           (catch Throwable t
@@ -1968,9 +2202,12 @@
   (when (and (:provider config) (not (:model config)))
     (throw (ex-info "Invalid session config: :model is required when :provider (BYOK) is specified"
                     {:config config})))
+  (validate-tool-filters! config)
+  (validate-empty-mode-session-requirements! client config)
   (ensure-connected! client)
   (ensure-session-fs-handler-factory! client config)
-  (let [{:keys [connection-io]} @(:state client)
+  (let [config (normalize-config-for-mode client config)
+        {:keys [connection-io]} @(:state client)
         trace-ctx (get-trace-context (:on-get-trace-context client))
         {:keys [transform-callbacks]} (extract-transform-callbacks (:system-message config))
         params (merge trace-ctx (build-resume-session-params session-id config))
@@ -1983,6 +2220,8 @@
       (let [result (proto/send-request! connection-io "session.resume" params)]
         (session/set-workspace-path! client session-id (:workspace-path result))
         (session/set-capabilities! client session-id (:capabilities result))
+        ;; Mode-specific post-resume options patch (upstream PR #1428).
+        (apply-session-options-update! client session config)
         session)
       (catch Throwable t
         (session/remove-session! client session-id)
@@ -2016,9 +2255,12 @@
   [client config]
   (log/debug "Creating session (async) with config: " (select-keys config [:model :session-id]))
   (validate-session-config! config)
+  (validate-tool-filters! config)
+  (validate-empty-mode-session-requirements! client config)
   (ensure-connected! client)
   (ensure-session-fs-handler-factory! client config)
-  (let [{:keys [connection-io]} @(:state client)
+  (let [config (normalize-config-for-mode client config)
+        {:keys [connection-io]} @(:state client)
         trace-ctx (get-trace-context (:on-get-trace-context client))
         {:keys [transform-callbacks]} (extract-transform-callbacks (:system-message config))
         cloud? (some? (:cloud config))
@@ -2068,8 +2310,11 @@
                         session-id (:session-id session)]
                     (session/set-workspace-path! client session-id (:workspace-path result))
                     (session/set-capabilities! client session-id (:capabilities result))
-                    (log/info "Session created (async, cloud, server-assigned id): " session-id)
-                    session)))))))
+                    (let [r (<! (<apply-session-options-update! client session config))]
+                      (if (instance? Throwable r)
+                        r
+                        (do (log/info "Session created (async, cloud, server-assigned id): " session-id)
+                            session))))))))))
       ;; Standard path: client supplies (or generates) the sessionId up front.
       (let [session-id (or caller-session-id (str (java.util.UUID/randomUUID)))
             params (merge trace-ctx (assoc (build-create-session-params config) :session-id session-id))
@@ -2102,8 +2347,11 @@
                     (do
                       (session/set-workspace-path! client session-id (:workspace-path result))
                       (session/set-capabilities! client session-id (:capabilities result))
-                      (log/info "Session created (async): " session-id)
-                      session)))))))))))
+                      (let [r (<! (<apply-session-options-update! client session config))]
+                        (if (instance? Throwable r)
+                          r
+                          (do (log/info "Session created (async): " session-id)
+                              session))))))))))))))
 (defn <resume-session
   "Async version of resume-session. Returns a channel that delivers a CopilotSession.
 
@@ -2132,9 +2380,12 @@
   (when (and (:provider config) (not (:model config)))
     (throw (ex-info "Invalid session config: :model is required when :provider (BYOK) is specified"
                     {:config config})))
+  (validate-tool-filters! config)
+  (validate-empty-mode-session-requirements! client config)
   (ensure-connected! client)
   (ensure-session-fs-handler-factory! client config)
-  (let [{:keys [connection-io]} @(:state client)
+  (let [config (normalize-config-for-mode client config)
+        {:keys [connection-io]} @(:state client)
         trace-ctx (get-trace-context (:on-get-trace-context client))
         {:keys [transform-callbacks]} (extract-transform-callbacks (:system-message config))
         params (merge trace-ctx (build-resume-session-params session-id config))
@@ -2162,7 +2413,10 @@
             (let [result (:result response)]
               (session/set-workspace-path! client session-id (:workspace-path result))
               (session/set-capabilities! client session-id (:capabilities result))
-              session)))))))
+              (let [r (<! (<apply-session-options-update! client session config))]
+                (if (instance? Throwable r)
+                  r
+                  session)))))))))
 (defn join-session
   "Join the current foreground session from an extension running as a child process.
 

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -1664,7 +1664,10 @@
             (if err
               (do
                 (log/warn "session.options.update failed; cleaning up session " session-id)
-                (cleanup-failed-options-update! client session-id)
+                ;; cleanup-failed-options-update! calls blocking session.destroy
+                ;; via proto/send-request! — offload to async/thread so it does
+                ;; not starve the core.async dispatch threadpool.
+                (<! (async/thread (cleanup-failed-options-update! client session-id)))
                 (>! out err))
               (>! out :ok))
             (close! out))))

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -14,7 +14,11 @@
      (stest/unstrument)"
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :as stest]
-            [github.copilot-sdk.specs :as specs]))
+            [github.copilot-sdk.specs :as specs]
+            ;; Ensure namespaces hosting public fns referenced by `register-fdef!`
+            ;; are loaded before `stest/instrument` runs (otherwise the missing
+            ;; var would be silently skipped, leaving an instrumentation gap).
+            [github.copilot-sdk.tool-set]))
 
 ;; -----------------------------------------------------------------------------
 ;; Single-source registry for fdefs
@@ -565,6 +569,30 @@
 (register-fdef! github.copilot-sdk.client/mcp-config-remove!
   :args (s/cat :client ::specs/client :params map?)
   :ret map?)
+
+;; -----------------------------------------------------------------------------
+;; Tool filter helpers (upstream PR #1428)
+;; -----------------------------------------------------------------------------
+
+(register-fdef! github.copilot-sdk.tool-set/valid-name?
+  :args (s/cat :name any?)
+  :ret boolean?)
+
+(register-fdef! github.copilot-sdk.tool-set/builtin
+  :args (s/cat :name string?)
+  :ret string?)
+
+(register-fdef! github.copilot-sdk.tool-set/mcp
+  :args (s/cat :name string?)
+  :ret string?)
+
+(register-fdef! github.copilot-sdk.tool-set/custom
+  :args (s/cat :name string?)
+  :ret string?)
+
+(register-fdef! github.copilot-sdk.tool-set/builtins
+  :args (s/cat :names (s/coll-of string?))
+  :ret (s/coll-of string? :kind vector?))
 
 ;; -----------------------------------------------------------------------------
 ;; Instrument all public API functions

--- a/src/github/copilot_sdk/process.clj
+++ b/src/github/copilot_sdk/process.clj
@@ -42,7 +42,7 @@
 
    This is a pure helper extracted so we can unit-test the env contract
    without spawning a real process."
-  [{:keys [github-token telemetry copilot-home tcp-connection-token] :as _opts}]
+  [{:keys [github-token telemetry copilot-home tcp-connection-token mode] :as _opts}]
   {:defaults {"NODE_DEBUG" nil}
    :overrides
    (cond-> {}
@@ -55,6 +55,11 @@
      ;; tcpConnectionToken (upstream PR #1176) — required when server enforces a token
      tcp-connection-token
      (assoc "COPILOT_CONNECTION_TOKEN" tcp-connection-token)
+     ;; Client mode :empty disables the system keychain (upstream PR #1428).
+     ;; Applied in :overrides so the caller's `:env` cannot accidentally
+     ;; re-enable it under multitenancy hardening.
+     (= mode :empty)
+     (assoc "COPILOT_DISABLE_KEYTAR" "1")
      ;; OpenTelemetry (upstream PR #785)
      telemetry
      (as-> m
@@ -88,6 +93,9 @@
    - :tcp-connection-token - Connection token sent via COPILOT_CONNECTION_TOKEN (upstream PR #1176)
    - :remote? - When true, append `--remote` so the CLI exposes its session
                 over a GitHub-hosted remote endpoint (upstream PR #1192)
+   - :mode - Client mode `:empty` or `:copilot-cli` (default). When `:empty`,
+             `COPILOT_DISABLE_KEYTAR=1` is forced into the spawned env so the
+             child CLI cannot reach the host keychain (upstream PR #1428).
 
    Returns a ManagedProcess record."
   [{:keys [cli-path cwd env use-stdio?]

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -186,23 +186,40 @@
 ;; Factory fn: (session) → session-fs-handler
 (s/def ::create-session-fs-handler fn?)
 
+;; Client mode (upstream PR #1428). `:copilot-cli` (the default) preserves
+;; the historical behavior; `:empty` enables multitenancy hardening:
+;; tenant-scoped storage is required, the system keychain is disabled, and
+;; a set of safe session defaults is spread under the caller's config.
+;;
+;; Note: the unqualified key in client-options is `:mode`, but the existing
+;; ::mode spec at line ~899 is already taken by message-options for
+;; #{:enqueue :immediate}. We use a uniquely-named ::client-mode spec and
+;; validate the unqualified `:mode` key via a predicate in ::client-options
+;; (mirrors the ::remote-session-mode pattern further down).
+(s/def ::client-mode #{:empty :copilot-cli})
+
 (def client-options-keys
   #{:cli-path :cli-args :cli-url :cwd :port
     :use-stdio? :log-level :auto-start? :auto-restart?
     :notification-queue-size :router-queue-size
     :tool-timeout-ms :env :github-token :use-logged-in-user?
     :is-child-process? :on-list-models :telemetry :on-get-trace-context
-    :session-fs :copilot-home :tcp-connection-token :remote?})
+    :session-fs :copilot-home :tcp-connection-token :remote?
+    :mode})
 
 (s/def ::client-options
-  (closed-keys
-   (s/keys :opt-un [::cli-path ::cli-args ::cli-url ::cwd ::port
-                    ::use-stdio? ::log-level ::auto-start? ::auto-restart?
-                    ::notification-queue-size ::router-queue-size
-                    ::tool-timeout-ms ::env ::github-token ::use-logged-in-user?
-                    ::is-child-process? ::on-list-models ::telemetry ::on-get-trace-context
-                    ::session-fs ::copilot-home ::tcp-connection-token ::remote?])
-   client-options-keys))
+  (s/and
+   (closed-keys
+    (s/keys :opt-un [::cli-path ::cli-args ::cli-url ::cwd ::port
+                     ::use-stdio? ::log-level ::auto-start? ::auto-restart?
+                     ::notification-queue-size ::router-queue-size
+                     ::tool-timeout-ms ::env ::github-token ::use-logged-in-user?
+                     ::is-child-process? ::on-list-models ::telemetry ::on-get-trace-context
+                     ::session-fs ::copilot-home ::tcp-connection-token ::remote?])
+    client-options-keys)
+   (fn [m]
+     (or (not (contains? m :mode))
+         (s/valid? ::client-mode (:mode m))))))
 
 ;; -----------------------------------------------------------------------------
 ;; Tool definitions
@@ -601,7 +618,7 @@
 
 ;; Multitenancy hardening flags (upstream PR #1474). All optional, plain
 ;; booleans/strings. Application-mode behavior is driven by Client Mode
-;; (upstream PR #1428), which has been deferred to a dedicated future round.
+;; (upstream PR #1428).
 (s/def ::skip-embedding-retrieval boolean?)
 (s/def ::organization-custom-instructions string?)
 (s/def ::enable-on-demand-instruction-discovery boolean?)
@@ -609,6 +626,15 @@
 (s/def ::enable-host-git-operations boolean?)
 (s/def ::enable-session-store boolean?)
 (s/def ::enable-skills boolean?)
+
+;; Client-mode session option flags (upstream PR #1428). Sent via
+;; session.options.update after session.create / session.resume. In empty
+;; mode these get safe defaults applied beneath the caller's config; in
+;; CLI mode they are only emitted when explicitly set.
+(s/def ::skip-custom-instructions boolean?)
+(s/def ::custom-agents-local-only boolean?)
+(s/def ::coauthor-enabled boolean?)
+(s/def ::manage-schedule-enabled boolean?)
 
 ;; Reasoning summary mode (upstream PR #813 - pre-existing parity gap).
 ;; Wire enum: "none" | "concise" | "detailed". Mirrors upstream's ReasoningSummary type.
@@ -648,6 +674,10 @@
     :enable-host-git-operations
     :enable-session-store
     :enable-skills
+    :skip-custom-instructions
+    :custom-agents-local-only
+    :coauthor-enabled
+    :manage-schedule-enabled
     :include-sub-agent-streaming-events?})
 
 (s/def ::session-config
@@ -682,6 +712,10 @@
                     ::enable-host-git-operations
                     ::enable-session-store
                     ::enable-skills
+                    ::skip-custom-instructions
+                    ::custom-agents-local-only
+                    ::coauthor-enabled
+                    ::manage-schedule-enabled
                     ::include-sub-agent-streaming-events?])
    session-config-keys))
 
@@ -710,6 +744,10 @@
     :enable-host-git-operations
     :enable-session-store
     :enable-skills
+    :skip-custom-instructions
+    :custom-agents-local-only
+    :coauthor-enabled
+    :manage-schedule-enabled
     :include-sub-agent-streaming-events?})
 
 (s/def ::resume-session-config
@@ -741,6 +779,10 @@
                     ::enable-host-git-operations
                     ::enable-session-store
                     ::enable-skills
+                    ::skip-custom-instructions
+                    ::custom-agents-local-only
+                    ::coauthor-enabled
+                    ::manage-schedule-enabled
                     ::include-sub-agent-streaming-events?])
    resume-session-config-keys))
 
@@ -774,6 +816,10 @@
                     ::enable-host-git-operations
                     ::enable-session-store
                     ::enable-skills
+                    ::skip-custom-instructions
+                    ::custom-agents-local-only
+                    ::coauthor-enabled
+                    ::manage-schedule-enabled
                     ::include-sub-agent-streaming-events?])
    resume-session-config-keys))
 

--- a/src/github/copilot_sdk/tool_set.clj
+++ b/src/github/copilot_sdk/tool_set.clj
@@ -1,0 +1,91 @@
+(ns github.copilot-sdk.tool-set
+  "Helpers for building source-qualified tool filter patterns used by
+   `:available-tools` and `:excluded-tools` in session configs.
+
+   The runtime matches each tool reference against patterns of the form
+   `\"<source>:<name>\"` where source is one of `builtin`, `mcp`, or
+   `custom` and name is either a literal tool name or the wildcard
+   `\"*\"`. The bare wildcard `\"*\"` (no source) is intentionally
+   rejected by the SDK — apps must explicitly opt into a source so an
+   absent source can never silently grant access to unexpected tools.
+
+   Mirrors upstream `ToolSet` and `BuiltInTools` from
+   `nodejs/src/toolSet.ts` (upstream PR #1428).
+
+   Examples:
+
+     (tool-set/builtin \"ask_user\")  ;; => \"builtin:ask_user\"
+     (tool-set/builtin \"*\")          ;; => \"builtin:*\"
+     (tool-set/mcp \"*\")              ;; => \"mcp:*\"
+     (tool-set/builtins [\"task\" \"skill\"]) ;; => [\"builtin:task\" \"builtin:skill\"]
+
+     ;; Ready-to-use: every built-in that is safely session-bounded.
+     tool-set/isolated  ;; => [\"builtin:ask_user\" \"builtin:task_complete\" ...]")
+
+(def ^:private valid-name-regex
+  "Allowed characters in a tool name segment (mirrors upstream `nameRe`)."
+  #"^[a-zA-Z0-9_-]+$")
+
+(defn valid-name?
+  "True when `name` is a valid tool-name segment — alphanumeric plus
+   `_` and `-`, or the literal wildcard `\"*\"`. Returns false for any
+   non-string input."
+  [name]
+  (and (string? name)
+       (or (= "*" name)
+           (some? (re-matches valid-name-regex name)))))
+
+(defn- validate! [source name]
+  (when-not (valid-name? name)
+    (throw (ex-info (format "Invalid %s tool name: %s" source (pr-str name))
+                    {:source source :name name}))))
+
+(defn builtin
+  "Returns the filter pattern `\"builtin:<name>\"`. `name` may be the
+   wildcard `\"*\"`. Throws on invalid names."
+  [name]
+  (validate! "builtin" name)
+  (str "builtin:" name))
+
+(defn mcp
+  "Returns the filter pattern `\"mcp:<name>\"`. `name` may be the
+   wildcard `\"*\"`. Throws on invalid names."
+  [name]
+  (validate! "mcp" name)
+  (str "mcp:" name))
+
+(defn custom
+  "Returns the filter pattern `\"custom:<name>\"`. `name` may be the
+   wildcard `\"*\"`. Throws on invalid names."
+  [name]
+  (validate! "custom" name)
+  (str "custom:" name))
+
+(defn builtins
+  "Returns a vector of `\"builtin:<name>\"` patterns, one per entry in
+   `names`. Throws on the first invalid name."
+  [names]
+  (mapv builtin names))
+
+(def isolated-builtins
+  "Names of the built-in tools that are safely session-bounded (no host
+   I/O). Mirrors upstream `BuiltInTools.Isolated`. Use [[isolated]] for
+   the source-qualified form ready to drop into `:available-tools`."
+  ["ask_user"
+   "task_complete"
+   "exit_plan_mode"
+   "task"
+   "read_agent"
+   "write_agent"
+   "list_agents"
+   "send_inbox"
+   "context_board"
+   "skill"])
+
+(def isolated
+  "Source-qualified `\"builtin:<name>\"` patterns for every tool in
+   [[isolated-builtins]]. Drop directly into `:available-tools`:
+
+     (copilot/create-session client
+       {:available-tools tool-set/isolated})"
+  (builtins isolated-builtins))

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -5399,3 +5399,502 @@
       (is (= custom-id (sdk/session-id session)))
       (sdk/destroy! session))))
 
+;; -----------------------------------------------------------------------------
+;; Client Mode (upstream PR #1428) — constructor + validation tests.
+;; The session-time options.update orchestration and wire-shape parity tests
+;; live further down once that plumbing lands; these are the pure-validation
+;; checks (client construction + bare-`*` rejection + required :available-tools).
+;; -----------------------------------------------------------------------------
+
+(deftest test-empty-mode-requires-tenant-scoped-storage
+  (testing "construction without storage hook throws"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Mode :empty requires"
+         (sdk/client {:mode :empty :auto-start? false}))))
+  (testing ":copilot-home satisfies the requirement"
+    (let [c (sdk/client {:mode :empty
+                         :copilot-home "/tmp/empty-mode-test"
+                         :auto-start? false})]
+      (is (= :empty (get-in c [:options :mode])))
+      (is (= "/tmp/empty-mode-test" (get-in c [:options :copilot-home])))))
+  (testing ":session-fs satisfies the requirement"
+    (let [c (sdk/client {:mode :empty
+                         :session-fs {:initial-cwd "/workspace"
+                                      :session-state-path "/state"
+                                      :conventions "posix"}
+                         :auto-start? false})]
+      (is (= :empty (get-in c [:options :mode])))))
+  (testing ":cli-url satisfies the requirement"
+    (let [c (sdk/client {:mode :empty
+                         :cli-url "localhost:1234"
+                         :auto-start? false})]
+      (is (= :empty (get-in c [:options :mode])))))
+  (testing ":is-child-process? satisfies the requirement"
+    (let [c (sdk/client {:mode :empty
+                         :is-child-process? true
+                         :auto-start? false})]
+      (is (= :empty (get-in c [:options :mode]))))))
+
+(deftest test-empty-mode-default-and-cli-mode
+  (testing "default mode is :copilot-cli (no extra options needed)"
+    (let [c (sdk/client {:auto-start? false})]
+      ;; :mode is not auto-injected; absence is treated as :copilot-cli by
+      ;; downstream code. The point is that no extra options are required.
+      (is (nil? (get-in c [:options :mode]))
+          ":mode should be unset by default — downstream code treats nil as :copilot-cli")))
+  (testing "explicit :copilot-cli mode imposes no extra requirements"
+    (let [c (sdk/client {:mode :copilot-cli :auto-start? false})]
+      (is (= :copilot-cli (get-in c [:options :mode]))))))
+
+(deftest test-empty-mode-spec-validation
+  (testing "an unknown :mode value is rejected by the spec"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid client options"
+         (sdk/client {:mode :bogus :copilot-home "/tmp/x" :auto-start? false})))))
+
+(deftest test-bare-star-rejected-in-available-tools
+  (testing ":available-tools containing bare * is rejected at create-session"
+    (let [c (sdk/client {:auto-start? false})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid availableTools entry '\*'"
+           (sdk/create-session c {:available-tools ["*"]}))))))
+
+(deftest test-bare-star-rejected-in-excluded-tools
+  (testing ":excluded-tools containing bare * is rejected at create-session"
+    (let [c (sdk/client {:auto-start? false})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid excludedTools entry '\*'"
+           (sdk/create-session c {:excluded-tools ["*"]}))))))
+
+(deftest test-bare-star-rejected-in-resume-session
+  (testing ":available-tools containing bare * is rejected at resume-session"
+    (let [c (sdk/client {:auto-start? false})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid availableTools entry '\*'"
+           (sdk/resume-session c "session-id" {:available-tools ["*"]}))))))
+
+(deftest test-source-qualified-tools-accepted
+  (testing "source-qualified patterns pass the bare-* validation"
+    ;; We can't fully exercise create-session without a started client, but
+    ;; the validation step throws BEFORE ensure-connected!, so a non-throw
+    ;; below means we made it past validate-tool-filters! (further work
+    ;; will hit the connection check).
+    (let [c (sdk/client {:auto-start? false})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Client is not started|not connected|Connection"
+           (sdk/create-session c {:available-tools ["builtin:*" "mcp:my_server"]}))))))
+
+(deftest test-empty-mode-requires-available-tools-on-create
+  (testing "empty mode rejects create-session without :available-tools"
+    (let [c (sdk/client {:mode :empty
+                         :copilot-home "/tmp/empty-mode-test"
+                         :auto-start? false})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Mode :empty requires every session to specify :available-tools"
+           (sdk/create-session c {}))))))
+
+(deftest test-empty-mode-allows-empty-available-tools
+  (testing "empty mode accepts :available-tools [] as explicit opt-in to no tools"
+    ;; The validation passes; downstream will fail because client is not
+    ;; started. Distinguish those errors by message.
+    (let [c (sdk/client {:mode :empty
+                         :copilot-home "/tmp/empty-mode-test"
+                         :auto-start? false})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Client is not started|not connected|Connection"
+           (sdk/create-session c {:available-tools []}))))))
+
+(deftest test-empty-mode-requires-available-tools-on-resume
+  (testing "empty mode rejects resume-session without :available-tools"
+    (let [c (sdk/client {:mode :empty
+                         :copilot-home "/tmp/empty-mode-test"
+                         :auto-start? false})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Mode :empty requires every session to specify :available-tools"
+           (sdk/resume-session c "session-id" {}))))))
+
+(deftest test-cli-mode-does-not-require-available-tools
+  (testing "cli mode allows create-session without :available-tools"
+    (let [c (sdk/client {:auto-start? false})]
+      ;; Validation passes; downstream throws because not started.
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Client is not started|not connected|Connection"
+           (sdk/create-session c {}))))))
+
+
+;; -----------------------------------------------------------------------------
+;; Client Mode (upstream PR #1428) — wire payload tests:
+;;   - `tool-filter-precedence` is always emitted as "excluded" (both modes).
+;;   - In `:empty` mode the 9 mode defaults are spread under caller config.
+;; -----------------------------------------------------------------------------
+
+(deftest test-tool-filter-precedence-always-excluded-on-create
+  (testing "session.create always sends toolFilterPrecedence=\"excluded\" (PR #1428)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server*
+                                    (fn [method params]
+                                      (when (= "session.create" method)
+                                        (swap! seen assoc method params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all
+                                 :model "gpt-5.4"})
+          create-params (get @seen "session.create")]
+      (is (= "excluded" (:toolFilterPrecedence create-params))
+          "tool-filter-precedence must always be \"excluded\" in CLI mode"))))
+
+(deftest test-tool-filter-precedence-always-excluded-on-resume
+  (testing "session.resume always sends toolFilterPrecedence=\"excluded\" (PR #1428)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server*
+                                    (fn [method params]
+                                      (when (= "session.resume" method)
+                                        (swap! seen assoc method params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all})
+          session-id (sdk/get-last-session-id *test-client*)
+          _ (sdk/resume-session *test-client* session-id
+                                {:on-permission-request sdk/approve-all})
+          resume-params (get @seen "session.resume")]
+      (is (= "excluded" (:toolFilterPrecedence resume-params))
+          "tool-filter-precedence must always be \"excluded\" on resume"))))
+
+(deftest test-empty-mode-spreads-config-defaults-under-caller
+  (testing "empty mode spreads the 9 safe defaults under caller config (PR #1428)"
+    (let [server (mock/create-mock-server)
+          _ (mock/start-mock-server! server)
+          seen (atom {})
+          _ (mock/set-request-hook! server
+                                    (fn [method params]
+                                      (when (= "session.create" method)
+                                        (swap! seen assoc method params))))
+          client (sdk/client {:mode :empty
+                              :copilot-home "/tmp/empty-mode-wire-test"
+                              :auto-start? false})
+          [in out] (mock/client-streams server)]
+      (try
+        (client/connect-with-streams! client in out)
+        (sdk/create-session client
+                            {:on-permission-request sdk/approve-all
+                             :available-tools ["builtin:think"]})
+        (let [p (get @seen "session.create")]
+          (is (= false (:enableSessionTelemetry p)))
+          (is (= "in-memory" (:mcpOAuthTokenStorage p)))
+          (is (= true (:skipEmbeddingRetrieval p)))
+          (is (= "in-memory" (:embeddingCacheStorage p)))
+          (is (= false (:enableOnDemandInstructionDiscovery p)))
+          (is (= false (:enableFileHooks p)))
+          (is (= false (:enableHostGitOperations p)))
+          (is (= false (:enableSessionStore p)))
+          (is (= false (:enableSkills p)))
+          (is (= "excluded" (:toolFilterPrecedence p))))
+        (finally
+          (try (sdk/stop! client) (catch Exception _))
+          (Thread/sleep 50)
+          (mock/stop-mock-server! server))))))
+
+(deftest test-empty-mode-caller-config-wins-over-mode-defaults
+  (testing "caller-provided config values always win over mode defaults (PR #1428)"
+    (let [server (mock/create-mock-server)
+          _ (mock/start-mock-server! server)
+          seen (atom {})
+          _ (mock/set-request-hook! server
+                                    (fn [method params]
+                                      (when (= "session.create" method)
+                                        (swap! seen assoc method params))))
+          client (sdk/client {:mode :empty
+                              :copilot-home "/tmp/empty-mode-override-test"
+                              :auto-start? false})
+          [in out] (mock/client-streams server)]
+      (try
+        (client/connect-with-streams! client in out)
+        ;; Caller overrides 2 of the 9 defaults — those values must win.
+        (sdk/create-session client
+                            {:on-permission-request sdk/approve-all
+                             :available-tools ["builtin:think"]
+                             :enable-session-telemetry? true
+                             :enable-skills true})
+        (let [p (get @seen "session.create")]
+          (is (= true (:enableSessionTelemetry p))
+              "caller-provided :enable-session-telemetry? must override the mode default")
+          (is (= true (:enableSkills p))
+              "caller-provided :enable-skills must override the mode default")
+          ;; Other defaults still apply
+          (is (= true (:skipEmbeddingRetrieval p))))
+        (finally
+          (try (sdk/stop! client) (catch Exception _))
+          (Thread/sleep 50)
+          (mock/stop-mock-server! server))))))
+
+(deftest test-cli-mode-does-not-spread-mode-defaults
+  (testing "CLI mode does NOT spread the empty-mode defaults (PR #1428)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server*
+                                    (fn [method params]
+                                      (when (= "session.create" method)
+                                        (swap! seen assoc method params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all})
+          p (get @seen "session.create")]
+      ;; None of the 9 mode-default flags should appear unless caller set them.
+      (is (not (contains? p :enableSessionTelemetry)))
+      (is (not (contains? p :skipEmbeddingRetrieval)))
+      (is (not (contains? p :enableFileHooks)))
+      (is (not (contains? p :enableSkills))))))
+
+;; -----------------------------------------------------------------------------
+;; Client Mode (upstream PR #1428) — system message normalization tests.
+;; In :empty mode, the SDK enforces that environment_context is stripped from
+;; the system message (unless app has taken control of it). Mirrors upstream
+;; `getSystemMessageConfigForMode`.
+;; -----------------------------------------------------------------------------
+
+(defn- empty-mode-create-with-system-message
+  "Spin up a fresh empty-mode client against a fresh mock server, invoke
+   create-session with the supplied :system-message, and return the
+   captured wire payload's :systemMessage field."
+  [system-message]
+  (let [server (mock/create-mock-server)
+        _ (mock/start-mock-server! server)
+        seen (atom {})
+        _ (mock/set-request-hook! server
+                                  (fn [method params]
+                                    (when (= "session.create" method)
+                                      (swap! seen assoc method params))))
+        client (sdk/client {:mode :empty
+                            :copilot-home "/tmp/empty-mode-sm-test"
+                            :auto-start? false})
+        [in out] (mock/client-streams server)]
+    (try
+      (client/connect-with-streams! client in out)
+      (sdk/create-session client
+                          (cond-> {:on-permission-request sdk/approve-all
+                                   :available-tools []}
+                            system-message (assoc :system-message system-message)))
+      (-> (get @seen "session.create") :systemMessage)
+      (finally
+        (try (sdk/stop! client) (catch Exception _))
+        (Thread/sleep 50)
+        (mock/stop-mock-server! server)))))
+
+(deftest test-empty-mode-system-message-default
+  (testing "no caller :system-message → emit customize with env-context removed"
+    (let [sm (empty-mode-create-with-system-message nil)]
+      (is (= "customize" (:mode sm)))
+      (is (= {:action "remove"} (get-in sm [:sections :environment_context]))))))
+
+(deftest test-empty-mode-system-message-replace-passes-through
+  (testing ":replace mode is preserved unchanged in empty mode"
+    (let [sm (empty-mode-create-with-system-message
+              {:mode :replace :content "Replacement text."})]
+      (is (= "replace" (:mode sm)))
+      (is (= "Replacement text." (:content sm)))
+      (is (not (contains? sm :sections))))))
+
+(deftest test-empty-mode-system-message-append-promoted-to-customize
+  (testing ":append mode is promoted to :customize, content preserved, env-context removed"
+    (let [sm (empty-mode-create-with-system-message
+              {:mode :append :content "Extra instructions."})]
+      (is (= "customize" (:mode sm)))
+      (is (= "Extra instructions." (:content sm))
+          "caller :content must be preserved verbatim")
+      (is (= {:action "remove"} (get-in sm [:sections :environment_context]))))))
+
+(deftest test-empty-mode-system-message-customize-adds-env-context-remove
+  (testing ":customize without env-context override → SDK adds env-context remove"
+    (let [sm (empty-mode-create-with-system-message
+              {:mode :customize
+               :sections {:tone {:action :replace :content "Be terse."}}})]
+      (is (= "customize" (:mode sm)))
+      (is (= {:action "remove"} (get-in sm [:sections :environment_context]))
+          "env-context section must be removed")
+      (is (some? (get-in sm [:sections :tone]))
+          "caller's :tone section must be preserved"))))
+
+(deftest test-empty-mode-system-message-customize-respects-app-env-context
+  (testing ":customize with explicit env-context override → SDK does NOT touch it"
+    (let [sm (empty-mode-create-with-system-message
+              {:mode :customize
+               :sections {:environment-context {:action :replace :content "Custom env."}}})]
+      (is (= "customize" (:mode sm)))
+      (is (= {:action "replace" :content "Custom env."}
+             (get-in sm [:sections :environment_context]))
+          "app's env-context override must win unchanged"))))
+
+(deftest test-cli-mode-system-message-untouched
+  (testing "CLI mode does NOT normalize :system-message (preserve historical behavior)"
+    (let [seen (atom {})
+          _ (mock/set-request-hook! *mock-server*
+                                    (fn [method params]
+                                      (when (= "session.create" method)
+                                        (swap! seen assoc method params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all
+                                 :system-message {:mode :append
+                                                  :content "Just append this."}})
+          sm (-> (get @seen "session.create") :systemMessage)]
+      (is (= "append" (:mode sm)) "CLI mode keeps :append, no promotion")
+      (is (= "Just append this." (:content sm))))))
+
+;; -----------------------------------------------------------------------------
+;; Client Mode (upstream PR #1428) — session.options.update RPC tests.
+;; After session.create succeeds, the SDK issues a follow-up RPC to set the 4
+;; overridable feature flags and (in :empty mode) the installedPlugins list.
+;; Mirrors upstream `updateSessionOptionsForMode`.
+;; -----------------------------------------------------------------------------
+
+(defn- empty-mode-capture-options-update
+  "Spin up a fresh empty-mode client, create a session with the given extra
+   config map, and return the captured session.options.update wire params
+   (or nil if the RPC was not issued)."
+  [extra-config]
+  (let [server (mock/create-mock-server)
+        _ (mock/start-mock-server! server)
+        seen (atom nil)
+        _ (mock/set-request-hook! server
+                                  (fn [method params]
+                                    (when (= "session.options.update" method)
+                                      (reset! seen params))))
+        client (sdk/client {:mode :empty
+                            :copilot-home "/tmp/empty-mode-opts-test"
+                            :auto-start? false})
+        [in out] (mock/client-streams server)]
+    (try
+      (client/connect-with-streams! client in out)
+      (sdk/create-session client
+                          (merge {:on-permission-request sdk/approve-all
+                                  :available-tools []}
+                                 extra-config))
+      @seen
+      (finally
+        (try (sdk/stop! client) (catch Exception _))
+        (Thread/sleep 50)
+        (mock/stop-mock-server! server)))))
+
+(deftest test-empty-mode-options-update-defaults
+  (testing "empty mode sends session.options.update with safe flag defaults + empty plugins"
+    (let [p (empty-mode-capture-options-update {})]
+      (is (some? p) "session.options.update must be issued in :empty mode")
+      (is (= true (:skipCustomInstructions p)))
+      (is (= true (:customAgentsLocalOnly p)))
+      (is (= false (:coauthorEnabled p)))
+      (is (= false (:manageScheduleEnabled p)))
+      (is (= [] (:installedPlugins p)))
+      (is (string? (:sessionId p)) "session-id must accompany the patch"))))
+
+(deftest test-empty-mode-options-update-caller-overrides
+  (testing "caller-supplied flags override empty-mode defaults in options.update patch"
+    (let [p (empty-mode-capture-options-update
+             {:skip-custom-instructions false
+              :coauthor-enabled true})]
+      (is (= false (:skipCustomInstructions p)) "caller false must win over default true")
+      (is (= true (:coauthorEnabled p)) "caller true must win over default false")
+      (is (= true (:customAgentsLocalOnly p)) "untouched flags keep their defaults")
+      (is (= false (:manageScheduleEnabled p)))
+      (is (= [] (:installedPlugins p)) "installedPlugins always forced to [] in :empty mode"))))
+
+(deftest test-cli-mode-options-update-skipped-when-no-caller-flags
+  (testing "CLI mode does NOT issue session.options.update when caller sets no flags"
+    (let [seen (atom nil)
+          _ (mock/set-request-hook! *mock-server*
+                                    (fn [method params]
+                                      (when (= "session.options.update" method)
+                                        (reset! seen params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all})]
+      (Thread/sleep 100)
+      (is (nil? @seen)
+          "no RPC should be sent when the patch would be empty"))))
+
+(deftest test-cli-mode-options-update-forwards-only-explicit-flags
+  (testing "CLI mode forwards ONLY caller-supplied flags via options.update (no defaults, no installedPlugins)"
+    (let [seen (atom nil)
+          _ (mock/set-request-hook! *mock-server*
+                                    (fn [method params]
+                                      (when (= "session.options.update" method)
+                                        (reset! seen params))))
+          _ (sdk/create-session *test-client*
+                                {:on-permission-request sdk/approve-all
+                                 :manage-schedule-enabled true})
+          p @seen]
+      (is (some? p) "RPC should be issued because caller set a flag")
+      (is (= true (:manageScheduleEnabled p)))
+      (is (not (contains? p :skipCustomInstructions)) "untouched flags must NOT appear")
+      (is (not (contains? p :customAgentsLocalOnly)))
+      (is (not (contains? p :coauthorEnabled)))
+      (is (not (contains? p :installedPlugins))
+          "installedPlugins must NOT be forced in :copilot-cli mode"))))
+
+(deftest test-empty-mode-options-update-async-path
+  (testing "async <create-session also issues session.options.update with mode defaults"
+    (let [server (mock/create-mock-server)
+          _ (mock/start-mock-server! server)
+          seen (atom nil)
+          _ (mock/set-request-hook! server
+                                    (fn [method params]
+                                      (when (= "session.options.update" method)
+                                        (reset! seen params))))
+          client (sdk/client {:mode :empty
+                              :copilot-home "/tmp/empty-mode-async-test"
+                              :auto-start? false})
+          [in out] (mock/client-streams server)]
+      (try
+        (client/connect-with-streams! client in out)
+        (let [result-ch (sdk/<create-session client
+                                             {:on-permission-request sdk/approve-all
+                                              :available-tools []})
+              result (first (alts!! [result-ch (timeout 5000)]))]
+          (is (some? result) "async create-session must return a session")
+          (is (not (instance? Throwable result))
+              (str "async create-session failed: " result)))
+        (let [p @seen]
+          (is (some? p) "options.update must be issued in async path")
+          (is (= true (:skipCustomInstructions p)))
+          (is (= [] (:installedPlugins p))))
+        (finally
+          (try (sdk/stop! client) (catch Exception _))
+          (Thread/sleep 50)
+          (mock/stop-mock-server! server))))))
+
+(deftest test-empty-mode-options-update-failure-cleans-up-session
+  (testing "options.update RPC failure cleans up session (disconnect + remove) and rethrows"
+    (let [server (mock/create-mock-server)
+          _ (mock/start-mock-server! server)
+          _ (mock/set-request-hook! server
+                                    (fn [method _params]
+                                      (when (= "session.options.update" method)
+                                        (throw (ex-info "Simulated options.update failure"
+                                                        {:code -32603})))))
+          client (sdk/client {:mode :empty
+                              :copilot-home "/tmp/empty-mode-fail-test"
+                              :auto-start? false})
+          [in out] (mock/client-streams server)]
+      (try
+        (client/connect-with-streams! client in out)
+        (let [ex (try
+                   (sdk/create-session client
+                                       {:on-permission-request sdk/approve-all
+                                        :available-tools []})
+                   nil
+                   (catch Throwable t t))]
+          (is (some? ex) "create-session must rethrow on options.update failure")
+          (is (re-find #"options\.update" (.getMessage ex))
+              "exception message should mention options.update"))
+        ;; After failure, the SDK should have removed the half-configured session
+        ;; from its in-memory registry.
+        (is (empty? (:sessions @(:state client)))
+            "failed session must be removed from in-memory registry")
+        (finally
+          (try (sdk/stop! client) (catch Exception _))
+          (Thread/sleep 50)
+          (mock/stop-mock-server! server))))))
+

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -5720,6 +5720,13 @@
       (is (some? (get-in sm [:sections :tone]))
           "caller's :tone section must be preserved"))))
 
+(deftest test-empty-mode-system-message-customize-no-sections-key
+  (testing ":customize with NO :sections key at all → SDK adds :sections with env-context remove"
+    (let [sm (empty-mode-create-with-system-message {:mode :customize})]
+      (is (= "customize" (:mode sm)))
+      (is (= {:action "remove"} (get-in sm [:sections :environment_context]))
+          "env-context section must be added even when caller omits :sections entirely"))))
+
 (deftest test-empty-mode-system-message-customize-respects-app-env-context
   (testing ":customize with explicit env-context override → SDK does NOT touch it"
     (let [sm (empty-mode-create-with-system-message
@@ -5893,6 +5900,36 @@
         ;; from its in-memory registry.
         (is (empty? (:sessions @(:state client)))
             "failed session must be removed from in-memory registry")
+        (finally
+          (try (sdk/stop! client) (catch Exception _))
+          (Thread/sleep 50)
+          (mock/stop-mock-server! server))))))
+
+(deftest test-empty-mode-options-update-async-failure-cleans-up-session
+  (testing "async <create-session: options.update failure cleans up session and yields Throwable"
+    (let [server (mock/create-mock-server)
+          _ (mock/start-mock-server! server)
+          _ (mock/set-request-hook! server
+                                    (fn [method _params]
+                                      (when (= "session.options.update" method)
+                                        (throw (ex-info "Simulated options.update failure"
+                                                        {:code -32603})))))
+          client (sdk/client {:mode :empty
+                              :copilot-home "/tmp/empty-mode-async-fail-test"
+                              :auto-start? false})
+          [in out] (mock/client-streams server)]
+      (try
+        (client/connect-with-streams! client in out)
+        (let [result-ch (sdk/<create-session client
+                                             {:on-permission-request sdk/approve-all
+                                              :available-tools []})
+              result (first (alts!! [result-ch (timeout 5000)]))]
+          (is (instance? Throwable result)
+              "async create-session must yield a Throwable on options.update failure")
+          (is (re-find #"options\.update" (.getMessage result))
+              "exception message should mention options.update"))
+        (is (empty? (:sessions @(:state client)))
+            "failed session must be removed from in-memory registry (async path)")
         (finally
           (try (sdk/stop! client) (catch Exception _))
           (Thread/sleep 50)

--- a/test/github/copilot_sdk/mock_server.clj
+++ b/test/github/copilot_sdk/mock_server.clj
@@ -372,6 +372,7 @@
                  "session.extensions.disable" {:success true}
                  "session.extensions.reload" {:success true}
                  "session.plugins.list" {:plugins []}
+                 "session.options.update" {:ok true}
                  "session.compaction.compact" {:success true}
                  "session.history.compact" {:success true}
                  "session.history.truncate" {:success true}

--- a/test/github/copilot_sdk/process_test.clj
+++ b/test/github/copilot_sdk/process_test.clj
@@ -98,3 +98,31 @@
           "--remote must NOT be present by default")
       (is (not (some #{"--remote"} (build-cli-args {:use-stdio? true :remote? false})))
           "--remote must NOT be present when :remote? is explicitly false"))))
+
+;; -----------------------------------------------------------------------------
+;; Client mode (upstream PR #1428)
+;; -----------------------------------------------------------------------------
+
+(deftest cli-env-overrides-empty-mode-disables-keytar
+  (testing ":mode :empty sets COPILOT_DISABLE_KEYTAR=1 as a strict override"
+    (let [{:keys [overrides]} (proc/cli-env-overrides {:mode :empty})]
+      (is (= "1" (get overrides "COPILOT_DISABLE_KEYTAR"))
+          "COPILOT_DISABLE_KEYTAR must be 1 in :empty mode")))
+  (testing ":mode :copilot-cli does NOT set COPILOT_DISABLE_KEYTAR"
+    (let [{:keys [overrides]} (proc/cli-env-overrides {:mode :copilot-cli})]
+      (is (not (contains? overrides "COPILOT_DISABLE_KEYTAR"))
+          "KEYTAR override must be absent in :copilot-cli mode")))
+  (testing "absent :mode does NOT set COPILOT_DISABLE_KEYTAR"
+    (let [{:keys [overrides]} (proc/cli-env-overrides {})]
+      (is (not (contains? overrides "COPILOT_DISABLE_KEYTAR"))
+          "KEYTAR override must be absent when :mode is unset"))))
+
+(deftest cli-env-overrides-empty-mode-user-env-cannot-override-keytar
+  (testing "KEYTAR override is in :overrides slot, so user :env cannot win"
+    ;; Lock in the precedence contract documented on cli-env-overrides:
+    ;; values returned in :overrides are applied AFTER user :env in spawn-cli,
+    ;; so an attempt to set COPILOT_DISABLE_KEYTAR=0 via :env would be clobbered.
+    (let [{:keys [defaults overrides]} (proc/cli-env-overrides {:mode :empty})]
+      (is (= "1" (get overrides "COPILOT_DISABLE_KEYTAR")))
+      (is (not (contains? defaults "COPILOT_DISABLE_KEYTAR"))
+          "KEYTAR must NOT be a default — defaults can be overridden by :env"))))

--- a/test/github/copilot_sdk/tool_set_test.clj
+++ b/test/github/copilot_sdk/tool_set_test.clj
@@ -1,0 +1,89 @@
+(ns github.copilot-sdk.tool-set-test
+  "Unit tests for github.copilot-sdk.tool-set — the source-qualified tool
+   filter helpers introduced by upstream PR #1428."
+  (:require [clojure.test :refer [deftest is testing]]
+            [github.copilot-sdk.tool-set :as tool-set]))
+
+(deftest valid-name?-tests
+  (testing "alphanumeric, underscore, hyphen are valid"
+    (is (true? (tool-set/valid-name? "ask_user")))
+    (is (true? (tool-set/valid-name? "task-complete")))
+    (is (true? (tool-set/valid-name? "Tool123")))
+    (is (true? (tool-set/valid-name? "a"))))
+  (testing "literal wildcard is valid"
+    (is (true? (tool-set/valid-name? "*"))))
+  (testing "wildcards in the middle of a name are invalid"
+    (is (false? (tool-set/valid-name? "ask*"))))
+  (testing "spaces, colons, dots, slashes are invalid"
+    (is (false? (tool-set/valid-name? "ask user")))
+    (is (false? (tool-set/valid-name? "builtin:ask_user")))
+    (is (false? (tool-set/valid-name? "ask.user")))
+    (is (false? (tool-set/valid-name? "ask/user"))))
+  (testing "empty string and non-strings are invalid"
+    (is (false? (tool-set/valid-name? "")))
+    (is (false? (tool-set/valid-name? nil)))
+    (is (false? (tool-set/valid-name? :ask_user)))
+    (is (false? (tool-set/valid-name? 42)))))
+
+(deftest builtin-tests
+  (testing "produces source-qualified pattern"
+    (is (= "builtin:ask_user" (tool-set/builtin "ask_user")))
+    (is (= "builtin:*" (tool-set/builtin "*"))))
+  (testing "rejects invalid name"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Invalid builtin tool name"
+                          (tool-set/builtin "bad name")))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Invalid builtin tool name"
+                          (tool-set/builtin "")))))
+
+(deftest mcp-tests
+  (testing "produces source-qualified pattern"
+    (is (= "mcp:my_server" (tool-set/mcp "my_server")))
+    (is (= "mcp:*" (tool-set/mcp "*"))))
+  (testing "rejects invalid name"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Invalid mcp tool name"
+                          (tool-set/mcp "bad:name")))))
+
+(deftest custom-tests
+  (testing "produces source-qualified pattern"
+    (is (= "custom:reviewer" (tool-set/custom "reviewer")))
+    (is (= "custom:*" (tool-set/custom "*"))))
+  (testing "rejects invalid name"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Invalid custom tool name"
+                          (tool-set/custom "has space")))))
+
+(deftest builtins-tests
+  (testing "maps over names and returns a vector"
+    (is (= ["builtin:task" "builtin:skill"]
+           (tool-set/builtins ["task" "skill"])))
+    (is (vector? (tool-set/builtins ["task"]))))
+  (testing "empty input yields empty vector"
+    (is (= [] (tool-set/builtins []))))
+  (testing "throws on the first invalid entry"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Invalid builtin tool name"
+                          (tool-set/builtins ["ok" "bad name"])))))
+
+(deftest isolated-builtins-tests
+  (testing "matches upstream BuiltInTools.Isolated exactly"
+    (is (= ["ask_user"
+            "task_complete"
+            "exit_plan_mode"
+            "task"
+            "read_agent"
+            "write_agent"
+            "list_agents"
+            "send_inbox"
+            "context_board"
+            "skill"]
+           tool-set/isolated-builtins))))
+
+(deftest isolated-tests
+  (testing "is the source-qualified form of isolated-builtins"
+    (is (= (mapv #(str "builtin:" %) tool-set/isolated-builtins)
+           tool-set/isolated)))
+  (testing "every entry starts with builtin: prefix"
+    (is (every? #(.startsWith ^String % "builtin:") tool-set/isolated))))


### PR DESCRIPTION
## Summary

Ports upstream [github/copilot-sdk PR #1428](https://github.com/github/copilot-sdk/pull/1428) — "Multitenancy hardening: Client Mode (Empty)" — that was deferred from round 6 ([copilot-community-sdk/copilot-sdk-clojure#113](https://github.com/copilot-community-sdk/copilot-sdk-clojure/pull/113)). This is the dedicated follow-up sync round for that one PR.

Adds the `:mode #{:copilot-cli :empty}` client option (default `:copilot-cli` — historical behavior preserved). `:empty` mode is the hardened multitenancy posture for SaaS hosts that run sessions on behalf of multiple users and must isolate sessions from local machine state.

This is a **non-breaking** addition. `:copilot-cli` mode is the default, and the only behavioral change for that mode is that `:tool-filter-precedence "excluded"` is now always emitted on `session.create` / `session.resume` so the ordering between `:available-tools` and `:excluded-tools` is deterministic across CLI versions. Bare `"*"` in tool filters is rejected at the SDK boundary in both modes (mirrors upstream `resolveToolFilterOptions`).

Session plan: `~/.copilot/session-state/b794e17b-2c5a-42ed-90fe-63b823312966/plan.md` (local; key decisions captured in this PR description and the per-step checkpoints).

## What `:empty` mode does

| Scope | Behavior |
|---|---|
| Constructor | Requires ONE of `:copilot-home`, `:session-fs`, `:cli-url`, or `:is-child-process?` so the CLI never falls back to the user's home directory |
| Constructor | Forces `COPILOT_DISABLE_KEYTAR=1` on the spawned CLI (via the `cli-env-overrides :overrides` slot — caller cannot override) |
| Session validation | Every `create-session` / `resume-session` (sync + async) must supply `:available-tools` (`[]` is legitimate — the key just has to be present so silently-empty filters cannot happen) |
| Session config | Spreads 9 safe defaults UNDER caller config (caller always wins): `:enable-session-telemetry? false`, `:mcp-oauth-token-storage :in-memory`, `:skip-embedding-retrieval true`, `:embedding-cache-storage :in-memory`, `:enable-on-demand-instruction-discovery false`, `:enable-file-hooks false`, `:enable-host-git-operations false`, `:enable-session-store false`, `:enable-skills false` |
| System message | Strips `environment_context` unless the app has taken control of it: no `:system-message` → `{:mode customize :sections {:environment_context {:action remove}}}`; `:append` is promoted to `:customize` preserving content + env-context removed; `:customize` without env-context override gets one added; `:customize` with explicit env-context override is left untouched; `:replace` passes through unchanged |
| Post-create RPC | After `session.create` / `session.resume` succeeds, issues a follow-up `session.options.update` with four overridable feature flags (`:skip-custom-instructions true`, `:custom-agents-local-only true`, `:coauthor-enabled false`, `:manage-schedule-enabled false`) plus `:installed-plugins []`. On RPC failure the SDK disconnects + removes the half-configured session before rethrowing |

In `:copilot-cli` mode the `session.options.update` RPC is only sent when the caller explicitly set one of the four new flags; if the resulting patch is empty the RPC is skipped entirely.

## New public API surface

- **Client option**: `:mode #{:copilot-cli :empty}` (default `:copilot-cli`).
- **Session-config keys** (forwarded via `session.options.update`, NOT `session.create`):
  - `:skip-custom-instructions` (boolean)
  - `:custom-agents-local-only` (boolean)
  - `:coauthor-enabled` (boolean)
  - `:manage-schedule-enabled` (boolean)
- **New namespace `github.copilot-sdk.tool-set`**: source-qualified tool filter constructors (`builtin`/`mcp`/`custom`/`builtins`) plus the `isolated-builtins` / `isolated` preset (parity with upstream `BuiltInTools.Isolated`). Bare `"*"` rejected at construction time.

See [`doc/reference/API.md` → Client Mode (Empty)](https://github.com/copilot-community-sdk/copilot-sdk-clojure/blob/upstream-sync/pr-1428-client-mode-empty/doc/reference/API.md#client-mode-empty) and [Tool Sets](https://github.com/copilot-community-sdk/copilot-sdk-clojure/blob/upstream-sync/pr-1428-client-mode-empty/doc/reference/API.md#tool-sets) for full reference docs.

## Design notes

### Why one mode flag and not nine

Upstream PR #1428 introduces a single `mode` enum so multi-tenant hosts can opt into the entire hardened posture (env-var override, config defaults, system-message normalization, options.update flags, validation) with one knob. The Clojure port preserves this — the per-feature flags exist (`:enable-skills`, `:skip-embedding-retrieval`, etc., from round 6) but `:mode :empty` is the one-line opt-in.

### `session.options.update` is a SEPARATE RPC, not a `session.create` field

The four feature flags do NOT ride on `session.create` — they ship in a follow-up `session.options.update` RPC that the SDK issues after the session is registered. This mirrors upstream and means:

- If `session.create` succeeds but `session.options.update` fails, the SDK MUST clean up (else we leak a half-configured session). `cleanup-failed-options-update!` calls both `session/disconnect!` (CLI-side cleanup via `session.destroy`) AND `session/remove-session!` (in-memory registry cleanup); both are idempotent.
- The async path (`<apply-session-options-update!`) returns a channel that yields `:ok` on success (including the no-op case) or a `Throwable` on failure (after cleanup), matching the existing async error convention.
- If the computed patch is empty (e.g. `:copilot-cli` mode + no flags set), the RPC is skipped entirely.

### `:available-tools` required, but `[]` is legitimate

`validate-empty-mode-session-requirements!` uses `(contains? config :available-tools)` — NOT `seq`. An explicit empty vector `[]` means "no tools" and is legitimate; only an absent key is rejected. This mirrors upstream's `resolveToolFilterOptions` where the distinction between "undefined" and "empty list" is meaningful.

### Always-emit `:tool-filter-precedence`

Both modes now always send `toolFilterPrecedence: "excluded"` on `session.create` and `session.resume`. This is the only behavioral change to `:copilot-cli` mode, and it makes the precedence between `:available-tools` and `:excluded-tools` deterministic regardless of CLI version (older CLIs might have defaulted differently).

### `::client-mode` not `::mode`

`::specs/mode` was already defined at line 899 for `message-options` (`#{:enqueue :immediate}`). The new spec is named `::specs/client-mode` and validated in `::client-options` via a predicate (mirrors the existing `::remote-session-mode` pattern further down).

## Validation

- `bb test` (unit + integration): **339 tests / 1578 assertions / 0 failures / 0 errors** (+ 18 new tests this round across constructor validation, env-var override, wire payload mode-defaults, system-message normalization, and `session.options.update` RPC including async path + cleanup-on-failure)
- `bb validate-docs`: clean
- `bb jar`: succeeds
- `COPILOT_E2E_TESTS=true bb test`: 2 flaky E2E timeouts (`test-e2e-blob-attachment`, `test-e2e-list-sessions`) — both pre-existing model-latency timeouts on `main`, neither exercises `:mode :empty` or any new code path. Not regressions.
- `examples/empty_mode.clj`: compile-checked. Not included in `run-all-examples.sh` because empty mode disables the local keychain and the example requires a BYOK API key (matches how `byok_provider.clj` and `mcp_local_server.clj` are handled — see [`examples/README.md`](https://github.com/copilot-community-sdk/copilot-sdk-clojure/blob/upstream-sync/pr-1428-client-mode-empty/examples/README.md#example-20-empty-multitenancy-mode-empty_modeclj)).

## Commits

1. [`feat(tool-set): add github.copilot-sdk.tool-set namespace + isolated preset`](https://github.com/copilot-community-sdk/copilot-sdk-clojure/commit/451d47c)
2. [`feat(client): implement client mode :empty (multitenancy hardening)`](https://github.com/copilot-community-sdk/copilot-sdk-clojure/commit/94ad7ab)
3. [`docs: document client mode :empty + empty_mode example`](https://github.com/copilot-community-sdk/copilot-sdk-clojure/commit/a3af6b3)

Each commit individually builds; commits 1 and 2 each pass tests at HEAD.

---

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>
