### PR TITLE
examples: add manual tool resume + complete the example runner (GA Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Added (examples)
+- **New `manual_tool_resume` example** (`examples/manual_tool_resume.clj`),
+  the SDK-driven analogue of the upstream `manual_tool_resume` sample. It
+  demonstrates a declaration-only tool (defined without a `:handler`, upstream
+  PR #1308) whose pending permission request and pending tool call are resolved
+  by hand via `handle-pending-permission-request!` and
+  `handle-pending-tool-call!`, subscribing to events before each trigger with a
+  bounded wait.
+- **`run-all-examples.sh` now runs `ask_user_failure` and `manual_tool_resume`**
+  (19 CLI-only examples total) and documents why `byok_provider`, `empty_mode`,
+  and `mcp_local_server` are excluded (they require a provider API key or
+  `npx`/network setup). `examples/README.md` updated to match.
+
 ### Changed (v1.0.0 GA sync)
 - **Synced version to upstream GA `v1.0.0`** (`1.0.0-beta.12.0` -> `1.0.0.0`).
   Upstream's `v1.0.0` release is functionally identical to `v1.0.0-beta.12` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ All notable changes to this project will be documented in this file. This change
   the SDK-driven analogue of the upstream `manual_tool_resume` sample. It
   demonstrates a declaration-only tool (defined without a `:handler`, upstream
   PR #1308) whose pending permission request and pending tool call are resolved
-  by hand via `handle-pending-permission-request!` and
-  `handle-pending-tool-call!`, subscribing to events before each trigger with a
-  bounded wait.
+  by hand across three separate client lifecycles via `resume-session` with
+  `:continue-pending-work? true` — resolving the original request ids with
+  `handle-pending-permission-request!` and `handle-pending-tool-call!`,
+  subscribing to events before each trigger with a bounded wait. Each lifecycle
+  suspends gracefully with `disconnect!` (which persists the in-flight pending
+  requests) rather than force-killing the client.
 - **`run-all-examples.sh` now runs `ask_user_failure` and `manual_tool_resume`**
   (19 CLI-only examples total) and documents why `byok_provider`, `empty_mode`,
   and `mcp_local_server` are excluded (they require a provider API key or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file. This change
   suspends gracefully with `disconnect!` (which persists the in-flight pending
   requests) rather than force-killing the client.
 - **`run-all-examples.sh` now runs `ask_user_failure` and `manual_tool_resume`**
-  (19 CLI-only examples total) and documents why `byok_provider`, `empty_mode`,
+  (18 CLI-only example files; 19 runs total, since `helpers-query` runs twice)
+  and documents why `byok_provider`, `empty_mode`,
   and `mcp_local_server` are excluded (they require a provider API key or
   `npx`/network setup). `examples/README.md` updated to match.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -928,15 +928,19 @@ sample (Python/.NET): a tool declared **without** a `:handler` is
 *declaration-only* — the runtime advertises it to the model but leaves the
 call pending for the application to resolve by hand. With no
 `:on-permission-request` handler registered either, the permission prompt is
-also left pending.
+also left pending. The pending requests are resolved across **three separate
+client lifecycles** via `resume-session` with `:continue-pending-work? true`.
 
 ### What It Demonstrates
 
 - Defining a declaration-only tool (no `:handler`) — upstream PR #1308
+- Resuming pending work across client lifecycles with `resume-session` +
+  `:continue-pending-work? true`, resolving the **original** request ids
 - Reading the `:request-id` from `:copilot/permission.requested` and resolving
-  it with `handle-pending-permission-request!` (`{:kind :approve-once}`)
+  it after resume with `handle-pending-permission-request!`
+  (`{:kind :approve-once}`)
 - Reading the `:request-id` from `:copilot/external_tool.requested` and
-  supplying the result with `handle-pending-tool-call!`
+  supplying the result after another resume with `handle-pending-tool-call!`
 - Subscribing to events **before** each trigger so no event is missed, with a
   bounded (120s) `alts!!` wait
 
@@ -947,10 +951,12 @@ clojure -A:examples -X manual-tool-resume/run
 clojure -A:examples -X manual-tool-resume/run :model '"gpt-5.4"'
 ```
 
-> The same pending requests can also be resolved after `resume-session` with
-> `:continue-pending-work? true` when the originating CLI process persists them
-> across resume. This example keeps everything in one client lifecycle so it
-> runs deterministically against any CLI build.
+> Each lifecycle ends by suspending the session with `disconnect!` rather than
+> force-killing the client. This demonstrates manual pending-work resolution
+> across graceful **suspend/resume**, not hard crash recovery: on CLI builds
+> where in-flight pending requests are persisted only during graceful teardown,
+> a SIGKILL (`force-stop!`) can drop the pending request ids before the next
+> `resume-session` can continue them.
 
 See [`doc/reference/API.md`](../doc/reference/API.md) for
 `handle-pending-permission-request!` and `handle-pending-tool-call!`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -98,7 +98,7 @@ Or run all examples:
 ./run-all-examples.sh
 ```
 
-> **Note:** `run-all-examples.sh` runs 19 examples that need only the Copilot CLI (examples 1–9, 12–19, and 21).
+> **Note:** `run-all-examples.sh` runs 18 example files that need only the Copilot CLI (examples 1–9, 12–19, and 21) — 19 runs in total, since `helpers-query` runs twice (`run` and `run-multi`).
 > Examples 10 (BYOK), 11 (MCP), and 20 (empty-mode — uses BYOK) require external dependencies (API keys, Node.js) and are run manually.
 
 With a custom CLI path:

--- a/examples/README.md
+++ b/examples/README.md
@@ -88,6 +88,9 @@ clojure -A:examples -X reasoning-effort/run
 
 # Empty (multitenancy) mode
 clojure -A:examples -X empty-mode/run
+
+# Manual tool resume (declaration-only tool, manual pending-call resolution)
+clojure -A:examples -X manual-tool-resume/run
 ```
 
 Or run all examples:
@@ -95,8 +98,8 @@ Or run all examples:
 ./run-all-examples.sh
 ```
 
-> **Note:** `run-all-examples.sh` runs 16 examples that need only the Copilot CLI (examples 1–9, 12–16, 18, and 19).
-> Examples 10 (BYOK), 11 (MCP), and 20 (empty-mode — uses BYOK) require external dependencies (API keys, Node.js), and example 17 (ask-user-failure) is excluded for reliability. Run these manually.
+> **Note:** `run-all-examples.sh` runs 19 examples that need only the Copilot CLI (examples 1–9, 12–19, and 21).
+> Examples 10 (BYOK), 11 (MCP), and 20 (empty-mode — uses BYOK) require external dependencies (API keys, Node.js) and are run manually.
 
 With a custom CLI path:
 ```bash
@@ -912,6 +915,45 @@ OPENAI_API_KEY=sk-... clojure -A:examples -X empty-mode/run :prompt '"What is Cl
 
 See [`doc/reference/API.md`](../doc/reference/API.md#client-mode-empty)
 for the full Client Mode reference.
+
+---
+
+## Example 21: Manual Tool Resume (`manual_tool_resume.clj`)
+
+**Difficulty:** Advanced
+**Concepts:** Declaration-only tools, manual permission resolution, manual tool-call resolution
+
+Demonstrates the SDK-driven analogue of the upstream `manual_tool_resume`
+sample (Python/.NET): a tool declared **without** a `:handler` is
+*declaration-only* — the runtime advertises it to the model but leaves the
+call pending for the application to resolve by hand. With no
+`:on-permission-request` handler registered either, the permission prompt is
+also left pending.
+
+### What It Demonstrates
+
+- Defining a declaration-only tool (no `:handler`) — upstream PR #1308
+- Reading the `:request-id` from `:copilot/permission.requested` and resolving
+  it with `handle-pending-permission-request!` (`{:kind :approve-once}`)
+- Reading the `:request-id` from `:copilot/external_tool.requested` and
+  supplying the result with `handle-pending-tool-call!`
+- Subscribing to events **before** each trigger so no event is missed, with a
+  bounded (120s) `alts!!` wait
+
+### Usage
+
+```bash
+clojure -A:examples -X manual-tool-resume/run
+clojure -A:examples -X manual-tool-resume/run :model '"gpt-5.4"'
+```
+
+> The same pending requests can also be resolved after `resume-session` with
+> `:continue-pending-work? true` when the originating CLI process persists them
+> across resume. This example keeps everything in one client lifecycle so it
+> runs deterministically against any CLI build.
+
+See [`doc/reference/API.md`](../doc/reference/API.md) for
+`handle-pending-permission-request!` and `handle-pending-tool-call!`.
 
 ---
 

--- a/examples/manual_tool_resume.clj
+++ b/examples/manual_tool_resume.clj
@@ -49,7 +49,7 @@
   (let [deadline (timeout 120000)]
     (try
       (loop []
-        (let [[event port] (alts!! [ch deadline])]
+        (let [[event port] (alts!! [ch deadline] :priority true)]
           (cond
             (= port deadline)
             (throw (ex-info "Timed out waiting for session event" {:event-type type-kw}))

--- a/examples/manual_tool_resume.clj
+++ b/examples/manual_tool_resume.clj
@@ -1,23 +1,29 @@
 (ns manual-tool-resume
-  "Demonstrates manually resolving a pending tool call (upstream PR #1308).
+  "Manually resolve pending tool calls across resume (upstream PR #1308).
 
    A tool declared without a `:handler` is *declaration-only*: the runtime
    advertises it to the model but, instead of executing anything locally, leaves
    the call pending and surfaces it to the application. With no
    `:on-permission-request` handler registered either, the permission prompt is
-   likewise left pending. The application drives the work forward by hand:
+   likewise left pending. The application drives the work forward by hand, and
+   the pending requests survive across separate client lifecycles via
+   `resume-session` with `:continue-pending-work? true`:
 
-   1. Ask the model to use the tool and wait for the pending permission request.
-   2. Resolve it with `handle-pending-permission-request!` (approve-once) and
-      wait for the resulting external tool request.
-   3. Supply the tool result with `handle-pending-tool-call!` and read the
-      model's final answer.
+   1. Lifecycle 1 — create a session, ask the model to use the tool, wait for the
+      pending permission request, then suspend.
+   2. Lifecycle 2 — resume, approve the pending permission with
+      `handle-pending-permission-request!`, wait for the pending tool request,
+      then suspend.
+   3. Lifecycle 3 — resume, supply the tool result with
+      `handle-pending-tool-call!`, and read the model's final answer.
 
    This is the SDK-driven analogue of the upstream `manual_tool_resume` sample.
-   The same pending requests can also be resolved after `resume-session` with
-   `:continue-pending-work? true` when the originating CLI process persists them;
-   this example keeps everything in one client lifecycle so it runs
-   deterministically against any CLI build."
+   It demonstrates manual pending-work resolution across graceful
+   **suspend/resume**, not hard crash recovery. Each lifecycle ends by suspending
+   the session with `disconnect!` rather than force-killing the client: on CLI
+   builds where in-flight pending requests are persisted only during graceful
+   teardown, a SIGKILL (`force-stop!`) can drop the pending request ids before the
+   next `resume-session` can continue them."
   (:require [clojure.core.async :refer [alts!! timeout]]
             [github.copilot-sdk :as copilot :refer [evt]]))
 
@@ -59,36 +65,65 @@
       (finally
         (copilot/unsubscribe-events! session ch)))))
 
+(defn- resolve-pending!
+  "Throw if a `handle-pending-*` call did not succeed. The whole point of the
+   example is that the original request ids resolve after resume, so a silent
+   `{:success false}` must surface loudly."
+  [result what]
+  (when-not (:success result)
+    (throw (ex-info (str "Failed to resolve pending " what) {:result result})))
+  result)
+
 (defn run
   [{:keys [model] :or {model "claude-haiku-4.5"}}]
-  (copilot/with-client-session
-    [session {:model model
-              :tools [tool]}]
-    ;; Step 1: ask for the tool, capture the pending permission request.
-    (let [permission-ch (copilot/subscribe-events session)]
-      (println "Step 1: asking the model to use the declaration-only tool...")
-      (copilot/send! session {:prompt (str "Use the manual_resume_status tool with id "
-                                           "'alpha', then tell me the status.")})
-      (let [permission (wait-for session (evt :permission.requested) permission-ch)
-            permission-id (get-in permission [:data :request-id])
-            ;; Subscribe BEFORE approving so the tool request cannot be missed.
-            tool-ch (copilot/subscribe-events session)]
-        (println "  pending permission request:" permission-id)
+  (let [config {:model model :tools [tool]}
+        ;; Lifecycle 1: ask for the tool, capture the pending permission, suspend.
+        {:keys [session-id permission-id]}
+        (copilot/with-client [client]
+          (let [session (copilot/create-session client config)
+                ;; Subscribe BEFORE sending so the permission event cannot be missed.
+                permission-ch (copilot/subscribe-events session)]
+            (println "Lifecycle 1: asking the model to use the declaration-only tool...")
+            (copilot/send! session {:prompt (str "Use the manual_resume_status tool with id "
+                                                 "'alpha', then tell me the status.")})
+            (let [permission (wait-for session (evt :permission.requested) permission-ch)
+                  permission-id (get-in permission [:data :request-id])]
+              (println "  pending permission request:" permission-id)
+              ;; Suspend gracefully so the pending request is flushed to disk.
+              (copilot/disconnect! session)
+              {:session-id (copilot/session-id session)
+               :permission-id permission-id})))
 
-        ;; Step 2: approve the pending permission, capture the pending tool call.
-        (println "Step 2: approving the pending permission...")
-        (copilot/handle-pending-permission-request!
-         session {:request-id permission-id :result {:kind :approve-once}})
-        (let [tool-event (wait-for session (evt :external_tool.requested) tool-ch
-                                   #(= (get-in % [:data :tool-name]) "manual_resume_status"))
-              tool-request-id (get-in tool-event [:data :request-id])
-              ;; Subscribe BEFORE resolving so the answer cannot be missed.
-              answer-ch (copilot/subscribe-events session)]
-          (println "  pending tool call:" tool-request-id)
+        ;; Lifecycle 2: resume, approve the permission, capture the pending tool call, suspend.
+        tool-request-id
+        (copilot/with-client [client]
+          (let [session (copilot/resume-session
+                         client session-id (assoc config :continue-pending-work? true))
+                ;; Subscribe BEFORE approving so the tool request cannot be missed.
+                tool-ch (copilot/subscribe-events session)]
+            (println "Lifecycle 2: resuming and approving the pending permission...")
+            (resolve-pending!
+             (copilot/handle-pending-permission-request!
+              session {:request-id permission-id :result {:kind :approve-once}})
+             "permission request")
+            (let [tool-event (wait-for session (evt :external_tool.requested) tool-ch
+                                       #(= (get-in % [:data :tool-name]) "manual_resume_status"))
+                  tool-request-id (get-in tool-event [:data :request-id])]
+              (println "  pending tool call:" tool-request-id)
+              (copilot/disconnect! session)
+              tool-request-id)))]
 
-          ;; Step 3: supply the tool result by hand, read the final answer.
-          (println "Step 3: supplying the tool result manually...")
-          (copilot/handle-pending-tool-call!
-           session {:request-id tool-request-id :result "MANUAL_STATUS_READY"})
-          (let [answer (wait-for session (evt :assistant.message) answer-ch)]
-            (println "🤖:" (get-in answer [:data :content]))))))))
+    ;; Lifecycle 3: resume, supply the tool result by hand, read the final answer.
+    (copilot/with-client [client]
+      (let [session (copilot/resume-session
+                     client session-id (assoc config :continue-pending-work? true))
+            ;; Subscribe BEFORE resolving so the answer cannot be missed.
+            answer-ch (copilot/subscribe-events session)]
+        (println "Lifecycle 3: resuming and supplying the tool result manually...")
+        (resolve-pending!
+         (copilot/handle-pending-tool-call!
+          session {:request-id tool-request-id :result "MANUAL_STATUS_READY"})
+         "tool call")
+        (let [answer (wait-for session (evt :assistant.message) answer-ch)]
+          (println "🤖:" (get-in answer [:data :content])))
+        (copilot/disconnect! session)))))

--- a/examples/manual_tool_resume.clj
+++ b/examples/manual_tool_resume.clj
@@ -1,0 +1,94 @@
+(ns manual-tool-resume
+  "Demonstrates manually resolving a pending tool call (upstream PR #1308).
+
+   A tool declared without a `:handler` is *declaration-only*: the runtime
+   advertises it to the model but, instead of executing anything locally, leaves
+   the call pending and surfaces it to the application. With no
+   `:on-permission-request` handler registered either, the permission prompt is
+   likewise left pending. The application drives the work forward by hand:
+
+   1. Ask the model to use the tool and wait for the pending permission request.
+   2. Resolve it with `handle-pending-permission-request!` (approve-once) and
+      wait for the resulting external tool request.
+   3. Supply the tool result with `handle-pending-tool-call!` and read the
+      model's final answer.
+
+   This is the SDK-driven analogue of the upstream `manual_tool_resume` sample.
+   The same pending requests can also be resolved after `resume-session` with
+   `:continue-pending-work? true` when the originating CLI process persists them;
+   this example keeps everything in one client lifecycle so it runs
+   deterministically against any CLI build."
+  (:require [clojure.core.async :refer [alts!! timeout]]
+            [github.copilot-sdk :as copilot :refer [evt]]))
+
+;; See examples/README.md for usage
+
+(def tool
+  (copilot/define-tool
+    "manual_resume_status"
+    {:description (str "Looks up a status value. The SDK consumer supplies the "
+                       "result manually.")
+     :parameters {:type "object"
+                  :properties {:id {:type "string"
+                                    :description "Identifier to look up"}}
+                  :required ["id"]}}))
+;; No :handler — the runtime leaves the call pending for manual resolution.
+
+(defn- wait-for
+  "Block (up to 120s) until an event of `type-kw` (optionally matching `pred`)
+   arrives on the freshly-subscribed channel `ch`, then unsubscribe and return
+   it. Subscribe BEFORE triggering the work so the event cannot be missed.
+   Throws if the channel closes or the timeout elapses first."
+  [session type-kw ch & [pred]]
+  (let [deadline (timeout 120000)]
+    (try
+      (loop []
+        (let [[event port] (alts!! [ch deadline])]
+          (cond
+            (= port deadline)
+            (throw (ex-info "Timed out waiting for session event" {:event-type type-kw}))
+
+            (nil? event)
+            (throw (ex-info "Event channel closed before expected event arrived"
+                            {:event-type type-kw}))
+
+            (and (= (:type event) type-kw) (or (nil? pred) (pred event)))
+            event
+
+            :else (recur))))
+      (finally
+        (copilot/unsubscribe-events! session ch)))))
+
+(defn run
+  [{:keys [model] :or {model "claude-haiku-4.5"}}]
+  (copilot/with-client-session
+    [session {:model model
+              :tools [tool]}]
+    ;; Step 1: ask for the tool, capture the pending permission request.
+    (let [permission-ch (copilot/subscribe-events session)]
+      (println "Step 1: asking the model to use the declaration-only tool...")
+      (copilot/send! session {:prompt (str "Use the manual_resume_status tool with id "
+                                           "'alpha', then tell me the status.")})
+      (let [permission (wait-for session (evt :permission.requested) permission-ch)
+            permission-id (get-in permission [:data :request-id])
+            ;; Subscribe BEFORE approving so the tool request cannot be missed.
+            tool-ch (copilot/subscribe-events session)]
+        (println "  pending permission request:" permission-id)
+
+        ;; Step 2: approve the pending permission, capture the pending tool call.
+        (println "Step 2: approving the pending permission...")
+        (copilot/handle-pending-permission-request!
+         session {:request-id permission-id :result {:kind :approve-once}})
+        (let [tool-event (wait-for session (evt :external_tool.requested) tool-ch
+                                   #(= (get-in % [:data :tool-name]) "manual_resume_status"))
+              tool-request-id (get-in tool-event [:data :request-id])
+              ;; Subscribe BEFORE resolving so the answer cannot be missed.
+              answer-ch (copilot/subscribe-events session)]
+          (println "  pending tool call:" tool-request-id)
+
+          ;; Step 3: supply the tool result by hand, read the final answer.
+          (println "Step 3: supplying the tool result manually...")
+          (copilot/handle-pending-tool-call!
+           session {:request-id tool-request-id :result "MANUAL_STATUS_READY"})
+          (let [answer (wait-for session (evt :assistant.message) answer-ch)]
+            (println "🤖:" (get-in answer [:data :content]))))))))

--- a/run-all-examples.sh
+++ b/run-all-examples.sh
@@ -69,3 +69,18 @@ clojure -A:examples -X elicitation-provider/run
 echo ""
 echo "=== commands ==="
 clojure -A:examples -X commands/run
+
+echo ""
+echo "=== ask-user-failure ==="
+clojure -A:examples -X ask-user-failure/run
+
+echo ""
+echo "=== manual-tool-resume ==="
+clojure -A:examples -X manual-tool-resume/run
+
+# Intentionally excluded — these require external credentials or network setup
+# and cannot run unattended in CI:
+#   byok_provider     needs a provider API key (OPENAI_API_KEY / ANTHROPIC_API_KEY / ...)
+#   empty_mode        :empty mode disables the local keychain, so it also needs a provider key
+#   mcp_local_server  needs npx (Node.js) + network to download @modelcontextprotocol/server-filesystem
+# Run them manually after providing the relevant key / tooling. See examples/README.md.


### PR DESCRIPTION
## What & why

Phase 5 (examples) of the 1.0.0 GA validation pass. Closes the one upstream
example concept this SDK lacked — **manual tool resume across resume
lifecycles** — and makes the example runner complete and self-documenting.

- **`examples/manual_tool_resume.clj`** — the SDK-driven analogue of the upstream
  `manual_tool_resume` sample. A tool declared **without** a `:handler` is
  *declaration-only* (upstream PR #1308): the runtime advertises it to the model
  but leaves the call pending. With no `:on-permission-request` handler either,
  the permission prompt is also pending. The example resolves both **by hand
  across three separate client lifecycles**, threading the session id through
  `resume-session` with `:continue-pending-work? true` and resolving the
  **original** request ids with `handle-pending-permission-request!`
  (`{:kind :approve-once}`) and `handle-pending-tool-call!`, then reads the
  model's final answer.
- **`run-all-examples.sh`** now also runs `ask_user_failure` (verified green) and
  `manual_tool_resume` — 19 CLI-only examples — and documents why `byok_provider`,
  `empty_mode`, and `mcp_local_server` are excluded (they need a provider API key
  or `npx`/network and can't run unattended).
- `examples/README.md` (Example 21 + runner note) and `CHANGELOG.md` updated.

## Non-obvious notes

- **Suspend gracefully, don't force-kill.** Upstream's sample uses `force_stop()`
  (SIGKILL) between lifecycles. Against the current CLI that loses the work:
  resolving a pending request after `force-stop!` + `resume-session` with
  `:continue-pending-work? true` returns `{:success false}`, because in-flight
  pending request state is flushed to the on-disk session store only during
  graceful teardown — a SIGKILL drops the request ids before the resume process
  can continue them. The SDK forwards `:continue-pending-work?` correctly (it is
  a CLI persistence property, not an SDK bug). The example therefore suspends each
  lifecycle with `disconnect!`, which persists the pending requests so the
  original ids resolve after resume. It demonstrates manual pending-work
  resolution across graceful **suspend/resume**, not hard crash recovery; the
  docstring frames this as an observed property of current CLI builds rather than
  a permanent guarantee.
- **Resolution results are asserted.** Each `handle-pending-*` result is checked
  for `:success`; a silent `{:success false}` throws, so a future regression in
  cross-resume pending-work resolution fails the example loudly.
- **Event-race safety.** Every awaited event is subscribed **before** the action
  that triggers it (`send!` / `handle-pending-*`), and `wait-for` uses a bounded
  120s `alts!!` so a missed or never-arriving event surfaces as a clear timeout
  rather than an indefinite hang.

Part of the GA pre-release validation plan (Phase 5 of 6).

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>
