### PR TITLE
fix: release resources during force stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed (lifecycle)
+- **Force-stop session teardown** — `force-stop!` now marks active sessions
+  terminal, cancels local factory executions, closes event subscriptions and
+  send locks, then drops client ownership without issuing `session.destroy` or
+  `runtime.shutdown` RPCs.
+
 ### Changed (agent workflow)
 - **Worktree-safe upstream sync** — the repo-local `update-upstream` skill now
   uses a tracked helper to resolve the sibling `github/copilot-sdk` checkout

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -207,7 +207,9 @@ the process is left running. (upstream [PR #1667](https://github.com/github/copi
 (copilot/force-stop! client)
 ```
 
-Force stop the CLI server without graceful cleanup. Use when `stop!` takes too long.
+Force stop the CLI server without graceful RPCs. It closes local session event
+subscriptions and releases in-flight session work before closing the transport
+and terminating an SDK-owned process. Use when `stop!` takes too long.
 
 #### `client-options`
 

--- a/src/github/copilot_sdk.clj
+++ b/src/github/copilot_sdk.clj
@@ -363,7 +363,10 @@
   (client/stop! client))
 
 (defn force-stop!
-  "Force stop the CLI server without graceful cleanup.
+  "Force stop the CLI server without graceful RPCs.
+
+   Releases local session resources before terminating the transport and any
+   SDK-owned process.
    Use when stop! takes too long."
   [client]
   (client/force-stop! client))

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -1367,13 +1367,19 @@
       @errors)))
 
 (defn force-stop!
-  "Force stop the CLI server without graceful cleanup."
-  [client]
-  (swap! (:state client) assoc :stopping? true)
+  "Force stop the CLI server without graceful RPCs.
 
-  (let [{:keys [connection-io socket process]} @(:state client)]
+   Releases locally-owned session resources before dropping client ownership, then
+   closes the transport and terminates an SDK-owned process."
+  [client]
+  (swap! (:state client) assoc :stopping? true :lifecycle-handlers {})
+
+  (let [{:keys [connection-io socket process sessions]} @(:state client)
+        session-ids (keys sessions)]
     (try
-      ;; Clear sessions without destroying
+      ;; Release event roots and send locks while their state is still reachable.
+      (doseq [session-id session-ids]
+        (session/teardown-local! client session-id))
       (swap! (:state client) assoc :sessions {} :session-io {})
 
       ;; Stop notification routing

--- a/src/github/copilot_sdk/session.clj
+++ b/src/github/copilot_sdk/session.clj
@@ -28,8 +28,17 @@
 (defn- session-io [client session-id]
   (get-in @(:state client) [:session-io session-id]))
 
+(defn- session-disconnected?
+  [client session-id]
+  (not (false? (:destroyed? (session-state client session-id)))))
+
 (defn- update-session! [client session-id f & args]
-  (apply swap! (:state client) update-in [:sessions session-id] f args))
+  (swap! (:state client)
+         (fn [state]
+           (let [session (get-in state [:sessions session-id])]
+             (if (and session (not (:destroyed? session)))
+               (apply update-in state [:sessions session-id] f args)
+               state)))))
 
 (defn- connection-io [client]
   (:connection-io @(:state client)))
@@ -83,33 +92,42 @@
                                      tools))
         command-handlers (into {} (map (fn [c] [(:name c) (:command-handler c)]) commands))]
     ;; Store session state and IO in client's atom
-    (swap! (:state client)
-           (fn [state]
-             (-> state
-                 (assoc-in [:sessions session-id]
-                           {:tool-handlers tool-handlers
-                            :command-handlers command-handlers
-                            :permission-handler on-permission-request
-                            :mcp-auth-handler on-mcp-auth-request
-                            :user-input-handler on-user-input-request
-                            :elicitation-handler on-elicitation-request
-                            :exit-plan-mode-handler on-exit-plan-mode
-                            :auto-mode-switch-handler on-auto-mode-switch
-                            :hooks hooks
-                            :factories factory-definitions
-                            :factory-executions {}
-                            :managed-settings-enabled?
-                            (or (true? (:enable-managed-settings? config))
-                                (some? (:managed-settings config)))
-                            :destroyed? false
-                            :workspace-path workspace-path
-                            :capabilities {}
-                            :open-canvases []
-                            :config config})
-                 (assoc-in [:session-io session-id]
-                           {:event-chan event-chan
-                            :event-mult event-mult
-                            :send-lock send-lock}))))
+    (let [[_ registered-state]
+          (swap-vals! (:state client)
+                      (fn [state]
+                        (if (:stopping? state)
+                          state
+                          (-> state
+                              (assoc-in [:sessions session-id]
+                                        {:tool-handlers tool-handlers
+                                         :command-handlers command-handlers
+                                         :permission-handler on-permission-request
+                                         :mcp-auth-handler on-mcp-auth-request
+                                         :user-input-handler on-user-input-request
+                                         :elicitation-handler on-elicitation-request
+                                         :exit-plan-mode-handler on-exit-plan-mode
+                                         :auto-mode-switch-handler on-auto-mode-switch
+                                         :hooks hooks
+                                         :factories factory-definitions
+                                         :factory-executions {}
+                                         :managed-settings-enabled?
+                                         (or (true? (:enable-managed-settings? config))
+                                             (some? (:managed-settings config)))
+                                         :destroyed? false
+                                         :workspace-path workspace-path
+                                         :capabilities {}
+                                         :open-canvases []
+                                         :config config})
+                              (assoc-in [:session-io session-id]
+                                        {:event-chan event-chan
+                                         :event-mult event-mult
+                                         :send-lock send-lock})))))]
+      (when-not (identical? event-chan
+                            (get-in registered-state [:session-io session-id :event-chan]))
+        (close! event-chan)
+        (close! send-lock)
+        (throw (ex-info "Client is stopping; cannot create session"
+                        {:session-id session-id}))))
     ;; If an on-event handler is provided, tap and forward events to it.
     ;; Uses async/thread to avoid blocking core.async dispatch threads,
     ;; since user handlers may perform blocking I/O.
@@ -139,12 +157,12 @@
   "Update the workspace path in session state. Called after RPC response."
   [client session-id workspace-path]
   (when workspace-path
-    (swap! (:state client) assoc-in [:sessions session-id :workspace-path] workspace-path)))
+    (update-session! client session-id assoc :workspace-path workspace-path)))
 
 (defn set-capabilities!
   "Store host capabilities in session state. Called after session.create/session.resume RPC."
   [client session-id capabilities]
-  (swap! (:state client) assoc-in [:sessions session-id :capabilities] (or capabilities {})))
+  (update-session! client session-id assoc :capabilities (or capabilities {})))
 
 ;; --- Open canvas snapshot (upstream PR #1604) -------------------------------
 ;; The CLI host can open auxiliary UI canvases inside a session. The SDK keeps
@@ -184,8 +202,7 @@
       (log/warn "dropping invalid entries from session.resume openCanvases"
                 {:session-id session-id
                  :dropped-count (count invalid)}))
-    (swap! (:state client) assoc-in [:sessions session-id :open-canvases]
-           (vec valid))))
+    (update-session! client session-id assoc :open-canvases (vec valid))))
 
 (defn upsert-open-canvas!
   "Apply a `session.canvas.opened` event payload to the snapshot. If an entry
@@ -198,15 +215,15 @@
     (log/warn "failed to deserialize session.canvas.opened payload"
               {:session-id session-id})
     (let [iid (:instance-id data)]
-      (swap! (:state client) update-in [:sessions session-id :open-canvases]
-             (fn [canvases]
-               (let [canvases (vec (or canvases []))
-                     idx (first (keep-indexed
-                                 (fn [i c] (when (= (:instance-id c) iid) i))
-                                 canvases))]
-                 (if idx
-                   (assoc canvases idx data)
-                   (conj canvases data))))))))
+      (update-session! client session-id update :open-canvases
+                       (fn [canvases]
+                         (let [canvases (vec (or canvases []))
+                               idx (first (keep-indexed
+                                           (fn [i c] (when (= (:instance-id c) iid) i))
+                                           canvases))]
+                           (if idx
+                             (assoc canvases idx data)
+                             (conj canvases data))))))))
 
 (defn remove-open-canvas!
   "Apply a `session.canvas.closed` event payload to the snapshot — removes the
@@ -218,9 +235,9 @@
     (if-not (and (string? iid) (not (str/blank? iid)))
       (log/warn "failed to deserialize session.canvas.closed payload"
                 {:session-id session-id})
-      (swap! (:state client) update-in [:sessions session-id :open-canvases]
-             (fn [canvases]
-               (filterv #(not= (:instance-id %) iid) (or canvases [])))))))
+      (update-session! client session-id update :open-canvases
+                       (fn [canvases]
+                         (filterv #(not= (:instance-id %) iid) (or canvases [])))))))
 
 (defn register-transform-callbacks!
   "Store system message transform callbacks on a session.
@@ -228,7 +245,7 @@
    that receive current content and return transformed content."
   [client session-id callbacks]
   (when callbacks
-    (swap! (:state client) assoc-in [:sessions session-id :transform-callbacks] callbacks)))
+    (update-session! client session-id assoc :transform-callbacks callbacks)))
 
 (defn- validate-session-fs-handler!
   [handler context]
@@ -268,7 +285,7 @@
               {:session-id session-id
                :capabilities (get-in client [:session-fs :capabilities])
                :missing-handlers (vec missing)})))
-    (swap! (:state client) assoc-in [:sessions session-id :session-fs-handler] validated)))
+    (update-session! client session-id assoc :session-fs-handler validated)))
 
 (defn- channel?
   "Check if x is a core.async channel."
@@ -769,11 +786,19 @@
                    :execution-token execution-token
                    :cancelled? (atom false)
                    :cancel-chan (chan)}]
-    (swap! (:state client)
-           assoc-in
-           [:sessions session-id :factory-executions run-id execution-token]
-           execution)
-    execution))
+    (when (identical?
+           execution
+           (get-in
+            (swap! (:state client)
+                   (fn [state]
+                     (let [session (get-in state [:sessions session-id])]
+                       (if (and session (not (:destroyed? session)))
+                         (assoc-in state
+                                   [:sessions session-id :factory-executions run-id execution-token]
+                                   execution)
+                         state))))
+            [:sessions session-id :factory-executions run-id execution-token]))
+      execution)))
 
 (defn- remove-factory-execution!
   [client session-id run-id execution-token execution]
@@ -791,17 +816,60 @@
                               dissoc
                               run-id))))))))
 
-(defn- cancel-factory-executions! [client session-id run-id]
+(defn- cancel-executions! [executions]
   (doseq [{:keys [cancelled? cancel-chan]}
-          (vals (get-in @(:state client)
-                        [:sessions session-id :factory-executions run-id]))]
+          executions]
     (reset! cancelled? true)
     (close! cancel-chan)))
 
+(defn- cancel-factory-executions! [client session-id run-id]
+  (cancel-executions!
+   (vals (get-in @(:state client)
+                 [:sessions session-id :factory-executions run-id]))))
+
 (defn- cancel-all-factory-executions! [client session-id]
-  (doseq [run-id (keys (get-in @(:state client)
-                               [:sessions session-id :factory-executions]))]
-    (cancel-factory-executions! client session-id run-id)))
+  (cancel-executions!
+   (mapcat vals
+           (vals (get-in @(:state client)
+                         [:sessions session-id :factory-executions])))))
+
+(defn ^:no-doc teardown-local!
+  "Mark a session terminal and release resources without contacting the runtime."
+  [client session-id]
+  (let [[old _] (swap-vals! (:state client)
+                            (fn [state]
+                              (let [session (get-in state [:sessions session-id])]
+                                (if (or (nil? session) (:destroyed? session))
+                                  state
+                                  (assoc-in state
+                                            [:sessions session-id]
+                                            (assoc session
+                                                   :destroyed? true
+                                                   :tool-handlers {}
+                                                   :permission-handler nil
+                                                   :user-input-handler nil
+                                                   :factories {}
+                                                   :factory-executions {}
+                                                   :hooks {}
+                                                   :config nil))))))]
+    (cond
+      (nil? (get-in old [:sessions session-id]))
+      :absent
+
+      (get-in old [:sessions session-id :destroyed?])
+      :already-destroyed
+
+      :else
+      (do
+        (cancel-executions!
+         (mapcat vals
+                 (vals (get-in old [:sessions session-id :factory-executions]))))
+        (let [{:keys [event-chan send-lock]} (get-in old [:session-io session-id])]
+          (when event-chan
+            (close! event-chan))
+          (when send-lock
+            (close! send-lock)))
+        :claimed))))
 
 (defn- factory-context
   [client session-id {:keys [run-id execution-token args] :as _params} execution]
@@ -887,35 +955,37 @@
   (async/thread-call
    (fn []
      (if-let [handle (get-in @(:state client) [:sessions session-id :factories name])]
-       (let [execution (register-factory-execution!
-                        client session-id run-id execution-token)
-             context (factory-context client session-id params execution)
-             flush! (::flush-progress! context)]
-         (try
-           (let [result (await-factory-value
-                         ((factory/factory-run-function handle)
-                          (dissoc context ::flush-progress!)))]
-             (flush!)
-             (cond
-               (nil? result) {:result {}}
-               (identical? factory/json-null result) {:result {:result nil}}
-               :else (do
-                       (assert-factory-json! result "Factory result")
-                       {:result {:result result}})))
-           (catch Throwable error
-             {:error {:code -32603
-                      :message (or (ex-message error) (str error))
-                      :data (serializable-ex-data error)}})
-           (finally
-             (try
+       (if-let [execution (register-factory-execution!
+                           client session-id run-id execution-token)]
+         (let [context (factory-context client session-id params execution)
+               flush! (::flush-progress! context)]
+           (try
+             (let [result (await-factory-value
+                           ((factory/factory-run-function handle)
+                            (dissoc context ::flush-progress!)))]
                (flush!)
-               (catch Throwable error
-                 (log/warn "Failed to flush final factory progress"
-                           {:session-id session-id
-                            :run-id run-id
-                            :error (ex-message error)})))
-             (remove-factory-execution!
-              client session-id run-id execution-token execution))))
+               (cond
+                 (nil? result) {:result {}}
+                 (identical? factory/json-null result) {:result {:result nil}}
+                 :else (do
+                         (assert-factory-json! result "Factory result")
+                         {:result {:result result}})))
+             (catch Throwable error
+               {:error {:code -32603
+                        :message (or (ex-message error) (str error))
+                        :data (serializable-ex-data error)}})
+             (finally
+               (try
+                 (flush!)
+                 (catch Throwable error
+                   (log/warn "Failed to flush final factory progress"
+                             {:session-id session-id
+                              :run-id run-id
+                              :error (ex-message error)})))
+               (remove-factory-execution!
+                client session-id run-id execution-token execution))))
+         {:error {:code -32001
+                  :message (str "Session has been disconnected: " session-id)}})
        {:error {:code -32602
                 :message (str "No factory registered with name " (pr-str name))
                 :data {:code "factory_not_found" :name name}}}))
@@ -1441,8 +1511,8 @@
   "Deep-merge capability changes into the session's capabilities map.
    Called when a capabilities.changed broadcast event is received."
   [client session-id capability-changes]
-  (swap! (:state client) update-in [:sessions session-id :capabilities]
-         (fn [caps] (deep-merge (or caps {}) capability-changes))))
+  (update-session! client session-id update :capabilities
+                   (fn [caps] (deep-merge (or caps {}) capability-changes))))
 
 ;; -----------------------------------------------------------------------------
 ;; Public API - functions that take CopilotSession handle
@@ -1484,7 +1554,7 @@
                      :explain (s/explain-data ::specs/send-options opts)})))
   (let [{:keys [session-id client]} session]
     (log/debug "send! called for session " session-id " with prompt: " (subs (str (:prompt opts)) 0 (min 50 (count (str (:prompt opts))))) "...")
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (let [conn (connection-io client)
           wire-attachments (when (:attachments opts)
@@ -1521,7 +1591,7 @@
   ([session opts timeout-ms]
    (let [{:keys [session-id client]} session]
      (log/debug "send-and-wait! called for session " session-id)
-     (when (:destroyed? (session-state client session-id))
+     (when (session-disconnected? client session-id)
        (throw (ex-info "Session has been disconnected" {:session-id session-id})))
 
      (let [event-ch (chan 1024)
@@ -1590,7 +1660,7 @@
    (send-async* session opts nil))
   ([session opts timeout-ms]
    (let [{:keys [session-id client]} session]
-     (when (:destroyed? (session-state client session-id))
+     (when (session-disconnected? client session-id)
        (throw (ex-info "Session has been disconnected" {:session-id session-id})))
 
      (let [out-ch (chan 1024)
@@ -1668,7 +1738,7 @@
    Returns events-ch immediately; events flow once the go block completes setup."
   [session opts timeout-ms]
   (let [{:keys [session-id client]} session]
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (let [out-ch (chan 1024)
           event-ch (chan 1024)
@@ -1848,7 +1918,7 @@
   "Abort the currently processing message in this session."
   [session]
   (let [{:keys [session-id client]} session]
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (let [conn (connection-io client)]
       (proto/send-request! conn "session.abort" {:session-id session-id})
@@ -1880,7 +1950,7 @@
   "Get all events/messages from this session's history."
   [session]
   (let [{:keys [session-id client]} session]
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (let [conn (connection-io client)
           result (proto/send-request! conn "session.getMessages" {:session-id session-id})]
@@ -1945,7 +2015,7 @@
    core.async variant."
   [session {:keys [request-id result error] :as opts}]
   (let [{:keys [session-id client]} session]
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (check-pending-request-id! request-id opts)
     (when-not (or (contains? opts :result) (contains? opts :error))
@@ -1966,7 +2036,7 @@
   [session opts]
   (let [{:keys [session-id client]} session
         {:keys [request-id result error]} opts]
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (check-pending-request-id! request-id opts)
     (when-not (or (contains? opts :result) (contains? opts :error))
@@ -2004,7 +2074,7 @@
    for the core.async variant."
   [session {:keys [request-id result] :as opts}]
   (let [{:keys [session-id client]} session]
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (check-pending-request-id! request-id opts)
     (check-pending-permission-result! result opts)
@@ -2020,7 +2090,7 @@
   [session opts]
   (let [{:keys [session-id client]} session
         {:keys [request-id result]} opts]
-    (when (:destroyed? (session-state client session-id))
+    (when (session-disconnected? client session-id)
       (throw (ex-info "Session has been disconnected" {:session-id session-id})))
     (check-pending-request-id! request-id opts)
     (check-pending-permission-result! result opts)
@@ -2042,37 +2112,15 @@
    (disconnect! (:client session) (:session-id session)))
   ([client session-id]
    (log/debug "Disconnecting session: " session-id)
-   ;; Atomically claim the teardown: only the caller that flips :destroyed?
-   ;; from falsey to true proceeds. Concurrent disconnect! calls on the same
-   ;; session then no-op instead of sending a second session.destroy RPC.
-   (let [[old _] (swap-vals! (:state client)
-                             (fn [s]
-                               (if (get-in s [:sessions session-id :destroyed?])
-                                 s
-                                 (assoc-in s [:sessions session-id :destroyed?] true))))]
-     (when-not (get-in old [:sessions session-id :destroyed?])
-       (let [conn (connection-io client)]
-         (cancel-all-factory-executions! client session-id)
-         ;; Try to notify server, but don't block forever if connection is broken
-         (try
-           (proto/send-request! conn "session.destroy" {:session-id session-id} 5000)
-           (catch Exception _
-             ;; Ignore errors - we're cleaning up anyway
-             nil))
-         ;; Clear handlers and closures to aid GC (:destroyed? already set above)
-         (update-session! client session-id assoc
-                          :tool-handlers {}
-                          :permission-handler nil
-                          :user-input-handler nil
-                          :factories {}
-                          :factory-executions {}
-                          :hooks {}
-                          :config nil)
-         ;; Close the event source channel - this propagates to all tapped channels
-         (when-let [{:keys [event-chan]} (session-io client session-id)]
-           (close! event-chan))
-         (log/debug "Session disconnected: " session-id)
-         nil)))))
+   (when-not (= :already-destroyed (teardown-local! client session-id))
+     ;; Try to notify server, but don't block forever if connection is broken.
+     (try
+       (proto/send-request! (connection-io client) "session.destroy" {:session-id session-id} 5000)
+       (catch Exception _
+         ;; Ignore errors - we're cleaning up anyway.
+         nil))
+     (log/debug "Session disconnected: " session-id))
+   nil))
 
 (defn destroy!
   "Deprecated: Use disconnect! instead. This function will be removed in a future release.

--- a/test/github/copilot_sdk/force_stop_test.clj
+++ b/test/github/copilot_sdk/force_stop_test.clj
@@ -10,7 +10,7 @@
   (let [deadline (async/timeout 500)
         [value port] (async/alts!! [ch deadline])]
     {:value value
-     :closed? (= port ch)}))
+     :closed? (and (= port ch) (nil? value))}))
 
 (deftest force-stop-releases-session-owned-resources-without-rpcs
   (let [client (sdk/client {:auto-start? false})

--- a/test/github/copilot_sdk/force_stop_test.clj
+++ b/test/github/copilot_sdk/force_stop_test.clj
@@ -1,0 +1,150 @@
+(ns github.copilot-sdk.force-stop-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer [deftest is testing]]
+            [github.copilot-sdk :as sdk]
+            [github.copilot-sdk.protocol :as protocol]
+            [github.copilot-sdk.session :as session]))
+
+(defn- await-port
+  [ch]
+  (let [deadline (async/timeout 500)
+        [value port] (async/alts!! [ch deadline])]
+    {:value value
+     :closed? (= port ch)}))
+
+(deftest force-stop-releases-session-owned-resources-without-rpcs
+  (let [client (sdk/client {:auto-start? false})
+        first-session (session/create-session client "first-session" {})
+        second-session (session/create-session client "second-session" {})
+        events-ch (session/subscribe-events first-session)
+        event-root (get-in @(:state client) [:session-io "first-session" :event-chan])
+        send-lock (get-in @(:state client) [:session-io "second-session" :send-lock])
+        cancelled? (atom false)
+        cancel-ch (async/chan)
+        lock-waiter (promise)
+        send-started (promise)
+        rpc-methods (atom [])]
+    (swap! (:state client)
+           assoc-in
+           [:sessions "first-session" :factory-executions "run-1" "execution-1"]
+           {:cancelled? cancelled?
+            :cancel-chan cancel-ch})
+    (async/<!! send-lock)
+    (async/take! send-lock #(deliver lock-waiter [:released %]))
+    (with-redefs [protocol/send-request!
+                  (fn [_ method _ & _]
+                    (swap! rpc-methods conj method)
+                    (deliver send-started true)
+                    {:message-id "message-1"})]
+      (let [in-flight-send
+            (future
+              (try
+                (session/send-and-wait! first-session {:prompt "wait"} 30000)
+                :completed
+                (catch Exception error
+                  [:failed (ex-message error)])))]
+        @send-started
+        (sdk/force-stop! client)
+        (try
+          (testing "event subscriptions and in-flight sends are released"
+            (is (:closed? (await-port events-ch)))
+            (let [result (deref in-flight-send 500 ::pending)]
+              (is (not= ::pending result))
+              (is (and (vector? result)
+                       (re-find #"Event channel closed" (second result)))))
+            (is (= [:released nil] (deref lock-waiter 500 ::pending))))
+          (testing "local session teardown cancels factory execution and rejects handles"
+            (is @cancelled?)
+            (is (:closed? (await-port cancel-ch)))
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Session has been disconnected"
+                 (session/send! first-session {:prompt "after force-stop"}))))
+          (testing "force stop remains local-only and idempotent"
+            (is (not-any? #{"session.destroy" "runtime.shutdown"} @rpc-methods))
+            (is (empty? (:sessions @(:state client))))
+            (is (empty? (:session-io @(:state client))))
+            (is (nil? (sdk/force-stop! client))))
+          (finally
+            (async/close! event-root)
+            (async/close! send-lock)
+            (deref in-flight-send 1000 nil)))))))
+
+(deftest force-stop-prevents-factory-registration-after-session-teardown
+  (let [client (sdk/client {:auto-start? false})
+        copilot-session (session/create-session client "factory-session" {})]
+    (sdk/force-stop! client)
+    (is (nil? (#'session/register-factory-execution!
+               client
+               (sdk/session-id copilot-session)
+               "run-1"
+               "execution-1")))
+    (is (empty? (:sessions @(:state client))))))
+
+(deftest force-stop-clears-lifecycle-handlers-before-transport-teardown
+  (let [client (sdk/client {:auto-start? false})
+        handlers-at-disconnect (atom nil)]
+    (swap! (:state client)
+           assoc
+           :connection-io :connection
+           :lifecycle-handlers {:handler {:handler identity}})
+    (with-redefs [protocol/disconnect
+                  (fn [_]
+                    (reset! handlers-at-disconnect
+                            (:lifecycle-handlers @(:state client))))]
+      (sdk/force-stop! client))
+    (is (= {} @handlers-at-disconnect))))
+
+(deftest disconnect-untracked-session-still-notifies-the-runtime
+  (let [client (sdk/client {:auto-start? false})
+        rpc-calls (atom [])]
+    (with-redefs [protocol/send-request!
+                  (fn [_ method params & _]
+                    (swap! rpc-calls conj [method params]))]
+      (is (nil? (session/disconnect! client "runtime-only-session"))))
+    (is (= [["session.destroy" {:session-id "runtime-only-session"}]]
+           @rpc-calls))
+    (is (empty? (:sessions @(:state client))))))
+
+(deftest local-teardown-does-not-recreate-a-session-after-claim
+  (let [client (sdk/client {:auto-start? false})
+        copilot-session (session/create-session client "race-session" {})
+        events-ch (session/subscribe-events copilot-session)
+        original-swap-vals! swap-vals!
+        claimed? (atom false)]
+    (with-redefs [clojure.core/swap-vals!
+                  (fn [state transition]
+                    (let [[old new] (original-swap-vals! state transition)]
+                      (if (compare-and-set! claimed? false true)
+                        (do
+                          (reset! state (assoc new :sessions {} :session-io {}))
+                          [old new])
+                        [old new])))]
+      (is (= :claimed
+             (session/teardown-local! client (sdk/session-id copilot-session)))))
+    (is (:closed? (await-port events-ch)))
+    (is (empty? (:sessions @(:state client))))
+    (is (empty? (:session-io @(:state client))))))
+
+(deftest session-state-writers-do-not-resurrect-a-force-stopped-session
+  (let [client (sdk/client {:auto-start? false})
+        copilot-session (session/create-session client "notification-session" {})
+        session-id (sdk/session-id copilot-session)]
+    (sdk/force-stop! client)
+    (session/update-capabilities! client session-id {:supports-canvases true})
+    (session/upsert-open-canvas!
+     client
+     session-id
+     {:instance-id "canvas-1" :extension-id "extension-1" :canvas-id "canvas-1"})
+    (is (empty? (:sessions @(:state client))))
+    (is (empty? (:session-io @(:state client))))))
+
+(deftest session-registration-rejects-a-stopping-client
+  (let [client (sdk/client {:auto-start? false})]
+    (sdk/force-stop! client)
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Client is stopping"
+         (session/create-session client "late-session" {})))
+    (is (empty? (:sessions @(:state client))))
+    (is (empty? (:session-io @(:state client))))))


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Force-stop now performs atomic local-only session teardown before removing client ownership, releasing event taps, send locks, and factory executions that could otherwise strand host work.

Normal disconnect retains `session.destroy` behavior for untracked session IDs. Concurrent session-state writers and late session registration are guarded once shutdown begins, so no session state can be recreated after force-stop.

`force-stop!` deliberately performs no graceful `session.destroy` or `runtime.shutdown` RPCs; graceful shutdown behavior remains on the normal stop and disconnect paths.