### PR TITLE
chore: remove Babashka test-compatibility tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,14 @@ See the sections below for the complete change list since `v1.0.0-beta.3.0`.
   previously such a request was silently dropped and the caller hung.
 
 ### Removed
+- **Dropped the Babashka test-compatibility tasks (`test:bb`, `test:all`) from
+  `bb.edn`.** The `test:bb` task ran the full JVM test suite under the Babashka
+  interpreter as a compatibility gate, but the suite depends on libraries
+  Babashka does not bundle (e.g. `clojure.data.json`), so the task could not
+  succeed and was not wired into CI. Removed the tasks and the related
+  "Babashka compatibility" claims in `JAVA_SDK_COMPARISON.md`. `bb test`
+  (the JVM test runner) and the Babashka-based build tooling under `script/`
+  are unaffected.
 - **Dropped the unused `:force-stopping?` client-state flag.** `force-stop!`
   set it (and `initial-state` initialized it), but nothing ever read it, so it
   was dead state. `:stopping?` (which the process-exit watcher does read) is

--- a/JAVA_SDK_COMPARISON.md
+++ b/JAVA_SDK_COMPARISON.md
@@ -19,7 +19,7 @@ the Java SDK.
 | Tracks upstream | github/copilot-sdk **Node.js** | github/copilot-sdk **.NET** |
 | Wire schema source | hand-maintained | `@github/copilot` npm `schemas/*.json` (JSON Schema → codegen) |
 | Versioning | `UPSTREAM.CLJ_PATCH` (4-segment) | `<upstream>-java.<n>` |
-| Min runtime | JDK 8+ (Babashka-compatible) | JDK 17 (JDK 25 recommended for virtual threads) |
+| Min runtime | JDK 8+ | JDK 17 (JDK 25 recommended for virtual threads) |
 
 ---
 
@@ -54,7 +54,6 @@ and the public API of each.
 | Forward compatibility for new event types | ⚠ unknown events drop through (no spec failure, since specs are input-only on send paths) | ✅ explicit `UnknownSessionEvent` as Jackson `defaultImpl` |
 | `with-client` / `with-client-session` macros | ✅ | n/a (uses try-with-resources `AutoCloseable`) |
 | Clojure spec runtime instrumentation | ✅ ~80 `s/fdef` definitions | n/a |
-| Babashka compatibility | ✅ explicit CI gate (`bb test:bb`) | n/a |
 
 **Net feature delta.** The Clojure SDK has a slightly broader user-facing surface
 (`query` helpers, `join-session`, client-level MCP CRUD, lazy-seq event ergonomics,
@@ -306,8 +305,8 @@ This is a real strategic question, not a rhetorical one. Here is an honest asses
 
 | # | Option | Effort | What you gain | What you lose |
 |---|---|---|---|---|
-| A | **Status quo: pure Clojure** | 0 | REPL-native idioms, single-atom state, mult-based events, `with-*` macros, `helpers/query`, Babashka compat | Ongoing manual sync, drift risk, v2-only mock, no schema source-of-truth |
-| B | **Thin Clojure veneer over Java SDK** | High (~3–6 weeks of focused work) | Schema correctness for free; ride the Java team's codegen + agentic sync pipeline; fewer types to maintain | Force Clojure consumers onto JVM-only, Jackson-typed POJOs; lose Babashka compatibility entirely; lose `core.async` event channels (have to bridge from Java consumers); lose `with-*` macros idiom; CompletableFuture interop is awkward in Clojure; lose REPL-friendly state inspection |
+| A | **Status quo: pure Clojure** | 0 | REPL-native idioms, single-atom state, mult-based events, `with-*` macros, `helpers/query` | Ongoing manual sync, drift risk, v2-only mock, no schema source-of-truth |
+| B | **Thin Clojure veneer over Java SDK** | High (~3–6 weeks of focused work) | Schema correctness for free; ride the Java team's codegen + agentic sync pipeline; fewer types to maintain | Force Clojure consumers onto JVM-only, Jackson-typed POJOs; lose `core.async` event channels (have to bridge from Java consumers); lose `with-*` macros idiom; CompletableFuture interop is awkward in Clojure; lose REPL-friendly state inspection |
 | C | **Adopt the Java codegen *output* (or schema directly), keep Clojure runtime** | Medium (~2–3 weeks) | Auto-generated Clojure specs + wire-key registry + RPC method registry from `@github/copilot` npm schemas. **Eliminates manual drift on the schema side, keeps Clojure idioms.** | Need to build a Clojure codegen (or transpile via `scripts/codegen/java.ts` style); some integration work |
 | D | **Drop Clojure SDK, point users at Java SDK + interop** | 0 | Zero maintenance | Forfeit the main reason a Clojure SDK exists |
 
@@ -321,9 +320,8 @@ This is a real strategic question, not a rhetorical one. Here is an honest asses
    a marshalling layer (POJO→map, CompletableFuture→chan, sealed event class→tagged
    map). You end up with the Java type surface as your maintenance burden *plus* the
    wrapper, plus user-facing semantics that feel un-Clojure.
-2. **You lose Babashka compatibility.** The Java SDK requires JDK 17. The Clojure SDK
-   explicitly tests `bb test:bb`. That capability is non-trivial to give up — it's how
-   scripts and CI tools embed the SDK.
+2. **You lock users into a heavier runtime.** The Java SDK requires JDK 17. The Clojure
+   SDK targets JDK 8+, which keeps it embeddable in a wider range of host environments.
 3. **You lose the things the Clojure SDK is genuinely better at:** the `helpers/query`
    family, `with-client-session` macros, single-atom REPL state, mult-based event
    fan-out, `async/thread` handler isolation. These are why someone reaches for a

--- a/bb.edn
+++ b/bb.edn
@@ -1,18 +1,8 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.4"}}
  :tasks
- {:require [[clojure.string :as str]]
-
-  test {:doc "Run the test suite."
+ {test {:doc "Run the test suite."
         :task (clojure "-M:test" "-m" "cognitect.test-runner")}
-
-  test:bb {:doc "Run the test suite using Babashka to check compatibility."
-           :extra-paths ["test"]
-           :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-           :task (exec 'cognitect.test-runner.api/test)}
-
-  test:all {:doc "Run the test suite with both Clojure and Babashka."
-            :depends [test test:bb]}
 
   fmt {:doc "Format all Clojure files."
        :task (clojure "-M:fmt" "fix" "src" "test" "examples")}


### PR DESCRIPTION
Removes the Babashka test-compatibility gate, which never worked and was not run in CI.

## Why

`bb.edn` defined a `test:bb` task that ran the full JVM test suite under the Babashka interpreter, plus a `test:all` task that ran both. The suite depends on libraries Babashka does not bundle (e.g. `clojure.data.json`), so `test:bb` aborted with a `FileNotFoundException` before running any tests, and it was never wired into any CI workflow. Running `bb test:all` surfaced this as a confusing error after the JVM tests had already passed.

The SDK itself (core.async, spec instrumentation, codegen tests) was never genuinely Babashka-runnable, so the "Babashka compatibility" claim was misleading rather than a real, tested capability.

## What changes

- Drop the `test:bb` and `test:all` tasks from `bb.edn` (and the now-unused `clojure.string` require). `bb test` remains the test entry point.
- Remove the stale "Babashka compatibility ✅ CI gate (`bb test:bb`)" claims in `JAVA_SDK_COMPARISON.md`; the Option-B trade-off is reframed around the heavier JDK 17 runtime the Java SDK requires.

## Not affected

Babashka as the **task runner** (`bb test`, `bb validate-docs`, `bb codegen`, `bb jar`) and the genuinely Babashka-compatible build tooling under `script/` are untouched.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>
