### PR TITLE
docs(skill): note create/resume wire-builder duplication pitfall

### DIFF
--- a/.github/skills/update-upstream/SKILL.md
+++ b/.github/skills/update-upstream/SKILL.md
@@ -174,4 +174,6 @@ Real recurring traps when porting upstream changes:
 
 5. **Outbound optional fields: match upstream's omit-vs-null behavior per RPC.** Don't reflexively gate an optional wire field on `contains?` and emit JSON `null`. Some patch RPCs (e.g. `session.options.update`) genuinely accept `null` to clear a value; others (e.g. `session.model.switchTo`) have no null variant in the schema — upstream spreads `...options`, dropping `undefined`. Check the upstream call site and the request schema: if the field has no null union, compute the wire value first and gate on `(some? v)` so a `nil` option omits the key instead of sending `null`.
 
+6. **`session.create` and `session.resume` build wire params in two separate functions — keep shared sub-shapes in a named helper.** `build-create-session-params` and `build-resume-session-params` both emit tool defs, system message, provider, MCP servers, custom agents, and commands. A new field on any shape sent by both must be added to both builders, or it ships on create and silently vanishes on resume. Funnel each shared sub-shape through one `*->wire` helper (e.g. `tool-def->wire`, `util/mcp-servers->wire`) rather than duplicating a `cond->` inline.
+
 For the mechanics of camelCase ↔ kebab-case conversion (including the `?`-suffix rule), see the cheat sheet in `references/PROJECT.md`.


### PR DESCRIPTION
Adds Common Pitfall #6 to the `update-upstream` skill.

This pitfall surfaced while porting the `:defer` tool option ([#137](https://github.com/copilot-community-sdk/copilot-sdk-clojure/pull/137)). `session.create` and `session.resume` build their wire params in two separate functions (`build-create-session-params` / `build-resume-session-params`) that share several sub-shapes — tool defs, system message, provider, MCP servers, custom agents, commands. A new field added to a shared shape in only one builder ships on create and silently vanishes on resume.

The existing pitfall #1 covers *declaration* sites (specs, `:opt-un`, public sets, docstrings); this is the distinct *construction* trap. The guidance: funnel each shared sub-shape through one named `*->wire` helper rather than duplicating a `cond->` inline.

Skill-maintenance only — no SDK code changes.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>