### PR TITLE
docs(api): document naming/shape differences vs official SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added (documentation)
+- **Naming and shape differences vs the official SDK** — new reference
+  section in `doc/reference/API.md` documenting the handful of public
+  Clojure names/return shapes that do not map 1:1 to the Node.js SDK:
+  `:disable-resume?` ↔ `suppressResumeEvent`, `:max-input-tokens` ↔
+  `maxPromptTokens`, and `join-session`'s `{:client :session}` return vs
+  the upstream `joinSession()` → `CopilotSession`. Resolves
+  [#124](https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/124).
 
 ## [1.0.7-preview.2.0] - 2026-07-15
 ### Added (v1.0.7-preview.2 sync)

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -103,6 +103,23 @@ Get information about the current shared client state. Returns `nil` if no share
 (require '[github.copilot-sdk :as copilot])
 ```
 
+### Naming and shape differences vs the official SDK
+
+The Clojure SDK maintains strict API parity with the official Node.js SDK
+(`@github/copilot-sdk`), but a handful of names and return shapes are
+adapted to Clojure idioms. When translating Node.js examples, use this map:
+
+| Clojure | Official Node.js SDK | Notes |
+|---------|----------------------|-------|
+| `:disable-resume?` | `suppressResumeEvent` | Config key on `resume-session` / `join-session`. When true, skips emitting the `session.resume` event. Defaults to `true` in `join-session` (matching upstream), `false` elsewhere. |
+| `:max-input-tokens` | `maxPromptTokens` | BYOK provider/model config key (input/prompt token cap). Serialized back to `maxPromptTokens` on the wire. |
+| `join-session` return `{:client :session}` | `joinSession()` returns `CopilotSession` | Clojure has no implicit/global client, so it returns both so the caller can own the client lifecycle. See [`join-session`](#join-session). |
+
+These are the only cases where a public Clojure key or return value does
+not map 1:1 to the upstream name. Everything else follows the standard
+kebab-case ↔ camelCase wire convention (e.g. `:working-directory` ↔
+`workingDirectory`), which is applied automatically and needs no lookup.
+
 ### Constructor
 
 ```clojure
@@ -398,6 +415,15 @@ Throws if `SESSION_ID` is not set in the environment.
   ;; use session...
   (copilot/stop! client))
 ```
+
+> **Return-shape difference vs the official SDK.** The Node.js
+> `joinSession(config)` returns the `CopilotSession` directly and hides the
+> client it creates internally. Clojure has no implicit/global client, so
+> `join-session` returns **both** the `:client` and the `:session`: the
+> caller owns the client's lifecycle and must call [`stop!`](#stop) on it
+> when finished. Bind the returned map's `:session` where a Node.js caller
+> would use the awaited return value, and keep the `:client` for cleanup.
+> See [Naming and shape differences vs the official SDK](#naming-and-shape-differences-vs-the-official-sdk).
 
 #### `ping`
 


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

## What

Documentation-only change that closes the "renamed/diverging surface is undocumented" gap from [#124](https://github.com/copilot-community-sdk/copilot-sdk-clojure/issues/124).

Adds a **"Naming and shape differences vs the official SDK"** section to `doc/reference/API.md` that maps the three public divergences from the Node.js `@github/copilot-sdk`:

| Clojure | Official Node.js SDK | Notes |
|---------|----------------------|-------|
| `:disable-resume?` | `suppressResumeEvent` | Config key on `resume-session` / `join-session`; serialized back on the wire. Defaults to `true` in `join-session` (matching upstream). |
| `:max-input-tokens` | `maxPromptTokens` | BYOK provider/model config; serialized to `maxPromptTokens`. |
| `join-session` → `{:client :session}` | `joinSession()` → `CopilotSession` | Clojure has no implicit/global client, so both are returned and the caller owns the client lifecycle. |

Also adds a **return-shape note** on the `join-session` entry explaining the `{:client :session}` divergence (F6) and how to translate an upstream `joinSession()` call.

## Why

These are the only cases where a public Clojure key or return value doesn't map 1:1 to upstream. Everything else follows the automatic kebab-case ↔ camelCase wire convention. Documenting them removes a real translation footgun for anyone porting Node.js examples.

## Verification

- No code change — docs only.
- `bb validate-docs` → ✓ 17 files, 0 warnings.

Resolves #124.
