### PR TITLE
docs: GA Phase 4 — document observability, fix stale docstrings, harden doc validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ All notable changes to this project will be documented in this file. This change
   range are Go/Java/CI/release plumbing and E2E test de-flaking — nothing to
   port. This SDK is therefore at full API/wire/schema parity with upstream GA.
 
+### Documentation
+- **Documented observability/telemetry.** Added an Observability section to the
+  API reference covering the client `:telemetry` map (OpenTelemetry export:
+  `:otlp-endpoint`, `:file-path`, `:exporter-type`, `:source-name`,
+  `:capture-content?`), the client `:on-get-trace-context` distributed-trace hook,
+  and the session `:enable-session-telemetry?` flag. These options were already
+  implemented but undocumented in the API reference.
+- **Documented `:on-exit-plan-mode` and `:on-auto-mode-switch`** session config
+  handlers (upstream PR #1228) in the API reference, plus added option-table rows
+  for `:telemetry` and `:on-get-trace-context` to the client constructor.
+- **Corrected stale docstrings.** The top-level `create-session`,
+  `resume-session`, and `join-session` docstrings claimed `:on-permission-request`
+  was **required**; it has been **optional** since upstream PR #1308. Docstrings
+  now match the implementation.
+- **Added a Features navigation map** to the documentation hub and a durable
+  `doc/upstream-doc-gap-matrix.md` recording per-topic coverage versus the
+  upstream SDK docs.
+- **Doc validation now covers `doc/`-root pages.** `bb validate-docs` previously
+  skipped markdown files directly under `doc/` (e.g. `index.md`,
+  `getting-started.md`); it now validates them, and link extraction ignores
+  illustrative links inside inline-code spans.
+
 ### Security
 - **Validation exceptions no longer leak secrets.** Configuration validation
   failures (`client`, `create-session`, `resume-session`, and MCP-server checks)

--- a/doc/index.md
+++ b/doc/index.md
@@ -33,7 +33,7 @@ Quick links to the major SDK capabilities (see the [API Reference](reference/API
 - [Session Filesystem](reference/API.md#session-filesystem) — route filesystem operations through host-provided handlers. **Security note:** the host fully controls session file access.
 - Remote / cloud sessions (`:remote-session`, `:cloud`) and [fleet mode](reference/API.md#experimental-rpc-methods) — **experimental**; not covered by GA semver guarantees.
 
-
+## Reference
 
 - [API Reference](reference/API.md) — Complete API: helpers, client, session, events, tools
 - [Generated API Docs](api/index.html) — Codox-generated namespace documentation

--- a/doc/index.md
+++ b/doc/index.md
@@ -16,7 +16,24 @@ Clojure SDK for programmatic control of the GitHub Copilot CLI via JSON-RPC.
 - [MCP Debugging](mcp/debugging.md) — Troubleshooting MCP connections
 - [Custom Agents](guides/custom-agents.md) — Define specialized agents with scoped tools for sub-agent orchestration
 
-## Reference
+## Features
+
+Quick links to the major SDK capabilities (see the [API Reference](reference/API.md) for full detail):
+
+- [Streaming events](reference/API.md#streaming) — incremental assistant/reasoning deltas
+- [Tools](reference/API.md#tools) and [Tool Sets](reference/API.md#tool-sets) — expose and filter callable tools
+- [Session Hooks](reference/API.md#session-hooks) — pre/post tool-use and lifecycle interception
+- [UI Elicitation](reference/API.md#ui-elicitation) — `ask_user` / structured elicitation handlers
+- [File & Blob Attachments](reference/API.md#file-attachments) — image and binary input
+- [Custom Agents](guides/custom-agents.md) — specialized sub-agents with scoped tools
+- [BYOK Providers](auth/byok.md) — OpenAI, Azure, Anthropic, Ollama
+- [MCP Servers](mcp/overview.md) — Model Context Protocol integration
+- [Observability](reference/API.md#observability) — OpenTelemetry export and session telemetry. **Privacy note:** `:capture-content?` records prompt/response content and is **off by default** — enable only in trusted environments.
+- [Client Mode `:empty`](reference/API.md#client-mode-empty) — multi-tenant SaaS isolation. **Security note:** hardens sessions against local machine state; intended for hosts serving multiple users.
+- [Session Filesystem](reference/API.md#session-filesystem) — route filesystem operations through host-provided handlers. **Security note:** the host fully controls session file access.
+- Remote / cloud sessions (`:remote-session`, `:cloud`) and [fleet mode](reference/API.md#experimental-rpc-methods) — **experimental**; not covered by GA semver guarantees.
+
+
 
 - [API Reference](reference/API.md) — Complete API: helpers, client, session, events, tools
 - [Generated API Docs](api/index.html) — Codox-generated namespace documentation
@@ -25,6 +42,7 @@ Clojure SDK for programmatic control of the GitHub Copilot CLI via JSON-RPC.
 
 - [Style Guide](style.md) — Documentation authoring conventions
 - [Code Generation](codegen.md) — Schema-driven generation of clojure.spec definitions
+- [Upstream Doc Gap Matrix](upstream-doc-gap-matrix.md) — Per-topic coverage vs the upstream SDK docs
 - [AGENTS.md](../AGENTS.md) — Guidelines for AI agents working on this codebase
 - [PUBLISHING.md](../PUBLISHING.md) — Versioning, CI/CD workflows, release process, build attestation
 - [CHANGELOG](../CHANGELOG.md) — Version history

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -133,8 +133,8 @@ Get information about the current shared client state. Returns `nil` if no share
 | `:remote?` | boolean | `false` | When `true`, append `--remote` to the spawned CLI args so the CLI exposes the session over a GitHub-hosted remote endpoint. Ignored when `:cli-url` is set. (upstream PR #1192) |
 | `:session-idle-timeout-seconds` | integer | `0` (disabled) | Server-wide session idle timeout in seconds. When `> 0`, append `--session-idle-timeout <n>` to the spawned CLI so idle sessions are cleaned up after the given duration. |
 | `:on-list-models` | fn | nil | Zero-arg function returning model info maps. Bypasses `models.list` RPC; does not require `start!`. Results are cached the same way as RPC results |
-| `:telemetry` | map | nil | OpenTelemetry export config. When present, enables OTel on the spawned CLI. Keys (all optional): `:otlp-endpoint` (OTLP HTTP endpoint), `:file-path` (write spans to a file), `:exporter-type` (exporter selection), `:source-name` (service/source name), `:capture-content?` (boolean — capture prompt/response content; **off by default for privacy**). See [Observability](#observability). (upstream PR #785) |
-| `:on-get-trace-context` | fn | nil | Zero-arg function returning `{:traceparent "..." :tracestate "..."}` to propagate a distributed-trace context into each session. Only `:traceparent` and `:tracestate` are forwarded. See [Observability](#observability) |
+| `:telemetry` | map | nil | OpenTelemetry export config, applied as environment variables to the **spawned** CLI (ignored when connecting to an existing server via `:cli-url` or a parent process via `:is-child-process?`, since no CLI is spawned). When present, enables OTel. Keys (all optional): `:otlp-endpoint` (OTLP HTTP endpoint), `:file-path` (write spans to a file), `:exporter-type` (exporter selection), `:source-name` (service/source name), `:capture-content?` (boolean — capture prompt/response content; **off by default for privacy**). See [Observability](#observability). (upstream PR #785) |
+| `:on-get-trace-context` | fn | nil | Zero-arg function returning `{:traceparent "..." :tracestate "..."}`, called per request (session create/resume and each message send) to propagate a distributed-trace context. Only `:traceparent` and `:tracestate` are forwarded. See [Observability](#observability) |
 | `:is-child-process?` | boolean | `false` | When `true`, connect via own stdio to a parent Copilot CLI process (no process spawning). Requires `:use-stdio?` `true`; mutually exclusive with `:cli-url` |
 | `:session-fs` | map | nil | Session filesystem provider config. Keys: `:initial-cwd` (string, required), `:session-state-path` (string, required), `:conventions` (`"windows"` or `"posix"`, required). When set, the client calls `sessionFs.setProvider` on connect and routes filesystem operations through per-session handlers. See [Session Filesystem](#session-filesystem) |
 | `:mode` | keyword | `:copilot-cli` | Client multitenancy mode: `:copilot-cli` (default — preserve historical CLI behavior) or `:empty` (multi-tenant SaaS hosts that must isolate sessions from local machine state). In `:empty` mode the SDK requires at least one tenant-scoped storage root (`:copilot-home`, `:session-fs`, `:cli-url`, or `:is-child-process?`), sets `COPILOT_DISABLE_KEYTAR=1` on the spawned CLI, spreads 9 safe defaults under caller session config, forces `installedPlugins []`, and normalizes `:system-message` to strip `environment_context`. See [Client Mode](#client-mode-empty). (upstream PR #1428) |
@@ -1595,9 +1595,9 @@ When `:telemetry` is present the SDK sets `COPILOT_OTEL_ENABLED=true` on the CLI
 #### Distributed trace propagation (`:on-get-trace-context`)
 
 To stitch CLI spans into a caller-managed distributed trace, provide a zero-arg
-`:on-get-trace-context` function in the **client** options. The SDK calls it to capture a
-fresh trace context for session operations (session create, resume, and each message
-send), forwarding only `:traceparent` and `:tracestate`:
+`:on-get-trace-context` function in the **client** options. The SDK calls it **per request**
+to capture a fresh trace context — on session create, session resume, and every message
+send — forwarding only `:traceparent` and `:tracestate`:
 
 ```clojure
 (def client

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -267,7 +267,7 @@ Create a client and session together, ensuring both are cleaned up on exit.
 | `:on-elicitation-request` | fn | Handler for elicitation requests from the agent. When provided, advertises `requestElicitation=true` and handles `elicitation.requested` broadcast events. Single-arg handler receives an `ElicitationContext` map with `:session-id`, `:message`, `:requested-schema`, `:mode`, `:elicitation-source`, `:url`. Returns an `ElicitationResult` map `{:action "accept"/"decline"/"cancel" :content {...}}`. See [Elicitation Provider](#elicitation-provider) |
 | `:on-exit-plan-mode` | fn | Handler for `exitPlanMode.request` RPCs — invoked when the agent asks to leave plan mode. When provided, advertises `requestExitPlanMode=true`. Receives the request map; returns the approval result. (upstream PR #1228) |
 | `:on-auto-mode-switch` | fn | Handler for `autoModeSwitch.request` RPCs — invoked when the agent asks to switch autonomy mode. When provided, advertises `requestAutoModeSwitch=true`. Receives the request map; returns the approval result. (upstream PR #1228) |
-| `:enable-session-telemetry?` | boolean | Enable/disable the CLI's **internal** session telemetry (distinct from the client `:telemetry` OpenTelemetry export). Defaults to enabled for GitHub-authenticated sessions; always disabled when a BYOK `:provider` is set. Wire-encoded as `enableSessionTelemetry`. See [Observability](#observability). (upstream PR #1224) |
+| `:enable-session-telemetry?` | boolean | Enable/disable the CLI's **internal** session telemetry (distinct from the client `:telemetry` OpenTelemetry export). Defaults to enabled for GitHub-authenticated sessions; always disabled when a BYOK `:provider` is set; defaulted to `false` in `:mode :empty` (caller can override). Wire-encoded as `enableSessionTelemetry`. See [Observability](#observability). (upstream PR #1224) |
 | `:create-session-fs-handler` | fn | Factory for session filesystem providers. Required when `:session-fs` is set on the client. Called as `(factory session)`, returns a provider-style map or a low-level handler map. See [Session Filesystem](#session-filesystem) |
 | `:enable-config-discovery` | boolean | Auto-discover `.mcp.json`, `.vscode/mcp.json`, skills, etc. Instruction files always load regardless. (upstream PR #1044) |
 | `:model-capabilities` | map | Model capabilities override. DeepPartial of model capabilities, e.g. `{:model-supports {:supports-vision true}}`. (upstream PR #1029) |
@@ -1595,8 +1595,9 @@ When `:telemetry` is present the SDK sets `COPILOT_OTEL_ENABLED=true` on the CLI
 #### Distributed trace propagation (`:on-get-trace-context`)
 
 To stitch CLI spans into a caller-managed distributed trace, provide a zero-arg
-`:on-get-trace-context` function in the **client** options. It is called per session and
-returns a W3C trace-context map; only `:traceparent` and `:tracestate` are forwarded:
+`:on-get-trace-context` function in the **client** options. The SDK calls it to capture a
+fresh trace context for session operations (session create, resume, and each message
+send), forwarding only `:traceparent` and `:tracestate`:
 
 ```clojure
 (def client
@@ -1611,7 +1612,9 @@ returns a W3C trace-context map; only `:traceparent` and `:tracestate` are forwa
 `:enable-session-telemetry?` is a **session** config flag that controls the CLI's own
 internal usage telemetry — independent of the OpenTelemetry export above. It defaults to
 enabled for GitHub-authenticated sessions and is **always disabled** when a BYOK
-`:provider` is configured. Set it to `false` to opt out:
+`:provider` is configured. In `:mode :empty` it is defaulted to `false` as one of the
+multi-tenant hardening defaults (the caller can still set it explicitly). Set it to
+`false` to opt out:
 
 ```clojure
 (def session

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -133,6 +133,8 @@ Get information about the current shared client state. Returns `nil` if no share
 | `:remote?` | boolean | `false` | When `true`, append `--remote` to the spawned CLI args so the CLI exposes the session over a GitHub-hosted remote endpoint. Ignored when `:cli-url` is set. (upstream PR #1192) |
 | `:session-idle-timeout-seconds` | integer | `0` (disabled) | Server-wide session idle timeout in seconds. When `> 0`, append `--session-idle-timeout <n>` to the spawned CLI so idle sessions are cleaned up after the given duration. |
 | `:on-list-models` | fn | nil | Zero-arg function returning model info maps. Bypasses `models.list` RPC; does not require `start!`. Results are cached the same way as RPC results |
+| `:telemetry` | map | nil | OpenTelemetry export config. When present, enables OTel on the spawned CLI. Keys (all optional): `:otlp-endpoint` (OTLP HTTP endpoint), `:file-path` (write spans to a file), `:exporter-type` (exporter selection), `:source-name` (service/source name), `:capture-content?` (boolean — capture prompt/response content; **off by default for privacy**). See [Observability](#observability). (upstream PR #785) |
+| `:on-get-trace-context` | fn | nil | Zero-arg function returning `{:traceparent "..." :tracestate "..."}` to propagate a distributed-trace context into each session. Only `:traceparent` and `:tracestate` are forwarded. See [Observability](#observability) |
 | `:is-child-process?` | boolean | `false` | When `true`, connect via own stdio to a parent Copilot CLI process (no process spawning). Requires `:use-stdio?` `true`; mutually exclusive with `:cli-url` |
 | `:session-fs` | map | nil | Session filesystem provider config. Keys: `:initial-cwd` (string, required), `:session-state-path` (string, required), `:conventions` (`"windows"` or `"posix"`, required). When set, the client calls `sessionFs.setProvider` on connect and routes filesystem operations through per-session handlers. See [Session Filesystem](#session-filesystem) |
 | `:mode` | keyword | `:copilot-cli` | Client multitenancy mode: `:copilot-cli` (default — preserve historical CLI behavior) or `:empty` (multi-tenant SaaS hosts that must isolate sessions from local machine state). In `:empty` mode the SDK requires at least one tenant-scoped storage root (`:copilot-home`, `:session-fs`, `:cli-url`, or `:is-child-process?`), sets `COPILOT_DISABLE_KEYTAR=1` on the spawned CLI, spreads 9 safe defaults under caller session config, forces `installedPlugins []`, and normalizes `:system-message` to strip `environment_context`. See [Client Mode](#client-mode-empty). (upstream PR #1428) |
@@ -263,6 +265,9 @@ Create a client and session together, ensuring both are cleaned up on exit.
 | `:agent` | string | Name of a custom agent to activate at session start. Must match a name in `:custom-agents`. Equivalent to calling `agent.select` after creation. |
 | `:on-event` | fn | Event handler (1-arg fn receiving event maps). Registered before the RPC call, guaranteeing early events like `session.start` are not missed. |
 | `:on-elicitation-request` | fn | Handler for elicitation requests from the agent. When provided, advertises `requestElicitation=true` and handles `elicitation.requested` broadcast events. Single-arg handler receives an `ElicitationContext` map with `:session-id`, `:message`, `:requested-schema`, `:mode`, `:elicitation-source`, `:url`. Returns an `ElicitationResult` map `{:action "accept"/"decline"/"cancel" :content {...}}`. See [Elicitation Provider](#elicitation-provider) |
+| `:on-exit-plan-mode` | fn | Handler for `exitPlanMode.request` RPCs — invoked when the agent asks to leave plan mode. When provided, advertises `requestExitPlanMode=true`. Receives the request map; returns the approval result. (upstream PR #1228) |
+| `:on-auto-mode-switch` | fn | Handler for `autoModeSwitch.request` RPCs — invoked when the agent asks to switch autonomy mode. When provided, advertises `requestAutoModeSwitch=true`. Receives the request map; returns the approval result. (upstream PR #1228) |
+| `:enable-session-telemetry?` | boolean | Enable/disable the CLI's **internal** session telemetry (distinct from the client `:telemetry` OpenTelemetry export). Defaults to enabled for GitHub-authenticated sessions; always disabled when a BYOK `:provider` is set. Wire-encoded as `enableSessionTelemetry`. See [Observability](#observability). (upstream PR #1224) |
 | `:create-session-fs-handler` | fn | Factory for session filesystem providers. Required when `:session-fs` is set on the client. Called as `(factory session)`, returns a provider-style map or a low-level handler map. See [Session Filesystem](#session-filesystem) |
 | `:enable-config-discovery` | boolean | Auto-discover `.mcp.json`, `.vscode/mcp.json`, skills, etc. Instruction files always load regardless. (upstream PR #1044) |
 | `:model-capabilities` | map | Model capabilities override. DeepPartial of model capabilities, e.g. `{:model-supports {:supports-vision true}}`. (upstream PR #1029) |
@@ -1555,6 +1560,67 @@ When `:streaming? true`:
 - `:copilot/assistant.reasoning_delta` events contain incremental reasoning in `:delta-content` (model-dependent)
 - Accumulate delta values to build the full response progressively
 - The final `:copilot/assistant.message` event always contains the complete content
+
+---
+
+## Observability
+
+The SDK supports two independent telemetry mechanisms.
+
+### OpenTelemetry export (client `:telemetry`)
+
+Pass a `:telemetry` map in the **client** options to enable OpenTelemetry export on the
+spawned CLI. Presence of the map enables OTel; all sub-keys are optional:
+
+```clojure
+(def client
+  (copilot/client
+    {:telemetry {:otlp-endpoint "http://localhost:4318"
+                 :exporter-type "otlp"
+                 :source-name   "my-app"
+                 :capture-content? false}}))
+```
+
+| Key | Type | Description | CLI env var |
+|-----|------|-------------|-------------|
+| `:otlp-endpoint` | string | OTLP HTTP endpoint to export spans to | `OTEL_EXPORTER_OTLP_ENDPOINT` |
+| `:file-path` | string | Write spans to a local file instead of/alongside OTLP | `COPILOT_OTEL_FILE_EXPORTER_PATH` |
+| `:exporter-type` | string | Exporter selection | `COPILOT_OTEL_EXPORTER_TYPE` |
+| `:source-name` | string | Service / source name attached to spans | `COPILOT_OTEL_SOURCE_NAME` |
+| `:capture-content?` | boolean | Capture prompt/response content in spans. **Defaults to off** — only enable in trusted environments, as it records message content | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` |
+
+When `:telemetry` is present the SDK sets `COPILOT_OTEL_ENABLED=true` on the CLI process.
+(upstream PR #785)
+
+#### Distributed trace propagation (`:on-get-trace-context`)
+
+To stitch CLI spans into a caller-managed distributed trace, provide a zero-arg
+`:on-get-trace-context` function in the **client** options. It is called per session and
+returns a W3C trace-context map; only `:traceparent` and `:tracestate` are forwarded:
+
+```clojure
+(def client
+  (copilot/client
+    {:on-get-trace-context
+     (fn [] {:traceparent "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+             :tracestate  "rojo=00f067aa0ba902b7"})}))
+```
+
+### Internal session telemetry (`:enable-session-telemetry?`)
+
+`:enable-session-telemetry?` is a **session** config flag that controls the CLI's own
+internal usage telemetry — independent of the OpenTelemetry export above. It defaults to
+enabled for GitHub-authenticated sessions and is **always disabled** when a BYOK
+`:provider` is configured. Set it to `false` to opt out:
+
+```clojure
+(def session
+  (copilot/create-session client
+    {:enable-session-telemetry? false
+     :on-permission-request copilot/approve-all}))
+```
+
+(upstream PR #1224)
 
 ---
 

--- a/doc/upstream-doc-gap-matrix.md
+++ b/doc/upstream-doc-gap-matrix.md
@@ -1,0 +1,111 @@
+# Upstream Documentation Gap Matrix
+
+This matrix maps every page in the upstream [`github/copilot-sdk`](https://github.com/github/copilot-sdk)
+`docs/**` tree to its coverage in this Clojure SDK, with a per-topic decision. It exists so
+GA reviewers (and future maintainers) can see, at a glance, which upstream topics are
+ported, adapted, intentionally folded into the API reference, deferred, or not applicable.
+
+**Decision legend**
+
+- **Adapted** — covered by a dedicated Clojure doc page (Clojure-idiomatic rewrite, not a copy).
+- **Folded** — the capability is documented, but inside [`reference/API.md`](reference/API.md)
+  (config-table rows or a topical section) rather than a standalone page. The stable API is
+  documented; a separate narrative page is post-GA polish.
+- **Deferred (post-GA)** — host-architecture / conceptual guidance that does not document a
+  stable SDK API surface. No GA blocker; tracked for a later docs pass.
+- **N-A** — not applicable to the Clojure SDK (index pages, or other-language integrations).
+
+GA gate: every **stable** public API is documented (Adapted or Folded). Deferred items are
+narrative/architecture guidance only — none gates a stable API.
+
+## auth/
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `auth/index.md` | Adapted | [`auth/index.md`](auth/index.md) |
+| `auth/authenticate.md` | Adapted | [`auth/index.md`](auth/index.md) (auth methods + priority order) |
+| `auth/byok.md` | Adapted | [`auth/byok.md`](auth/byok.md) |
+
+## features/
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `features/index.md` | N-A | Index — see [`index.md`](index.md) Features section |
+| `features/agent-loop.md` | Folded | Conceptual; reflected in API.md [Event Types](reference/API.md#event-types) + [Streaming](reference/API.md#streaming) |
+| `features/streaming-events.md` | Folded | API.md [Streaming](reference/API.md#streaming) |
+| `features/hooks.md` | Folded | API.md [Session Hooks](reference/API.md#session-hooks) |
+| `features/mcp.md` | Adapted | [`mcp/overview.md`](mcp/overview.md) |
+| `features/custom-agents.md` | Adapted | [`guides/custom-agents.md`](guides/custom-agents.md) |
+| `features/skills.md` | Folded | API.md [Config Directory and Skills](reference/API.md#config-directory-and-skills) + `:skill-directories`/`:enable-skills`/`:disabled-skills` |
+| `features/image-input.md` | Folded | API.md [File Attachments](reference/API.md#file-attachments) / [Blob Attachments](reference/API.md#blob-attachments) |
+| `features/session-persistence.md` | Folded | API.md `resume-session`, `list-sessions`, `get-session-metadata` |
+| `features/steering-and-queueing.md` | Folded | API.md `send!` `:mode` (`:enqueue`/`:immediate`) |
+| `features/plugin-directories.md` | Folded | API.md `:plugin-directories` config row |
+| `features/remote-sessions.md` | Folded (experimental) | API.md `:remote?` / `:remote-session` config rows |
+| `features/cloud-sessions.md` | Folded (experimental) | API.md `:cloud` config row |
+| `features/fleet-mode.md` | Folded (experimental) | API.md [Experimental RPC Methods](reference/API.md#experimental-rpc-methods) (`session/fleet-start!`) |
+
+## hooks/
+
+Upstream splits hooks across six pages; the Clojure SDK consolidates them into a single
+API.md section. The stable hook API (registration, pre/post-tool-use, lifecycle,
+user-prompt-submitted, short-circuit semantics) is documented; per-hook narrative pages are
+post-GA polish.
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `hooks/index.md` | N-A | Index |
+| `hooks/hooks-overview.md` | Folded | API.md [Session Hooks](reference/API.md#session-hooks) |
+| `hooks/pre-tool-use.md` | Folded | API.md [Session Hooks](reference/API.md#session-hooks) |
+| `hooks/post-tool-use.md` | Folded | API.md [Session Hooks](reference/API.md#session-hooks) |
+| `hooks/user-prompt-submitted.md` | Folded | API.md [Session Hooks](reference/API.md#session-hooks) |
+| `hooks/session-lifecycle.md` | Folded | API.md [Session Hooks](reference/API.md#session-hooks) + `on-lifecycle-event` |
+| `hooks/error-handling.md` | Folded | API.md [Session Hooks](reference/API.md#session-hooks) + [Error Handling](reference/API.md#error-handling) |
+
+## observability/
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `observability/index.md` | Folded | API.md [Observability](reference/API.md#observability) |
+| `observability/opentelemetry.md` | Folded | API.md [Observability](reference/API.md#observability) (client `:telemetry`, `:on-get-trace-context`, session `:enable-session-telemetry?`) |
+
+## setup/
+
+Upstream setup pages are largely Node/host-deployment architecture guidance. The Clojure
+SDK documents the stable setup surface (client options, auth) in the API reference and
+getting-started; deep host-architecture guides are deferred.
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `setup/index.md` | N-A | Index |
+| `setup/local-cli.md` | Folded | [`getting-started.md`](getting-started.md) + API.md `:cli-path` |
+| `setup/bundled-cli.md` | N-A | Node-specific CLI bundling; the Clojure SDK uses an external CLI via `:cli-path` |
+| `setup/github-oauth.md` | Adapted | [`auth/index.md`](auth/index.md) |
+| `setup/azure-managed-identity.md` | Adapted | [`auth/azure-managed-identity.md`](auth/azure-managed-identity.md) |
+| `setup/multi-tenancy.md` | Folded | API.md [Client Mode (Empty)](reference/API.md#client-mode-empty) |
+| `setup/choosing-a-setup-path.md` | Deferred (post-GA) | Conceptual setup-selection guide |
+| `setup/backend-services.md` | Deferred (post-GA) | Host-architecture guidance, not an SDK API |
+| `setup/scaling.md` | Deferred (post-GA) | Host-architecture guidance, not an SDK API |
+
+## troubleshooting/
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `troubleshooting/index.md` | N-A | Index |
+| `troubleshooting/mcp-debugging.md` | Adapted | [`mcp/debugging.md`](mcp/debugging.md) |
+| `troubleshooting/debugging.md` | Folded | [`mcp/debugging.md`](mcp/debugging.md) + `:log-level` client option |
+| `troubleshooting/compatibility.md` | Deferred (post-GA) | CLI/JVM/Clojure compatibility matrix (Phase 0.75 follow-up) |
+
+## integrations/
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `integrations/index.md` | N-A | Index |
+| `integrations/microsoft-agent-framework.md` | N-A | .NET / Python Microsoft Agent Framework integration; not applicable to the Clojure SDK |
+
+## Top-level
+
+| Upstream page | Decision | Clojure coverage |
+|---------------|----------|------------------|
+| `index.md` | Adapted | [`index.md`](index.md) |
+| `getting-started.md` | Adapted | [`getting-started.md`](getting-started.md) |

--- a/script/validate_docs.clj
+++ b/script/validate_docs.clj
@@ -14,9 +14,11 @@
 (def doc-files
   "Markdown files to validate."
   (->> (concat (fs/glob "." "doc/**/*.md")
+               (fs/glob "." "doc/*.md")
                (fs/glob "." "*.md")
                (fs/glob "." "examples/**/*.md"))
        (map str)
+       (distinct)
        (remove #(str/includes? % "doc/api/"))
        sort))
 
@@ -60,13 +62,15 @@
 ;; --- Link Validation ---
 
 (defn extract-md-links
-  "Extract [text](path) links from markdown content. Returns seq of {:text :path :line}."
+  "Extract [text](path) links from markdown content. Returns seq of {:text :path :line}.
+   Links inside inline-code spans (backtick-delimited) are illustrative, not real links,
+   and are skipped."
   [content]
   (let [lines (str/split-lines content)]
     (->> lines
          (map-indexed
           (fn [idx line]
-            (->> (re-seq #"\[([^\]]*)\]\(([^)]+)\)" line)
+            (->> (re-seq #"\[([^\]]*)\]\(([^)]+)\)" (str/replace line #"`[^`]*`" ""))
                  (map (fn [[_ text path]]
                         {:text text :path path :line (inc idx)})))))
          (apply concat))))

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -465,8 +465,12 @@
 (defn create-session
   "Create a new conversation session.
 
-   Config options (`:on-permission-request` is **required**):
-   - :on-permission-request - Permission handler function (**required**, e.g. `approve-all`)
+   `:on-permission-request` is **optional** (since upstream PR #1308) — omit it to
+   leave permission requests pending for manual resolution via
+   `handle-pending-permission-request!`. Commonly-used config options:
+   - :on-permission-request - Permission handler function (optional, e.g. `approve-all`).
+                             When omitted, permission requests surface as
+                             `:copilot/permission.requested` events and stay pending.
    - :session-id           - Custom session ID
    - :model                - Model to use (e.g., \"gpt-5.4\", \"claude-sonnet-4.5\")
    - :tools                - Vector of tool definitions (use define-tool)
@@ -478,12 +482,14 @@
    - :mcp-servers          - MCP server configs map (keyed by server ID)
    - :custom-agents        - Custom agent configs
    - :default-agent        - Built-in agent config, e.g. {:excluded-tools [\"private_tool\"]}
-   - :config-dir           - Override config directory for CLI (configDir)
    - :skill-directories    - Additional skill directories to load
    - :disabled-skills      - Disable specific skills by name
-   - :large-output         - (Experimental) Tool output handling config {:enabled :max-size-bytes :output-dir}
-                             Note: CLI protocol feature, not in official SDK. outputDir may be ignored.
    - :working-directory    - Working directory for the session (tool operations relative to this)
+
+   See the [API reference](https://github.com/copilot-community-sdk/copilot-sdk-clojure/blob/main/doc/reference/API.md)
+   for the complete, current option list (including observability/telemetry, trace
+   context, exit-plan-mode / auto-mode-switch handlers, skills, plugins, remote, and
+   cloud session options).
 
    Example:
    ```clojure
@@ -611,7 +617,8 @@
    plus:
    - :disable-resume?  - When true, skip emitting the session.resume event (default: false)
 
-   `:on-permission-request` is **required**.
+   `:on-permission-request` is **optional** (since upstream PR #1308) — omit it to
+   leave permission requests pending for manual resolution.
 
    Example:
    ```clojure
@@ -651,7 +658,8 @@
    Reads the SESSION_ID environment variable and connects to the parent CLI process
    via stdio. Intended for extensions spawned by the Copilot CLI.
 
-   Config is the same as `resume-session` (`:on-permission-request` is **required**).
+   Config is the same as `resume-session`. `:on-permission-request` is **optional**;
+   when omitted, join-session uses `default-join-session-permission-handler`.
    The `:disable-resume?` option defaults to true.
 
    Returns a map with `:client` and `:session` keys. The caller is responsible for

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -486,10 +486,9 @@
    - :disabled-skills      - Disable specific skills by name
    - :working-directory    - Working directory for the session (tool operations relative to this)
 
-   See the [API reference](https://github.com/copilot-community-sdk/copilot-sdk-clojure/blob/main/doc/reference/API.md)
-   for the complete, current option list (including observability/telemetry, trace
-   context, exit-plan-mode / auto-mode-switch handlers, skills, plugins, remote, and
-   cloud session options).
+   See the API reference (doc/reference/API.md in this repository) for the complete,
+   current option list (including observability/telemetry, trace context, exit-plan-mode /
+   auto-mode-switch handlers, skills, plugins, remote, and cloud session options).
 
    Example:
    ```clojure


### PR DESCRIPTION
Phase 4 (documentation completeness) of the 1.0.0 GA pre-release pass. Closes the gap between the implemented API surface and the docs, and hardens doc validation.

## What this does

- **Documents observability/telemetry.** OpenTelemetry export (client `:telemetry` map), distributed-trace propagation (`:on-get-trace-context`), and the CLI's internal session telemetry (`:enable-session-telemetry?`) were all implemented but missing from the API reference. Adds an Observability section plus the corresponding client/session option-table rows. Also documents the `:on-exit-plan-mode` / `:on-auto-mode-switch` session handlers (upstream PR #1228).
- **Fixes incorrect docstrings.** The top-level `create-session` / `resume-session` / `join-session` docstrings stated `:on-permission-request` was *required*. It has been *optional* since upstream PR #1308 (omit it to leave permission requests pending for manual resolution). The implementation docstrings were already correct; only the public re-export wrappers were stale.
- **Adds a Features nav map** to the documentation hub with privacy/security notes on sensitive features (telemetry content capture, `:empty` client mode, session filesystem) and an experimental marker for remote/cloud/fleet sessions.
- **Adds a durable per-topic gap matrix** (`doc/upstream-doc-gap-matrix.md`) mapping all 43 upstream `docs/**` pages to a coverage decision (Adapted / Folded into the API reference / Deferred post-GA / N-A), so GA reviewers can audit coverage against upstream at a glance.
- **Closes a doc-validation hole.** `bb validate-docs` globbed `doc/**/*.md`, which silently skipped every markdown file directly under `doc/` (including `index.md` and `getting-started.md`). The widened glob raises coverage from 12 to 17 files and immediately surfaced a latent broken link, now fixed.

## Non-obvious notes

- The validator now ignores `[text](path)` links inside inline-code spans: the style guide documents link *forms* as backtick-wrapped examples, which are documentation, not navigable links. Without this, the wider glob produces a false positive on the style guide's own examples.
- Telemetry support was nearly mis-reported as absent here due to a bad grep during investigation; it is in fact fully wired (`process.clj` maps `:telemetry` to `COPILOT_OTEL_*` / `OTEL_*` env vars). The fix was purely documentation.
- Deliberate non-goals: full example-runner coverage is deferred to Phase 5; codox (`bb docs`) regeneration is deferred to Phase 6, intentionally after these docstring corrections so the generated HTML picks them up.

Session plan: this is Phase 4 of the GA validation plan tracked in the session `plan.md`.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>
