### PR TITLE
ci: make release branch name unique per run attempt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,14 +181,16 @@ jobs:
             exit 0
           fi
           VERSION=$(grep -m1 -F '(def version' build.clj | sed 's/.*"\(.*\)".*/\1/')
-          BRANCH="release/v${VERSION}-run${GITHUB_RUN_ID}"
+          # Include the run attempt so re-runs (which reuse GITHUB_RUN_ID) get a
+          # fresh branch instead of colliding with the ref a prior attempt pushed.
+          BRANCH="release/v${VERSION}-run${GITHUB_RUN_ID}-attempt${GITHUB_RUN_ATTEMPT}"
           git checkout -b "$BRANCH"
           git add build.clj README.md doc/getting-started.md CHANGELOG.md
           git commit -m "chore: release v${VERSION}"
           git push origin "$BRANCH"
           PR_URL=$(gh pr create \
             --title "chore: release v${VERSION}" \
-            --body "Automated release PR for v${VERSION}. Created by the Release workflow (run ${GITHUB_RUN_ID})." \
+            --body "Automated release PR for v${VERSION}. Created by the Release workflow (run ${GITHUB_RUN_ID}, attempt ${GITHUB_RUN_ATTEMPT})." \
             --base main \
             --head "$BRANCH")
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Makes the release PR branch name unique per workflow **attempt** so re-running a failed release no longer collides with the branch a prior attempt already pushed.

## Why

The "Create release PR" step named its branch `release/v${VERSION}-run${GITHUB_RUN_ID}`. `GITHUB_RUN_ID` is stable across GitHub's "Re-run jobs" — only `GITHUB_RUN_ATTEMPT` increments. So when a release run failed after pushing the branch (e.g. a bad `RELEASE_TOKEN`) and was re-run, the step regenerated the identical branch name and `git push` was rejected as a non-fast-forward against the still-present ref:

```
! [rejected]  release/v1.0.0.0-run26941594411 -> ... (fetch first)
```

The recovery was manual: delete the stale remote branch, then dispatch a fresh run.

## Change

Append `-attempt${GITHUB_RUN_ATTEMPT}` to the branch name (and note the attempt in the PR body). Each re-run now gets a fresh branch, so re-running a failed release "just works" without manual branch cleanup. On success the branch is still auto-deleted by `gh pr merge --delete-branch`.

This addresses the naming root cause rather than masking it with a force-push.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>
