### PR TITLE
docs(skill): correct upstream-sync file mapping and add omit-vs-null pitfall

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,11 +174,14 @@ This project emphasizes **rigor and correctness**, particularly for:
 ## Project Structure
 
 ```
+src/github/copilot_sdk.clj   # Top-level public API namespace (github.copilot-sdk):
+                             # re-exports + curated public `event-types` / `session-events` sets
 src/github/copilot_sdk/
 ├── client.clj       # Main client API (create-client, create-session, etc.)
 ├── session.clj      # Session operations (send!, send-and-wait!, etc.)
 ├── helpers.clj      # Convenience functions (query, query-seq!, query-chan, etc.)
 ├── tools.clj        # Helper functions for defining tools (define-tool, result-success, etc.)
+├── tool_set.clj     # Source-qualified tool filter patterns (:available-tools/:excluded-tools)
 ├── specs.clj        # clojure.spec definitions for all data shapes
 ├── instrument.clj   # Function specs (fdefs) and instrumentation
 ├── util.clj         # Wire conversion (camelCase ↔ kebab-case), MCP helpers

--- a/.github/skills/update-upstream/SKILL.md
+++ b/.github/skills/update-upstream/SKILL.md
@@ -172,4 +172,6 @@ Real recurring traps when porting upstream changes:
 
 4. **Test fixtures: match the shape the layer actually produces.** Mock server responses use wire shape; client-side assertions use idiomatic shape. Production conversion (`util/wire->clj`) only transforms keyword keys — string-keyed fixtures silently bypass it and produce tests that pass for the wrong reason.
 
+5. **Outbound optional fields: match upstream's omit-vs-null behavior per RPC.** Don't reflexively gate an optional wire field on `contains?` and emit JSON `null`. Some patch RPCs (e.g. `session.options.update`) genuinely accept `null` to clear a value; others (e.g. `session.model.switchTo`) have no null variant in the schema — upstream spreads `...options`, dropping `undefined`. Check the upstream call site and the request schema: if the field has no null union, compute the wire value first and gate on `(some? v)` so a `nil` option omits the key instead of sending `null`.
+
 For the mechanics of camelCase ↔ kebab-case conversion (including the `?`-suffix rule), see the cheat sheet in `references/PROJECT.md`.

--- a/.github/skills/update-upstream/references/PROJECT.md
+++ b/.github/skills/update-upstream/references/PROJECT.md
@@ -18,6 +18,7 @@ When syncing, map upstream changes to the corresponding Clojure files:
 | `nodejs/src/index.ts` | Public exports (defines the public API surface) |
 | `nodejs/src/generated/session-events.ts` | All event types and data shapes |
 | `nodejs/src/generated/rpc.ts` | RPC method signatures |
+| `nodejs/src/toolSet.ts` | `ToolSet` / `BuiltInTools` tool-filter helpers |
 
 ### Clojure Counterparts
 
@@ -26,9 +27,11 @@ When syncing, map upstream changes to the corresponding Clojure files:
 | Types / config | `specs.clj` | Session config, event data, permissions, tools |
 | Client methods | `client.clj` | Broadcast handlers, create-client, create-session |
 | Session methods | `session.clj` | send/receive, UI convenience methods |
-| Event types | `client.clj` | `event-types` set, `subscribe-events!` |
+| Curated public event sets | `copilot_sdk.clj` | Top-level `github.copilot-sdk` ns: hand-curated public `event-types` / `session-events` sets |
+| Generated event specs | `generated/event_specs.clj` | AUTO-GENERATED full `event-types` set + wire specs (`bb codegen`) |
 | RPC methods | `protocol.clj` | JSON-RPC protocol layer |
-| Public exports | `client.clj`, `helpers.clj`, `tools.clj` | Public API surface |
+| Tool-filter helpers | `tool_set.clj` | Source-qualified `:available-tools` / `:excluded-tools` patterns |
+| Public exports | `copilot_sdk.clj`, `client.clj`, `helpers.clj`, `tools.clj` | Public API surface |
 | Function specs | `instrument.clj` | fdefs for all public functions |
 
 ## Wire Conversion Cheat Sheet


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Phase 10 self-review of the `update-upstream` skill, following the v1.0.0-beta.12 sync ([#115](https://github.com/copilot-community-sdk/copilot-sdk-clojure/pull/115)). Documentation-only — corrects drift between the skill's reference material and the actual codebase.

## Changes

- **`AGENTS.md` (`.github/copilot-instructions.md`)** — the Project Structure tree was missing two real files: `tool_set.clj` and the top-level public namespace `src/github/copilot_sdk.clj` (home of the curated public `event-types` / `session-events` sets that sync work depends on).
- **`references/PROJECT.md`** — the upstream↔Clojure mapping pointed the public `event-types` set at `client.clj` (it lives in `copilot_sdk.clj`) and referenced a non-existent `subscribe-events!`. Corrected, split the curated-vs-generated event sets into distinct rows, and added the `toolSet.ts` → `tool_set.clj` mapping.
- **`SKILL.md`** — adds pitfall #5: outbound optional wire fields must match upstream's omit-vs-null behavior per RPC. The `contextTier` lesson from #115, generalized — compute the wire value and gate on `(some? v)` when the request schema has no null variant (e.g. `session.model.switchTo`), rather than `contains?`-gating and emitting JSON `null`.

## Validation

`bb validate-docs` ✓ (13 files, 0 warnings). No source or test changes.
