### PR TITLE
fix: preserve :arglists on re-exported permission helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project will be documented in this file. This change
 - **Re-exported permission helpers now preserve `:arglists`** — `approve-all` and
   `default-join-session-permission-handler` in the top-level `github.copilot-sdk`
   namespace were bare `def` aliases, so editor tooltips and generated API docs showed
-  no call signature. They now carry `:arglists '([request ctx])` matching the source
-  vars. Resolves [#119](https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/119).
+  no call signature. They now carry an explicit `:arglists '([request ctx])` so
+  editor tooltips and generated API docs surface the two-arg `[request ctx]` contract.
+  (The source vars name these params `_request`/`_ctx` since they ignore them; the
+  re-exports use the descriptive names for public documentation.)
+  Resolves [#119](https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/119).
   (The `result-*` and `convert-mcp-call-tool-result` re-exports mentioned in that issue
   are already `defn` wrappers and were unaffected.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- **Re-exported permission helpers now preserve `:arglists`** — `approve-all` and
+  `default-join-session-permission-handler` in the top-level `github.copilot-sdk`
+  namespace were bare `def` aliases, so editor tooltips and generated API docs showed
+  no call signature. They now carry `:arglists '([request ctx])` matching the source
+  vars. Resolves [#119](https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/119).
+  (The `result-*` and `convert-mcp-call-tool-result` re-exports mentioned in that issue
+  are already `defn` wrappers and were unaffected.)
 
 ## [1.0.7-preview.2.0] - 2026-07-15
 ### Added (v1.0.7-preview.2 sync)

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -1310,12 +1310,12 @@
   (tools/convert-mcp-call-tool-result result))
 
 ;; Re-export permission helpers
-(def approve-all
+(def ^{:arglists '([request ctx])} approve-all
   "Permission handler that approves all requests with `{:kind :approve-once}`.
    See `github.copilot-sdk.client/approve-all`."
   client/approve-all)
 
-(def default-join-session-permission-handler
+(def ^{:arglists '([request ctx])} default-join-session-permission-handler
   "Default permission handler for resuming sessions.
   Returns `{:kind :no-result}` — the CLI handles permissions itself.
   When used with `resume-session`, sends `requestPermission: false` on the wire.


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

## Summary

Adds `:arglists '([request ctx])` to the two permission-handler helpers re-exported by the top-level `github.copilot-sdk` namespace, which were previously bare `def` aliases:

- `approve-all`
- `default-join-session-permission-handler`

Without `:arglists`, editor tooltips and generated API docs (codox) showed no call signature for these public functions.

## Investigation notes

The issue title also lists `result-success` / `result-failure` / `result-denied` / `result-rejected` and `convert-mcp-call-tool-result`. Those re-exports are **already** `defn` wrappers in the current code and correctly preserve both docstring and `:arglists`, so only the two `def` aliases above needed fixing. The other bare `def` re-exports in the namespace (`event-types`, `session-events`, `system-prompt-sections`, etc.) are value sets/maps, not functions, and legitimately carry no `:arglists`.

Verified in a REPL that all seven helpers named in the issue now report `:arglists` and `:doc`:

```
result-success                           arglists=([text] [text telemetry]) doc?=true
result-failure                           arglists=([text] [text error] [text error telemetry]) doc?=true
result-denied                            arglists=([text] [text telemetry]) doc?=true
result-rejected                          arglists=([text] [text telemetry]) doc?=true
convert-mcp-call-tool-result             arglists=([result]) doc?=true
approve-all                              arglists=([request ctx]) doc?=true
default-join-session-permission-handler  arglists=([request ctx]) doc?=true
```

## Testing

- `bb test` → 406 tests, 2219 assertions, 0 failures.

Resolves https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/119
