### PR TITLE
chore: restore formatting gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed
+- Restore the green formatting gate by correcting the formatter-prescribed indentation in `src/github/copilot_sdk/util.clj`.
+
 ### Changed (agent workflow)
 - **Worktree-safe upstream sync** — the repo-local `update-upstream` skill now
   uses a tracked helper to resolve the sibling `github/copilot-sdk` checkout

--- a/src/github/copilot_sdk/util.clj
+++ b/src/github/copilot_sdk/util.clj
@@ -127,8 +127,8 @@
    Each server value has :mcp-* prefixed keys stripped before camelCase conversion."
   [servers]
   (into {} (map (fn [[k v]] [(if (keyword? k) (subs (str k) 1) k)
-                              (mcp-server->wire v)]))
-                servers))
+                             (mcp-server->wire v)]))
+        servers))
 
 ;; -----------------------------------------------------------------------------
 ;; Attachment wire conversion


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Restore the repository formatting gate by applying the formatter-prescribed indentation fix that `bb fmt:check` reported. The change stays narrowly scoped to the release-hygiene failure so the branch returns to a green format check without touching unrelated findings.