### PR TITLE
ci(release): accept -preview prerelease qualifier in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@13.5.2
+        uses: DeLaGuardo/setup-clojure@13.6.1
         with:
           cli: latest
           bb: 1.12.214

--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@13.5.2
+        uses: DeLaGuardo/setup-clojure@13.6.1
         with:
           cli: latest
           bb: 1.12.214

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@13.5.2
+        uses: DeLaGuardo/setup-clojure@13.6.1
         with:
           cli: 1.12.4.1582
           bb: 1.12.214

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@13.5.2
+        uses: DeLaGuardo/setup-clojure@13.6.1
         with:
           cli: latest
           bb: 1.12.214
@@ -96,8 +96,8 @@ jobs:
                 echo "explicit_version must be empty when version_strategy=sync-upstream." >&2
                 exit 1
               fi
-              if [[ ! "$UPSTREAM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
-                echo "upstream_version must match X.Y.Z or X.Y.Z-(alpha|beta|rc).N (e.g., 0.1.23 or 1.0.0-beta.3)." >&2
+              if [[ ! "$UPSTREAM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|preview|rc)\.[0-9]+)?$ ]]; then
+                echo "upstream_version must match X.Y.Z or X.Y.Z-(alpha|beta|preview|rc).N (e.g., 0.1.23 or 1.0.7-preview.2)." >&2
                 exit 1
               fi
               ;;
@@ -116,8 +116,8 @@ jobs:
                 echo "upstream_version must be empty when version_strategy=set-version." >&2
                 exit 1
               fi
-              if [[ ! "$EXPLICIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?\.[0-9]+(-SNAPSHOT)?$ ]]; then
-                echo "explicit_version must match X.Y.Z.N or X.Y.Z-(alpha|beta|rc).M.N (with optional -SNAPSHOT). Examples: 0.1.23.1, 1.0.0-beta.3.0." >&2
+              if [[ ! "$EXPLICIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|preview|rc)\.[0-9]+)?\.[0-9]+(-SNAPSHOT)?$ ]]; then
+                echo "explicit_version must match X.Y.Z.N or X.Y.Z-(alpha|beta|preview|rc).M.N (with optional -SNAPSHOT). Examples: 0.1.23.1, 1.0.7-preview.2.0." >&2
                 exit 1
               fi
               if [[ "$SNAPSHOT" == "true" ]]; then


### PR DESCRIPTION
The Release workflow's input-validation step rejected `upstream_version=1.0.7-preview.2` (the version we just synced to), failing at "Validate release inputs" before doing any work. Its regexes only permitted `-(alpha|beta|rc).N` prerelease qualifiers, but upstream `copilot-sdk` uses `preview` — and `build.clj`'s `sync-version` already accepts it (we ship `1.0.6-preview.1.0`). The workflow was simply inconsistent with the build tooling it drives.

This adds `preview` to both the `upstream_version` and `explicit_version` validation regexes (and their example error messages), bringing them in line with `build.clj`'s `upstream-version-re` / `full-version-re`.

Also bumps `DeLaGuardo/setup-clojure` `13.5.2 → 13.6.1` across all four workflows to clear the "Node.js 20 is deprecated" runner annotation — `13.6.1` runs on node24.

Verified the corrected regex accepts `1.0.7-preview.2` / `1.0.7-preview.2.0` and still rejects malformed input.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>