### PR TITLE
docs(helpers): warn that query-seq! leaks on early abandonment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to this project will be documented in this file. This change
   when the lazy seq is realized to end of stream — a `:copilot/session.idle` /
   `:copilot/session.error` event, or the events channel closing (an end-of-stream
   condition detected when the next read yields `nil`, not an emitted event).
-  Abandoning the seq early
-  (`(first ...)`, `(take 1 ...)`), or hitting `:max-events` before a terminal
-  event, leaks the session. Rewrote the docstring and API docs to warn about this
+  Abandoning the seq early — `(first ...)` / `(take 1 ...)` when that first
+  realized element is not itself a terminal event, or hitting a *positive*
+  `:max-events` bound before a terminal event (`:max-events 0` disconnects
+  immediately) — leaks the session. Rewrote the docstring and API docs to warn
+  about this
   and steer callers toward `query-chan` / `query` for early-stop use.
   ([#127](https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/127))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed (documentation)
+- **`query-seq!` leak foot-gun documented** — the `query-seq!` docstring and the
+  API reference previously claimed "guaranteed cleanup ... even if the consumer
+  stops early," which is false: the session and its event tap are released only
+  when the lazy seq is realized to its terminal event (channel close /
+  `:copilot/session.idle` / `:copilot/session.error`). Abandoning the seq early
+  (`(first ...)`, `(take 1 ...)`), or hitting `:max-events` before a terminal
+  event, leaks the session. Rewrote the docstring and API docs to warn about this
+  and steer callers toward `query-chan` / `query` for early-stop use.
+  ([#127](https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/127))
 
 ## [1.0.7-preview.2.0] - 2026-07-15
 ### Added (v1.0.7-preview.2 sync)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to this project will be documented in this file. This change
 - **`query-seq!` leak foot-gun documented** — the `query-seq!` docstring and the
   API reference previously claimed "guaranteed cleanup ... even if the consumer
   stops early," which is false: the session and its event tap are released only
-  when the lazy seq is realized to its terminal event (channel close /
-  `:copilot/session.idle` / `:copilot/session.error`). Abandoning the seq early
+  when the lazy seq is realized to end of stream — a `:copilot/session.idle` /
+  `:copilot/session.error` event, or the events channel closing (an end-of-stream
+  condition detected when the next read yields `nil`, not an emitted event).
+  Abandoning the seq early
   (`(first ...)`, `(take 1 ...)`), or hitting `:max-events` before a terminal
   event, leaks the session. Rewrote the docstring and API docs to warn about this
   and steer callers toward `query-chan` / `query` for early-stop use.

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -51,7 +51,13 @@ When `:session` is a CopilotSession instance, the query uses that session direct
 (h/query-seq! prompt & {:keys [client session max-events]})
 ```
 
-Execute a query and return a bounded lazy sequence of events with guaranteed cleanup (default: 256 events).
+Execute a query and return a bounded lazy sequence of events (default: 256 events).
+
+**Warning:** cleanup (session disconnect) runs only when the sequence is consumed to its natural end — a
+`:copilot/session.idle` / `:copilot/session.error` event or the events channel closing. Abandoning the seq
+early (e.g. `(first ...)` or `(take 1 ...)`), or hitting `:max-events` before that terminal event, leaks the
+session and its event tap. Consume the whole seq, or use `query-chan` (explicit lifecycle, safe early stop) or
+`query` when you may stop reading early.
 
 ```clojure
 (->> (h/query-seq! "Tell me a story" :session {:on-permission-request copilot/approve-all :streaming? true})

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -55,8 +55,9 @@ Execute a query and return a bounded lazy sequence of events (default: 256 event
 
 **Warning:** cleanup (session disconnect) runs only when the sequence is consumed to its natural end — a
 `:copilot/session.idle` / `:copilot/session.error` event, or the events channel closing (detected when the
-next read yields `nil`, the end-of-stream sentinel — not an emitted element). Abandoning the seq early (e.g.
-`(first ...)` or `(take 1 ...)`), or hitting a positive `:max-events` bound before that end of stream, leaks
+next read yields `nil`, the end-of-stream sentinel — not an emitted element). Abandoning the seq before it
+reaches a terminal event (e.g. `(first ...)` or `(take 1 ...)` when the first element isn't already terminal),
+or hitting a positive `:max-events` bound before that end of stream, leaks
 the session and its event tap (the sole exception is `:max-events 0`, which disconnects
 immediately without emitting anything). Consume the whole seq, or use `query-chan` (explicit lifecycle — safe
 to stop early provided you close the returned channel) or `query` when you may stop reading early.

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -55,9 +55,10 @@ Execute a query and return a bounded lazy sequence of events (default: 256 event
 
 **Warning:** cleanup (session disconnect) runs only when the sequence is consumed to its natural end — a
 `:copilot/session.idle` / `:copilot/session.error` event or the events channel closing. Abandoning the seq
-early (e.g. `(first ...)` or `(take 1 ...)`), or hitting `:max-events` before that terminal event, leaks the
-session and its event tap. Consume the whole seq, or use `query-chan` (explicit lifecycle, safe early stop) or
-`query` when you may stop reading early.
+early (e.g. `(first ...)` or `(take 1 ...)`), or hitting a positive `:max-events` bound before that terminal
+event, leaks the session and its event tap (the sole exception is `:max-events 0`, which disconnects
+immediately without emitting anything). Consume the whole seq, or use `query-chan` (explicit lifecycle — safe
+to stop early provided you close the returned channel) or `query` when you may stop reading early.
 
 ```clojure
 (->> (h/query-seq! "Tell me a story" :session {:on-permission-request copilot/approve-all :streaming? true})

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -54,9 +54,10 @@ When `:session` is a CopilotSession instance, the query uses that session direct
 Execute a query and return a bounded lazy sequence of events (default: 256 events).
 
 **Warning:** cleanup (session disconnect) runs only when the sequence is consumed to its natural end — a
-`:copilot/session.idle` / `:copilot/session.error` event or the events channel closing. Abandoning the seq
-early (e.g. `(first ...)` or `(take 1 ...)`), or hitting a positive `:max-events` bound before that terminal
-event, leaks the session and its event tap (the sole exception is `:max-events 0`, which disconnects
+`:copilot/session.idle` / `:copilot/session.error` event, or the events channel closing (detected when the
+next read yields `nil`, the end-of-stream sentinel — not an emitted element). Abandoning the seq early (e.g.
+`(first ...)` or `(take 1 ...)`), or hitting a positive `:max-events` bound before that end of stream, leaks
+the session and its event tap (the sole exception is `:max-events 0`, which disconnects
 immediately without emitting anything). Consume the whole seq, or use `query-chan` (explicit lifecycle — safe
 to stop early provided you close the returned channel) or `query` when you may stop reading early.
 

--- a/src/github/copilot_sdk/helpers.clj
+++ b/src/github/copilot_sdk/helpers.clj
@@ -248,11 +248,11 @@
    (realizing the terminal event runs cleanup). The `:max-events` bound only caps
    how many events are yielded — it is not a cleanup guarantee; hitting a positive
    bound before a terminal event still leaks the session (the sole exception is
-   `:max-events 0`, which disconnects immediately without emitting anything). Only
-   use `query-seq!` when you will consume the
-   sequence to its natural end. If you may stop early, prefer `query-chan`
-   (explicit lifecycle — safe to stop early *provided you close the returned
-   channel*) or `query` (single response, deterministic cleanup).
+   `:max-events 0`, which disconnects immediately without emitting anything).
+   Only use `query-seq!` when you will consume the sequence to its natural end.
+   If you may stop early, prefer `query-chan` (explicit lifecycle — safe to stop
+   early *provided you close the returned channel*) or `query` (single response,
+   deterministic cleanup).
 
    Keyword options:
      :client - Client options map

--- a/src/github/copilot_sdk/helpers.clj
+++ b/src/github/copilot_sdk/helpers.clj
@@ -234,11 +234,13 @@
   "Execute a query and return a bounded lazy sequence of events.
 
    Cleanup (session disconnect) happens only when the sequence is realized all the
-   way to a terminal channel event: the events channel closing (`nil`), or a
-   `:copilot/session.idle` / `:copilot/session.error` event. Consuming the whole
-   seq to its natural end releases the session and its event tap.
+   way to the end of the event stream: either a `:copilot/session.idle` /
+   `:copilot/session.error` event, or the events channel closing — detected when
+   the next read yields `nil` (the end-of-stream sentinel, not an emitted event).
+   Consuming the whole seq to its natural end releases the session and its event
+   tap.
 
-   WARNING: cleanup is tied to reaching that terminal element, so a consumer that
+   WARNING: cleanup is tied to reaching that end of stream, so a consumer that
    abandons the seq early leaks the session and its event tap. For example
    `(first (query-seq! ...))` or `(take 1 (query-seq! ...))` realize one element
    and stop, so the terminal event is never reached and cleanup never runs. The

--- a/src/github/copilot_sdk/helpers.clj
+++ b/src/github/copilot_sdk/helpers.clj
@@ -231,16 +231,28 @@
           (copilot/disconnect! sess))))))
 
 (defn query-seq!
-  "Execute a query and return a lazy sequence of events with guaranteed cleanup.
-   
-   This variant limits consumption and ensures the session is disconnected even if
-   the consumer stops early.
-   
+  "Execute a query and return a bounded lazy sequence of events.
+
+   Cleanup (session disconnect) happens only when the sequence is realized all the
+   way to a terminal channel event: the events channel closing (`nil`), or a
+   `:copilot/session.idle` / `:copilot/session.error` event. Consuming the whole
+   seq to its natural end releases the session and its event tap.
+
+   WARNING: cleanup is tied to reaching that terminal element, so a consumer that
+   abandons the seq early leaks the session and its event tap. For example
+   `(first (query-seq! ...))` or `(take 1 (query-seq! ...))` realize one element
+   and stop, so the terminal event is never reached and cleanup never runs. The
+   `:max-events` bound only caps how many events are yielded — it is not a cleanup
+   guarantee; if the bound is hit before a terminal event the session still leaks.
+   Only use `query-seq!` when you will consume the sequence to its natural end. If
+   you may stop early, prefer `query-chan` (explicit lifecycle, safe to stop
+   reading early) or `query` (single response, deterministic cleanup).
+
    Keyword options:
      :client - Client options map
      :session - Session options map
      :max-events - Maximum number of events to emit (default: 256)
-   
+
    Returns a lazy sequence of at most :max-events events."
   [prompt & {:keys [client session max-events] :or {max-events 256}}]
   (let [c (ensure-client! client)

--- a/src/github/copilot_sdk/helpers.clj
+++ b/src/github/copilot_sdk/helpers.clj
@@ -241,13 +241,15 @@
    tap.
 
    WARNING: cleanup is tied to reaching that end of stream, so a consumer that
-   abandons the seq early leaks the session and its event tap. For example
-   `(first (query-seq! ...))` or `(take 1 (query-seq! ...))` realize one element
-   and stop, so the terminal event is never reached and cleanup never runs. The
-   `:max-events` bound only caps how many events are yielded — it is not a cleanup
-   guarantee; hitting a positive bound before a terminal event still leaks the
-   session (the sole exception is `:max-events 0`, which disconnects immediately
-   without emitting anything). Only use `query-seq!` when you will consume the
+   abandons the seq before it reaches a terminal event leaks the session and its
+   event tap. For example `(first (query-seq! ...))` or `(take 1 (query-seq! ...))`
+   realize just one element: they leak unless that first element already happens
+   to be a terminal `:copilot/session.idle` / `:copilot/session.error` event
+   (realizing the terminal event runs cleanup). The `:max-events` bound only caps
+   how many events are yielded — it is not a cleanup guarantee; hitting a positive
+   bound before a terminal event still leaks the session (the sole exception is
+   `:max-events 0`, which disconnects immediately without emitting anything). Only
+   use `query-seq!` when you will consume the
    sequence to its natural end. If you may stop early, prefer `query-chan`
    (explicit lifecycle — safe to stop early *provided you close the returned
    channel*) or `query` (single response, deterministic cleanup).

--- a/src/github/copilot_sdk/helpers.clj
+++ b/src/github/copilot_sdk/helpers.clj
@@ -243,10 +243,12 @@
    `(first (query-seq! ...))` or `(take 1 (query-seq! ...))` realize one element
    and stop, so the terminal event is never reached and cleanup never runs. The
    `:max-events` bound only caps how many events are yielded — it is not a cleanup
-   guarantee; if the bound is hit before a terminal event the session still leaks.
-   Only use `query-seq!` when you will consume the sequence to its natural end. If
-   you may stop early, prefer `query-chan` (explicit lifecycle, safe to stop
-   reading early) or `query` (single response, deterministic cleanup).
+   guarantee; hitting a positive bound before a terminal event still leaks the
+   session (the sole exception is `:max-events 0`, which disconnects immediately
+   without emitting anything). Only use `query-seq!` when you will consume the
+   sequence to its natural end. If you may stop early, prefer `query-chan`
+   (explicit lifecycle — safe to stop early *provided you close the returned
+   channel*) or `query` (single response, deterministic cleanup).
 
    Keyword options:
      :client - Client options map


### PR DESCRIPTION
Corrects a false guarantee in the `query-seq!` documentation. The docstring and API reference claimed "guaranteed cleanup ... even if the consumer stops early," but `query-seq!` returns a lazy seq backed by a live session and event tap, and the disconnect only runs when the seq is realized to a terminal channel event (channel close / `:copilot/session.idle` / `:copilot/session.error`). A consumer that stops early — `(first ...)`, `(take 1 ...)` — never reaches that element, so the session and its tap leak.

This is the "document the foot-gun" resolution from the issue (severity `post-ga`); documentation only, no behavior change. The docstring and `doc/reference/API.md` now warn about early abandonment and steer callers toward `query-chan` (explicit lifecycle, safe early stop) or `query` (single deterministic response) when they may not consume the whole seq.

Worth flagging for the reviewer: the warning also calls out that reaching `:max-events` before a terminal event leaks too. Cleanup fires eagerly only when `:max-events` is `0`; otherwise it is strictly tied to realizing a terminal channel event, so `:max-events` bounds the yield count but is not itself a cleanup trigger.

Closes https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/127

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>