### PR TITLE
GA prep: Phase 3 idiomatic/state review — race fixes, API rename, <send-and-wait!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,12 @@ All notable changes to this project will be documented in this file. This change
   closes it — so it now carries the `!` side-effect suffix per the SDK's naming
   convention. Update callers to the new name (no behavior change).
 
+### Added
+- **`<send-and-wait!`** — channel-based equivalent of `send-and-wait!` for use
+  inside `go` blocks. Returns a channel that delivers the final assistant message
+  event (the same value `send-and-wait!` returns), or closes empty if none was
+  received. Complements `<send!` (which yields just the content string).
+
 ### Fixed (GA parity)
 - **BYOK `ProviderConfig` wire keys** — `:provider {:provider-type ...
   :azure-options {:azure-api-version ...}}` now serializes to the upstream wire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ All notable changes to this project will be documented in this file. This change
   `swap-vals!` compare-and-set: only the caller that observes a non-`:connecting`
   /`:connected` status proceeds to spawn; the others no-op. The same atomic guard
   is applied to the test-only `connect-with-streams!`.
+- **`disconnect!` is now idempotent under concurrent calls.** It used a
+  non-atomic check-then-act on the session's `:destroyed?` flag, so two threads
+  disconnecting the same session could both send a `session.destroy` RPC. The
+  teardown is now claimed with an atomic `swap-vals!` on `:destroyed?`; only the
+  winning caller notifies the server and closes the event channel.
+- **`remove-session!` no longer closes the event channel before removing the
+  session.** It closed the channel first and dissoc'd the session afterward,
+  leaving a window where the notification router could still resolve the session
+  and `offer!` an event to the just-closed channel (a spurious "buffer full"
+  warning). The session is now removed from the registry first, then its channel
+  is closed.
 - **`query-chan` no longer blocks a go dispatch thread or leaks on send
   failure.** It called the blocking `disconnect!` directly inside its event
   go-loop (parking a shared core.async dispatch thread for the duration of
@@ -65,6 +76,12 @@ All notable changes to this project will be documented in this file. This change
   atomic step, and resolves the response channel with a connection-closed error
   if the connection is gone or the outgoing channel is already closed —
   previously such a request was silently dropped and the caller hung.
+
+### Removed
+- **Dropped the unused `:force-stopping?` client-state flag.** `force-stop!`
+  set it (and `initial-state` initialized it), but nothing ever read it, so it
+  was dead state. `:stopping?` (which the process-exit watcher does read) is
+  unchanged.
 
 ### Fixed (GA parity)
 - **BYOK `ProviderConfig` wire keys** — `:provider {:provider-type ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,8 +92,10 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - **`<send-and-wait!`** — channel-based equivalent of `send-and-wait!` for use
   inside `go` blocks. Returns a channel that delivers the final assistant message
-  event (the same value `send-and-wait!` returns), or closes empty if none was
-  received. Complements `<send!` (which yields just the content string).
+  event (same shape as `send-and-wait!`'s successful return; content under
+  `[:data :content]`), or closes empty if none was received. Like `<send!`, it
+  does not surface `:copilot/session.error`/timeout as exceptions. Complements
+  `<send!` (which yields just the content string).
 
 ### Fixed (GA parity)
 - **BYOK `ProviderConfig` wire keys** — `:provider {:provider-type ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Changed (v1.0.0 GA sync)
+- **Synced version to upstream GA `v1.0.0`** (`1.0.0-beta.12.0` -> `1.0.0.0`).
+  Upstream's `v1.0.0` release is functionally identical to `v1.0.0-beta.12` at
+  the SDK level: no changes to `nodejs/src/`, the pinned `@github/copilot` CLI
+  dependency stays `^1.0.57` (matching our schema `1.0.57`), and there are no
+  `schemas/` or generated-code diffs. The remaining upstream commits in the
+  range are Go/Java/CI/release plumbing and E2E test de-flaking — nothing to
+  port. This SDK is therefore at full API/wire/schema parity with upstream GA.
+
 ### Security
 - **Validation exceptions no longer leak secrets.** Configuration validation
   failures (`client`, `create-session`, `resume-session`, and MCP-server checks)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ All notable changes to this project will be documented in this file. This change
   was dead state. `:stopping?` (which the process-exit watcher does read) is
   unchanged.
 
+### Changed
+- **BREAKING**: renamed `unsubscribe-events` to `unsubscribe-events!`. The
+  function mutates — it untaps the channel from the session's event mult and
+  closes it — so it now carries the `!` side-effect suffix per the SDK's naming
+  convention. Update callers to the new name (no behavior change).
+
 ### Fixed (GA parity)
 - **BYOK `ProviderConfig` wire keys** — `:provider {:provider-type ...
   :azure-options {:azure-api-version ...}}` now serializes to the upstream wire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ All notable changes to this project will be documented in this file. This change
   and `ex-data` before the exception is thrown.
 
 ### Fixed (correctness)
+- **`start!` is now safe under concurrent calls.** The status guard previously
+  did a non-atomic check-then-act (read `:status`, then a separate `swap!` to
+  `:connecting`), so two threads calling `start!` on the same client could both
+  pass the guard and spawn two CLI processes. The transition is now an atomic
+  `swap-vals!` compare-and-set: only the caller that observes a non-`:connecting`
+  /`:connected` status proceeds to spawn; the others no-op. The same atomic guard
+  is applied to the test-only `connect-with-streams!`.
 - **`query-chan` no longer blocks a go dispatch thread or leaks on send
   failure.** It called the blocking `disconnect!` directly inside its event
   go-loop (parking a shared core.async dispatch thread for the duration of

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add to your `deps.edn`:
 
 ```clojure
 ;; From Maven Central
-io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "1.0.0-beta.12.0"}
+io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "1.0.0.0"}
 
 ;; Or git dependency
 io.github.copilot-community-sdk/copilot-sdk-clojure {:git/url "https://github.com/copilot-community-sdk/copilot-sdk-clojure.git"

--- a/build.clj
+++ b/build.clj
@@ -7,7 +7,7 @@
   (:import [java.io File]))
 
 (def lib 'io.github.copilot-community-sdk/copilot-sdk-clojure)
-(def version "1.0.0-beta.12.0")
+(def version "1.0.0.0")
 (def class-dir "target/classes")
 
 (defn- try-sh

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -157,7 +157,7 @@ The SDK uses core.async `mult/tap` for event subscription:
 |----------|-------------|
 | `(copilot/events session)` | Get the core.async mult for all events |
 | `(copilot/subscribe-events session)` | Get a tapped channel (convenience) |
-| `(copilot/unsubscribe-events session ch)` | Untap a channel |
+| `(copilot/unsubscribe-events! session ch)` | Untap a channel |
 | `(copilot/events->chan session opts)` | Advanced: custom buffer, transducer |
 
 ## Step 4: Add a Custom Tool

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -799,6 +799,24 @@ Combined with `<create-session`, enables fully non-blocking pipelines:
     (println answer)))
 ```
 
+#### `<send-and-wait!`
+
+```clojure
+(copilot/<send-and-wait! session options)
+```
+
+Async equivalent of `send-and-wait!` for use inside `go` blocks. Returns a channel that yields the final assistant message **event** (the same value `send-and-wait!` returns), or closes with nothing if no assistant message was received.
+Supports `:timeout-ms` in options (default: `300000`, set to `nil` to disable).
+
+```clojure
+(go
+  (let [session (<! (copilot/<create-session client {:on-permission-request copilot/approve-all}))
+        event   (<! (copilot/<send-and-wait! session {:prompt "Explain monads"}))]
+    (println (:content event))))
+```
+
+Use `<send!` when you only need the content string; use `<send-and-wait!` when you need the full event (metadata, id, etc.).
+
 #### `events`
 
 ```clojure

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -852,10 +852,10 @@ Key points:
 With the default 1024 buffer, drops are unlikely unless a subscriber completely stops
 reading. For most use cases, this is not a concern.
 
-#### `unsubscribe-events`
+#### `unsubscribe-events!`
 
 ```clojure
-(copilot/unsubscribe-events session ch)
+(copilot/unsubscribe-events! session ch)
 ```
 
 Unsubscribe a channel from session events.

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -805,14 +805,16 @@ Combined with `<create-session`, enables fully non-blocking pipelines:
 (copilot/<send-and-wait! session options)
 ```
 
-Async equivalent of `send-and-wait!` for use inside `go` blocks. Returns a channel that yields the final assistant message **event** (the same value `send-and-wait!` returns), or closes with nothing if no assistant message was received.
+Async equivalent of `send-and-wait!` for use inside `go` blocks. Returns a channel that yields the final assistant message **event** — the same shape as `send-and-wait!`'s successful return value (content lives under `[:data :content]`), or closes with nothing if no assistant message was received.
 Supports `:timeout-ms` in options (default: `300000`, set to `nil` to disable).
+
+Error semantics differ from `send-and-wait!`: where `send-and-wait!` throws on `:copilot/session.error` or timeout, this variant never surfaces those — the channel closes (delivering the last assistant message if one arrived, otherwise nothing), consistent with `<send!`.
 
 ```clojure
 (go
   (let [session (<! (copilot/<create-session client {:on-permission-request copilot/approve-all}))
         event   (<! (copilot/<send-and-wait! session {:prompt "Explain monads"}))]
-    (println (:content event))))
+    (println (get-in event [:data :content]))))
 ```
 
 Use `<send!` when you only need the content string; use `<send-and-wait!` when you need the full event (metadata, id, etc.).

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -890,7 +890,7 @@
 (defn subscribe-events
   "Subscribe to session events. Returns a channel (buffer 1024) that receives events.
    The channel receives nil (close) when the session is disconnected.
-   For explicit cleanup, call unsubscribe-events.
+   For explicit cleanup, call unsubscribe-events!.
    
    This is a convenience wrapper around (tap (copilot/events session) ch).
 
@@ -926,10 +926,13 @@
   ([session opts]
    (session/events->chan session opts)))
 
-(defn unsubscribe-events
-  "Unsubscribe a channel from session events."
+(defn unsubscribe-events!
+  "Unsubscribe a channel from session events.
+
+   Side effects: untaps `ch` from the session's event mult and closes `ch`.
+   The caller must not use `ch` after calling this."
   [session ch]
-  (session/unsubscribe-events session ch))
+  (session/unsubscribe-events! session ch))
 
 (defn session-id
   "Get the session ID."

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -371,9 +371,9 @@
   "Ping the server to check connectivity.
    Returns {:message :timestamp :protocol-version}.
 
-   `:timestamp` is an ISO 8601 date-time string on CLI ≥ 1.0.51
-   (upstream PR #1340). Earlier CLI versions returned a numeric
-   epoch-millis value."
+   `:timestamp` is either an ISO 8601 date-time string (CLI ≥ 1.0.51,
+   upstream PR #1340) or a numeric epoch-millis value, depending on the
+   CLI version; the SDK forwards whatever the server sends."
   ([client]
    (client/ping client))
   ([client message]

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -799,6 +799,27 @@
   [session opts]
   (session/<send! session opts))
 
+(defn <send-and-wait!
+  "Send a message and return a channel that delivers the final assistant message
+   event - the channel-based equivalent of `send-and-wait!`. Use it inside go
+   blocks instead of blocking a dispatch thread. Unlike `<send!` (which delivers
+   the final content string), this delivers the full assistant message event.
+
+   Options: same as send!, plus:
+   - :timeout-ms   - Timeout in milliseconds (default: 300000, set to nil to disable)
+
+   The returned channel delivers a single value (the final assistant message
+   event, or nothing if none was received) then closes.
+
+   Example:
+   ```clojure
+   (go
+     (let [event (<! (copilot/<send-and-wait! session {:prompt \"What is 2+2?\"}))]
+       (println (get-in event [:data :content]))))
+   ```"
+  [session opts]
+  (session/<send-and-wait! session opts))
+
 (defn send-async-with-id
   "Send a message and return {:message-id :events-ch}."
   [session opts]

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -1218,9 +1218,10 @@
   "Ping the server to check connectivity.
    Returns {:message :timestamp :protocol-version}.
 
-   `:timestamp` is an ISO 8601 date-time string (e.g. \"2026-05-21T08:00:00Z\")
-   on CLI ≥ 1.0.51 (upstream PR #1340). Earlier CLI versions returned a
-   numeric epoch-millis value; the SDK forwards whatever the server sends."
+   `:timestamp` is either an ISO 8601 date-time string (e.g.
+   \"2026-05-21T08:00:00Z\"; CLI ≥ 1.0.51, upstream PR #1340) or a numeric
+   epoch-millis value, depending on the CLI version; the SDK forwards
+   whatever the server sends."
   ([client]
    (ping client nil))
   ([client message]

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -987,107 +987,111 @@
   "Start the CLI server and establish connection.
    Blocks until connected or throws on error.
 
-   Thread safety: do not call start! and stop! concurrently from different
-   threads. The :stopping? flag guards against concurrent calls, but explicit
-   concurrent calls are unsupported."
+   Thread safety: concurrent start! calls are safe — an atomic compare-and-set
+   on :status ensures only one caller spawns the process; the others no-op.
+   Do not, however, call start! and stop! concurrently from different threads."
   [client]
-  (when-not (= :connected (:status @(:state client)))
-    (log/info "Starting Copilot client...")
-    (swap! (:state client) assoc :stopping? false :status :connecting)
+  (let [[old _] (swap-vals! (:state client)
+                            (fn [s]
+                              (if (#{:connecting :connected} (:status s))
+                                s
+                                (assoc s :stopping? false :status :connecting))))]
+    (when-not (#{:connecting :connected} (:status old))
+      (log/info "Starting Copilot client...")
 
-    ;; Set log level from options
-    (when-let [level (:log-level (:options client))]
-      (log/set-log-level! level))
+      ;; Set log level from options
+      (when-let [level (:log-level (:options client))]
+        (log/set-log-level! level))
 
-    (try
+      (try
       ;; Start CLI process if not connecting to external server
-      (when-not (:external-server? client)
-        (log/debug "Spawning CLI process")
-        (let [opts (:options client)
-              mp (proc/spawn-cli opts)]
-          (swap! (:state client) assoc :process mp)
-          (start-stderr-forwarder! client mp)
-          (watch-process-exit! client mp)
+        (when-not (:external-server? client)
+          (log/debug "Spawning CLI process")
+          (let [opts (:options client)
+                mp (proc/spawn-cli opts)]
+            (swap! (:state client) assoc :process mp)
+            (start-stderr-forwarder! client mp)
+            (watch-process-exit! client mp)
 
           ;; For TCP mode, wait for port announcement
-          (when-not (:use-stdio? opts)
-            (let [port (proc/wait-for-port mp 10000)]
-              (swap! (:state client) assoc :actual-port port)))))
+            (when-not (:use-stdio? opts)
+              (let [port (proc/wait-for-port mp 10000)]
+                (swap! (:state client) assoc :actual-port port)))))
 
       ;; Connect to server
-      (cond
+        (cond
         ;; Child process mode: use own stdin/stdout to talk to parent
-        (:is-child-process? (:options client))
-        (do
-          (log/debug "Connecting via parent stdio (child process mode)")
-          (connect-parent-stdio! client))
+          (:is-child-process? (:options client))
+          (do
+            (log/debug "Connecting via parent stdio (child process mode)")
+            (connect-parent-stdio! client))
 
         ;; External server (cli-url) or TCP mode
-        (or (:external-server? client)
-            (not (:use-stdio? (:options client))))
-        (do
-          (log/debug "Connecting via TCP")
-          (connect-tcp! client))
+          (or (:external-server? client)
+              (not (:use-stdio? (:options client))))
+          (do
+            (log/debug "Connecting via TCP")
+            (connect-tcp! client))
 
         ;; Normal stdio to spawned process
-        :else
-        (do
-          (log/debug "Connecting via stdio")
-          (connect-stdio! client)))
+          :else
+          (do
+            (log/debug "Connecting via stdio")
+            (connect-stdio! client)))
 
       ;; Verify protocol version
-      (verify-protocol-version! client)
+        (verify-protocol-version! client)
 
       ;; Register sessionFs provider if configured
-      (when-let [sf-config (:session-fs client)]
-        (let [{:keys [connection-io]} @(:state client)]
-          (proto/send-request! connection-io "sessionFs.setProvider"
-                               (cond-> {:initial-cwd (:initial-cwd sf-config)
-                                        :session-state-path (:session-state-path sf-config)
-                                        :conventions (:conventions sf-config)}
+        (when-let [sf-config (:session-fs client)]
+          (let [{:keys [connection-io]} @(:state client)]
+            (proto/send-request! connection-io "sessionFs.setProvider"
+                                 (cond-> {:initial-cwd (:initial-cwd sf-config)
+                                          :session-state-path (:session-state-path sf-config)
+                                          :conventions (:conventions sf-config)}
                                  ;; Upstream PR #1299: forward provider capabilities (e.g., {:sqlite true}).
-                                 (:capabilities sf-config)
-                                 (assoc :capabilities (:capabilities sf-config))))))
+                                   (:capabilities sf-config)
+                                   (assoc :capabilities (:capabilities sf-config))))))
 
       ;; Set up notification routing and request handling
-      (start-notification-router! client)
-      (setup-request-handler! client)
+        (start-notification-router! client)
+        (setup-request-handler! client)
 
-      (swap! (:state client) assoc :status :connected)
-      (log/info "Copilot client connected")
-      nil
+        (swap! (:state client) assoc :status :connected)
+        (log/info "Copilot client connected")
+        nil
 
-      (catch Exception e
-        (let [stderr (get-stderr-output client)
-              msg (cond-> (str "Failed to start client: " (ex-message e))
-                    stderr (str "\nstderr: " stderr))]
-          (log/error msg)
+        (catch Exception e
+          (let [stderr (get-stderr-output client)
+                msg (cond-> (str "Failed to start client: " (ex-message e))
+                      stderr (str "\nstderr: " stderr))]
+            (log/error msg)
           ;; Release any resources created before the failure so a failed
           ;; start! does not leak the spawned process, its stderr/exit watcher
           ;; threads, the socket, or the JSON-RPC connection. Mark :stopping? so
           ;; the process-exit watcher treats the teardown as expected. Status is
           ;; left as :error (not :disconnected) so callers can distinguish a
           ;; failed start from a clean stop.
-          (swap! (:state client) assoc :stopping? true)
+            (swap! (:state client) assoc :stopping? true)
           ;; Tear down the notification router if it was started before the
           ;; failure (mirrors stop!), so its dispatcher thread/channel don't leak.
-          (swap! (:state client) assoc :router-running? false)
-          (when-let [^Thread router-thread (:router-thread @(:state client))]
-            (.interrupt router-thread)
-            (try (.join router-thread 500) (catch Exception _)))
-          (when-let [router-ch (:router-ch @(:state client))]
-            (close! router-ch))
-          (swap! (:state client) assoc :router-ch nil :router-queue nil :router-thread nil)
-          (let [{:keys [connection-io socket process]} @(:state client)]
-            (when connection-io
-              (try (proto/disconnect connection-io) (catch Exception _)))
-            (when socket
-              (try (.close ^Socket socket) (catch Exception _)))
-            (when (and (not (:external-server? client)) process)
-              (try (proc/destroy! process) (catch Exception _))))
-          (swap! (:state client) assoc :status :error :connection nil
-                 :connection-io nil :socket nil :process nil :actual-port nil)
-          (throw e))))))
+            (swap! (:state client) assoc :router-running? false)
+            (when-let [^Thread router-thread (:router-thread @(:state client))]
+              (.interrupt router-thread)
+              (try (.join router-thread 500) (catch Exception _)))
+            (when-let [router-ch (:router-ch @(:state client))]
+              (close! router-ch))
+            (swap! (:state client) assoc :router-ch nil :router-queue nil :router-thread nil)
+            (let [{:keys [connection-io socket process]} @(:state client)]
+              (when connection-io
+                (try (proto/disconnect connection-io) (catch Exception _)))
+              (when socket
+                (try (.close ^Socket socket) (catch Exception _)))
+              (when (and (not (:external-server? client)) process)
+                (try (proc/destroy! process) (catch Exception _))))
+            (swap! (:state client) assoc :status :error :connection nil
+                   :connection-io nil :socket nil :process nil :actual-port nil)
+            (throw e)))))))
 
 (defn stop!
   "Stop the CLI server and close all sessions.
@@ -2672,27 +2676,31 @@
   "Connect to a server using pre-existing input/output streams.
    For testing purposes only."
   [client in out]
-  (when-not (= :connected (:status @(:state client)))
-    (swap! (:state client) assoc :status :connecting)
-    (try
-      ;; Initialize connection state before connecting
-      (swap! (:state client) assoc :connection (proto/initial-connection-state))
-      (let [conn (proto/connect in out (:state client))]
-        (swap! (:state client) assoc :connection-io conn))
-      (verify-protocol-version! client)
-      ;; Register sessionFs provider if configured
-      (when-let [sf-config (:session-fs client)]
-        (let [{:keys [connection-io]} @(:state client)]
-          (proto/send-request! connection-io "sessionFs.setProvider"
-                               (cond-> {:initial-cwd (:initial-cwd sf-config)
-                                        :session-state-path (:session-state-path sf-config)
-                                        :conventions (:conventions sf-config)}
-                                 (:capabilities sf-config)
-                                 (assoc :capabilities (:capabilities sf-config))))))
-      (start-notification-router! client)
-      (setup-request-handler! client)
-      (swap! (:state client) assoc :status :connected)
-      nil
-      (catch Exception e
-        (swap! (:state client) assoc :status :error)
-        (throw e)))))
+  (let [[old _] (swap-vals! (:state client)
+                            (fn [s]
+                              (if (#{:connecting :connected} (:status s))
+                                s
+                                (assoc s :status :connecting))))]
+    (when-not (#{:connecting :connected} (:status old))
+      (try
+        ;; Initialize connection state before connecting
+        (swap! (:state client) assoc :connection (proto/initial-connection-state))
+        (let [conn (proto/connect in out (:state client))]
+          (swap! (:state client) assoc :connection-io conn))
+        (verify-protocol-version! client)
+        ;; Register sessionFs provider if configured
+        (when-let [sf-config (:session-fs client)]
+          (let [{:keys [connection-io]} @(:state client)]
+            (proto/send-request! connection-io "sessionFs.setProvider"
+                                 (cond-> {:initial-cwd (:initial-cwd sf-config)
+                                          :session-state-path (:session-state-path sf-config)
+                                          :conventions (:conventions sf-config)}
+                                   (:capabilities sf-config)
+                                   (assoc :capabilities (:capabilities sf-config))))))
+        (start-notification-router! client)
+        (setup-request-handler! client)
+        (swap! (:state client) assoc :status :connected)
+        nil
+        (catch Exception e
+          (swap! (:state client) assoc :status :error)
+          (throw e))))))

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -155,7 +155,6 @@
 ;;  :router-ch nil or channel
 ;;  :stopping? false
 ;;  :restarting? false
-;;  :force-stopping? false
 ;;  :models-cache nil|promise|vector (list-models cache)
 ;;  :lifecycle-handlers {handler-id -> {:handler fn :event-type type-or-nil}}}
 
@@ -175,7 +174,6 @@
    :router-thread nil
    :router-running? false
    :stopping? false
-   :force-stopping? false
    :models-cache nil         ; nil, promise, or vector of models (cleared on stop)
    :lifecycle-handlers {}
    :stderr-buffer nil         ; atom of recent stderr lines (for error context)
@@ -1162,7 +1160,7 @@
 (defn force-stop!
   "Force stop the CLI server without graceful cleanup."
   [client]
-  (swap! (:state client) assoc :force-stopping? true :stopping? true)
+  (swap! (:state client) assoc :stopping? true)
 
   (let [{:keys [connection-io socket process]} @(:state client)]
     (try
@@ -1203,7 +1201,6 @@
           :router-queue nil
           :router-thread nil
           :router-running? false
-          :force-stopping? false
           :models-cache nil
           :lifecycle-handlers {}
           :stderr-buffer nil}) ; reset caches, handlers, and stderr

--- a/src/github/copilot_sdk/helpers.clj
+++ b/src/github/copilot_sdk/helpers.clj
@@ -98,7 +98,7 @@
         (cond
           ;; No client exists - create one
           (nil? client)
-          (let [new-client (copilot/client (or client-opts {}))]
+          (let [new-client (copilot/client normalized)]
             (copilot/start! new-client)
             (reset! client-state {:client new-client :client-opts normalized})
             new-client)

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -277,7 +277,7 @@
                 :args (s/cat :session ::specs/session)
                 :ret any?)  ; core.async channel
 
-(register-fdef! github.copilot-sdk.session/unsubscribe-events
+(register-fdef! github.copilot-sdk.session/unsubscribe-events!
                 :args (s/cat :session ::specs/session
                              :ch any?)
                 :ret nil?)

--- a/src/github/copilot_sdk/instrument.clj
+++ b/src/github/copilot_sdk/instrument.clj
@@ -216,6 +216,12 @@
                                             (s/keys :opt-un [::specs/timeout-ms])))
                 :ret any?)  ; core.async channel
 
+(register-fdef! github.copilot-sdk.session/<send-and-wait!
+                :args (s/cat :session ::specs/session
+                             :opts (s/merge ::specs/send-options
+                                            (s/keys :opt-un [::specs/timeout-ms])))
+                :ret any?)  ; core.async channel
+
 (register-fdef! github.copilot-sdk.session/abort!
                 :args (s/cat :session ::specs/session)
                 :ret nil?)

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -405,12 +405,13 @@
 (defn remove-session!
   "Remove a session from client state. Called on RPC failure during pre-registration."
   [client session-id]
-  (when-let [{:keys [event-chan]} (get-in @(:state client) [:session-io session-id])]
-    (close! event-chan))
-  (swap! (:state client) (fn [s]
-                           (-> s
-                               (update :sessions dissoc session-id)
-                               (update :session-io dissoc session-id)))))
+  (let [event-chan (get-in @(:state client) [:session-io session-id :event-chan])]
+    (swap! (:state client) (fn [s]
+                             (-> s
+                                 (update :sessions dissoc session-id)
+                                 (update :session-io dissoc session-id))))
+    (when event-chan
+      (close! event-chan))))
 
 (defn dispatch-event!
   "Dispatch an event to all subscribers via the mult. Called by client notification router.
@@ -1447,27 +1448,34 @@
    (disconnect! (:client session) (:session-id session)))
   ([client session-id]
    (log/debug "Disconnecting session: " session-id)
-   (when-not (:destroyed? (session-state client session-id))
-     (let [conn (connection-io client)]
-       ;; Try to notify server, but don't block forever if connection is broken
-       (try
-         (proto/send-request! conn "session.destroy" {:session-id session-id} 5000)
-         (catch Exception _
-           ;; Ignore errors - we're cleaning up anyway
-           nil))
-       ;; Atomically update state — clear handlers and closures to aid GC
-       (update-session! client session-id assoc
-                        :destroyed? true
-                        :tool-handlers {}
-                        :permission-handler nil
-                        :user-input-handler nil
-                        :hooks {}
-                        :config nil)
-       ;; Close the event source channel - this propagates to all tapped channels
-       (when-let [{:keys [event-chan]} (session-io client session-id)]
-         (close! event-chan))
-       (log/debug "Session disconnected: " session-id)
-       nil))))
+   ;; Atomically claim the teardown: only the caller that flips :destroyed?
+   ;; from falsey to true proceeds. Concurrent disconnect! calls on the same
+   ;; session then no-op instead of sending a second session.destroy RPC.
+   (let [[old _] (swap-vals! (:state client)
+                             (fn [s]
+                               (if (get-in s [:sessions session-id :destroyed?])
+                                 s
+                                 (assoc-in s [:sessions session-id :destroyed?] true))))]
+     (when-not (get-in old [:sessions session-id :destroyed?])
+       (let [conn (connection-io client)]
+         ;; Try to notify server, but don't block forever if connection is broken
+         (try
+           (proto/send-request! conn "session.destroy" {:session-id session-id} 5000)
+           (catch Exception _
+             ;; Ignore errors - we're cleaning up anyway
+             nil))
+         ;; Clear handlers and closures to aid GC (:destroyed? already set above)
+         (update-session! client session-id assoc
+                          :tool-handlers {}
+                          :permission-handler nil
+                          :user-input-handler nil
+                          :hooks {}
+                          :config nil)
+         ;; Close the event source channel - this propagates to all tapped channels
+         (when-let [{:keys [event-chan]} (session-io client session-id)]
+           (close! event-chan))
+         (log/debug "Session disconnected: " session-id)
+         nil)))))
 
 (defn destroy!
   "Deprecated: Use disconnect! instead. This function will be removed in a future release.

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -1245,17 +1245,22 @@
 
 (defn <send-and-wait!
   "Send a message and return a channel that delivers the final assistant message
-   event - the same value `send-and-wait!` returns. This is the channel-based
-   equivalent of `send-and-wait!`; use it inside go blocks instead of blocking a
-   dispatch thread.
+   event. This is the channel-based equivalent of `send-and-wait!`; use it inside
+   go blocks instead of blocking a dispatch thread.
+
+   The delivered event has the same shape as `send-and-wait!`'s successful return
+   value (an `:copilot/assistant.message` event - content lives under
+   `[:data :content]`). Error semantics differ: unlike `send-and-wait!`, which
+   throws on `:copilot/session.error` or timeout, this variant never surfaces those
+   - on error or timeout the channel simply closes (delivering the last assistant
+   message if one had already arrived, otherwise nothing). This matches `<send!`.
 
    Options: same as send!.
 
    Additional options:
    - :timeout-ms   - Timeout in milliseconds (default: 300000, set to nil to disable)
 
-   The returned channel delivers a single value (the final assistant message
-   event, or nothing if none was received) then closes."
+   The returned channel delivers at most one value then closes."
   [session opts]
   (let [timeout-ms (if (contains? opts :timeout-ms) (:timeout-ms opts) 300000)
         events-ch (send-async session (assoc opts :timeout-ms timeout-ms))

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -1505,7 +1505,7 @@
   "Subscribe to session events. Returns a channel that receives events.
    
    The channel will receive nil (close) when the session is disconnected.
-   For explicit cleanup before session disconnection, call unsubscribe-events.
+   For explicit cleanup before session disconnection, call unsubscribe-events!.
    
    Drop behavior: the returned channel uses a sliding buffer of 1024 events.
    If this subscriber falls behind and its buffer fills, the oldest buffered
@@ -1541,8 +1541,11 @@
      (tap event-mult ch)
      ch)))
 
-(defn unsubscribe-events
-  "Unsubscribe a channel from session events."
+(defn unsubscribe-events!
+  "Unsubscribe a channel from session events.
+
+   Side effects: untaps `ch` from the session's event mult and closes `ch`.
+   The caller must not use `ch` after calling this."
   [session ch]
   (let [{:keys [session-id client]} session
         {:keys [event-mult]} (session-io client session-id)]

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -1243,6 +1243,39 @@
       (close! out-ch))
     out-ch))
 
+(defn <send-and-wait!
+  "Send a message and return a channel that delivers the final assistant message
+   event - the same value `send-and-wait!` returns. This is the channel-based
+   equivalent of `send-and-wait!`; use it inside go blocks instead of blocking a
+   dispatch thread.
+
+   Options: same as send!.
+
+   Additional options:
+   - :timeout-ms   - Timeout in milliseconds (default: 300000, set to nil to disable)
+
+   The returned channel delivers a single value (the final assistant message
+   event, or nothing if none was received) then closes."
+  [session opts]
+  (let [timeout-ms (if (contains? opts :timeout-ms) (:timeout-ms opts) 300000)
+        events-ch (send-async session (assoc opts :timeout-ms timeout-ms))
+        out-ch (chan (async/sliding-buffer 1))]
+    (go
+      (loop [last-msg nil]
+        (when-let [event (<! events-ch)]
+          (cond
+            (= :copilot/assistant.message (:type event))
+            (recur event)
+
+            (#{:copilot/session.idle :copilot/session.error} (:type event))
+            (when last-msg
+              (async/offer! out-ch last-msg))
+
+            :else
+            (recur last-msg))))
+      (close! out-ch))
+    out-ch))
+
 (defn send-async-with-id
   "Send a message and return {:message-id :events-ch}."
   [session opts]

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -551,6 +551,32 @@
             (is (= "Here is the final answer with all the details." result)
                 "<send! should return the last assistant.message content, not the first")))))))
 
+(deftest test-<send-and-wait!-returns-final-event
+  (testing "<send-and-wait! delivers the final assistant.message EVENT (not just content)"
+    (let [session (sdk/create-session *test-client* {:on-permission-request sdk/approve-all})
+          session-id (sdk/session-id session)
+          client (:client session)]
+      (with-redefs [protocol/send-request (fn [_ _ _]
+                                            (let [ch (async/chan 1)]
+                                              (async/put! ch {:result {:message-id "msg-id"}})
+                                              (async/close! ch)
+                                              ch))]
+        (let [result-ch (sdk/<send-and-wait! session {:prompt "Q"})]
+          (Thread/sleep 50)
+          (session/dispatch-event! client session-id
+                                   {:type :copilot/assistant.message
+                                    :data {:content "first" :message-id "m1"}})
+          (session/dispatch-event! client session-id
+                                   {:type :copilot/assistant.message
+                                    :data {:content "final answer" :message-id "m2"}})
+          (session/dispatch-event! client session-id {:type :copilot/session.idle :data {}})
+          (let [[result _] (alts!! [result-ch (timeout 2000)])]
+            (is (= :copilot/assistant.message (:type result))
+                "<send-and-wait! should deliver the full event map, not just content")
+            (is (= "final answer" (get-in result [:data :content]))
+                "<send-and-wait! should deliver the LAST assistant.message")
+            (is (= "m2" (get-in result [:data :message-id])))))))))
+
 ;; -----------------------------------------------------------------------------
 ;; Session Operations Tests
 ;; -----------------------------------------------------------------------------

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -6096,3 +6096,27 @@
           (Thread/sleep 50)
           (mock/stop-mock-server! server))))))
 
+(deftest disconnect-concurrent-idempotent-test
+  ;; disconnect! must be idempotent under concurrent calls: only the caller that
+  ;; atomically claims :destroyed? should send session.destroy. A non-atomic
+  ;; check-then-act lets multiple concurrent callers each send the RPC. Run many
+  ;; iterations with several racing threads; the non-atomic version observes the
+  ;; race in ~45% of iterations, so requiring exactly one RPC per iteration is a
+  ;; reliable (non-flaky) regression guard.
+  (dotimes [_ 100]
+    (let [ch (chan)
+          client {:state (atom {:sessions {"s1" {:destroyed? false}}
+                                :session-io {"s1" {:event-chan ch}}
+                                :connection-io :fake})}
+          calls (atom 0)
+          latch (java.util.concurrent.CountDownLatch. 1)]
+      (with-redefs [protocol/send-request! (fn [& _] (swap! calls inc) nil)]
+        (let [threads (doall (for [_ (range 8)]
+                               (future (.await latch)
+                                       (try (session/disconnect! client "s1")
+                                            (catch Throwable _)))))]
+          (.countDown latch)
+          (doseq [t threads] @t)))
+      (is (= 1 @calls)
+          "exactly one concurrent disconnect! should send session.destroy")
+      (is (true? (get-in @(:state client) [:sessions "s1" :destroyed?]))))))

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -612,7 +612,7 @@
               (swap! events conj v)
               (recur))))
         (is (pos? (count @events))))
-      (sdk/unsubscribe-events session events-ch))))
+      (sdk/unsubscribe-events! session events-ch))))
 
 (deftest test-non-session-notification-routed
   (testing "Non-session notifications are delivered to client notifications channel"
@@ -2214,7 +2214,7 @@
         (is (= :copilot/session.snapshot_rewind (:type event)))
         (is (= "evt-42" (get-in event [:data :up-to-event-id])))
         (is (= 5 (get-in event [:data :events-removed]))))
-      (sdk/unsubscribe-events session events-ch))))
+      (sdk/unsubscribe-events! session events-ch))))
 
 ;; -----------------------------------------------------------------------------
 ;; Async Session Lifecycle Tests

--- a/test/github/copilot_sdk_test.clj
+++ b/test/github/copilot_sdk_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [github.copilot-sdk :as copilot]
             [github.copilot-sdk.helpers :as h]
+            [github.copilot-sdk.process :as proc]
             [github.copilot-sdk.protocol :as proto]
             [github.copilot-sdk.specs :as specs]
             [github.copilot-sdk.util :as util]
@@ -279,6 +280,23 @@
               "first-use client must honor the requested :cli-path")))
       (finally
         (reset! state-atom saved)))))
+
+(deftest start-guard-prevents-double-spawn-test
+  ;; The start! status guard must be atomic: if a start is already in progress
+  ;; (:connecting) or complete (:connected), a second start! must NOT spawn a
+  ;; second CLI process. A non-atomic check-then-act lets two concurrent callers
+  ;; both pass the guard and double-spawn. We simulate the in-progress state
+  ;; deterministically and assert no spawn is attempted.
+  (testing "already :connecting -> start! is a no-op (no second spawn)"
+    (let [c (copilot/client {:auto-start? false :use-stdio? true})]
+      (swap! (:state c) assoc :status :connecting)
+      (with-redefs [proc/spawn-cli (fn [_] (throw (ex-info "start! must not spawn when already :connecting" {})))]
+        (is (nil? (copilot/start! c))))))
+  (testing "already :connected -> start! is a no-op"
+    (let [c (copilot/client {:auto-start? false :use-stdio? true})]
+      (swap! (:state c) assoc :status :connected)
+      (with-redefs [proc/spawn-cli (fn [_] (throw (ex-info "start! must not spawn when already :connected" {})))]
+        (is (nil? (copilot/start! c)))))))
 
 ;; =============================================================================
 ;; Protocol Tests (Unit)

--- a/test/github/copilot_sdk_test.clj
+++ b/test/github/copilot_sdk_test.clj
@@ -1,6 +1,7 @@
 (ns github.copilot-sdk-test
   (:require [clojure.test :refer [deftest is testing]]
             [github.copilot-sdk :as copilot]
+            [github.copilot-sdk.helpers :as h]
             [github.copilot-sdk.protocol :as proto]
             [github.copilot-sdk.specs :as specs]
             [github.copilot-sdk.util :as util]
@@ -261,6 +262,23 @@
   (testing "result-rejected"
     (let [r (copilot/result-rejected "User rejected")]
       (is (= "rejected" (:result-type r))))))
+
+(deftest ensure-client-honors-requested-opts-test
+  ;; Regression: the shared-client initializer must create the first client with
+  ;; the caller-supplied :client options (e.g. a custom :cli-path or :env), per
+  ;; the documented contract ("First query initializes the client with provided
+  ;; :client options"). Stub start! so no CLI is spawned; the client constructor
+  ;; itself does not spawn, so the option-threading logic is exercised in full.
+  (let [state-atom @#'h/client-state
+        saved @state-atom]
+    (try
+      (reset! state-atom nil)
+      (with-redefs [copilot/start! (fn [c] c)]
+        (let [c (#'h/ensure-client! {:cli-path "custom-copilot-xyz"})]
+          (is (= "custom-copilot-xyz" (:cli-path (copilot/client-options c)))
+              "first-use client must honor the requested :cli-path")))
+      (finally
+        (reset! state-atom saved)))))
 
 ;; =============================================================================
 ;; Protocol Tests (Unit)


### PR DESCRIPTION
Phase 3 of the **1.0.0 GA pre-release validation** pass — the idiomatic-Clojure / state-management / API-ergonomics review. Scope is deliberately held to GA-relevant **correctness, races, and one-way-door API** decisions; cosmetic refactors are left for 1.1.

Sits on top of `main`, which already carries the squash-merged Phase 0–2 work from https://github.com/copilot-community-sdk/copilot-sdk-clojure/pull/125.

## Correctness / race fixes

- **`start!` no longer double-spawns under concurrency.** The old check-then-act could let two concurrent `start!` calls each spawn a CLI process. Now an atomic `swap-vals!` CAS elects a single starter; losers no-op. The same guard is applied to the test-only `connect-with-streams!`.
- **`disconnect!` is atomically idempotent, and `remove-session!` closes after it dissocs.** `disconnect!` claims `:destroyed?` via `swap-vals!` so only the first caller issues the `session.destroy` RPC and closes the channel. `remove-session!` now captures the event channel, removes the session from the registry, *then* closes — so the router can never resolve a session and offer onto an already-closing channel. The regression test runs **100 iterations** because the race was only ~45% observable per run on the old code; a single-shot test would flake.
- **`ensure-client!` honors the caller's options on first shared-client creation** instead of discarding them.

## State cleanup

- **Removed the `:force-stopping?` flag** — it was written by `force-stop!` and initialized in `initial-state`, but never read anywhere. `:stopping?` (read by the process-exit watcher) is untouched.

## API

- **BREAKING: `unsubscribe-events` → `unsubscribe-events!`.** It untaps and closes the channel, so it now carries the `!` mutation suffix to match the rest of the SDK. Behavior is unchanged.
- **New `<send-and-wait!`** — the channel-based counterpart to `send-and-wait!` for use inside `go` blocks. It yields the final assistant-message **event** (metadata, id, content), whereas the existing `<send!` yields only the content string.

## Docs

- The `ping` docstrings now state the dual ISO-string / epoch-millis `:timestamp` contract as a present-tense fact (keeping the upstream PR #1340 provenance) rather than narrating older CLI behavior.

## Deliberately not done here

- Privatizing the session.clj `handle-*` / `dispatch-event!` / `remove-session!` / `set-*` helpers was rejected: they're called cross-namespace from the client.clj router, so `defn-` would break compilation. They're already outside the GA contract (not re-exported).
- `config` stays public because it's re-exported as `session-config`; the `set-model!` / `switch-model!` pair is intentional `setModel` / `switchModel` upstream parity.
- The JSON-RPC write-path buffer-copy simplification is tracked for post-GA in https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/128. Helpers `:client` overload and the remaining state-audit teardown-race items also stay post-GA.

## Reviewer heads-up

Commit `bd9f013` is titled for the `:force-stopping?` removal but also contains the `disconnect!` / `remove-session!` race fixes and their 100-iteration test. The commits aren't being rewritten (no-history-rewrite policy), so reviewing commit-by-commit will show that bundling.

Full plan and Phase 3 closeout table: session `plan.md` at `~/.copilot/session-state/008a79b4-5881-4d4c-8e1c-159f19ec3836/plan.md`.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>
