### PR TITLE
fix: bound reverse request handler execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,48 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Changed (reverse-RPC execution policy)
+- **Reverse request handlers run on a bounded worker pool** — server→client RPC
+  handlers (hooks, `sessionFs.*`, factories, user input, provider tokens,
+  `systemMessage.transform`, etc.) are arbitrary caller code that may block, and
+  were previously invoked from inside a core.async `go` block. In core.async
+  1.8 `go` dispatch is backed by the same process-wide unbounded cached `:io`
+  executor as `thread-call`, so blocking handlers grew that shared pool without
+  limit: a 32-request reproducer entered all 32 handlers concurrently on
+  `async-io-*` threads. Handlers now execute on a bounded `ThreadPoolExecutor`
+  owned by the connection, on threads named `jsonrpc-request-worker-*`, and the
+  same reproducer now caps at the configured bound. The reader thread only
+  submits work, so it keeps routing responses and notifications while every
+  worker is busy.
+- **BREAKING (behavior)**: when more than
+  `:request-handler-threads` + `:request-handler-queue-size` reverse requests
+  are outstanding, the runtime now receives an explicit JSON-RPC
+  `-32000` error with `data.code` `request_handler_saturated` (including
+  `method`, `maxConcurrency`, and `queueSize`) instead of the request being
+  queued indefinitely. Nothing is silently dropped, and no timeout was added
+  around handler execution — a wedged handler occupies exactly one worker and
+  is surfaced through the overload error and the new counters.
+- `disconnect` now shuts the handler pool down explicitly, interrupting blocked
+  handlers, and warns if workers fail to terminate rather than leaking them.
+
+### Added (reverse-RPC execution policy)
+- `:request-handler-threads` (default `16`) and `:request-handler-queue-size`
+  (default `256`) client options bound reverse-handler concurrency. Defaults are
+  well above realistic reverse-RPC concurrency, so existing hosts are unaffected.
+  These are the only new public keys; the worker/queue counters that back them
+  (`:dropped-notifications`, `:rejected-requests`, `:active-request-workers`,
+  `:queued-requests`, `:request-workers-terminated?`) are protocol-internal
+  diagnostics, not public API.
+
+### Fixed (observability)
+- **Notification-queue overflow is no longer silent** — `dispatch-message!`
+  dropped notifications with a `debug` log and no counter. Drops are now logged
+  at `warn` with the method and a running total, and counted in
+  `protocol/connection-stats`. A deterministic saturation test proves the branch
+  is reachable and observable; it does **not** demonstrate that a terminal
+  session event can be lost, so no event prioritization or transport change was
+  made.
+
 ### Changed (agent workflow)
 - **Worktree-safe upstream sync** — the repo-local `update-upstream` skill now
   uses a tracked helper to resolve the sibling `github/copilot-sdk` checkout

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -149,6 +149,8 @@ kebab-case ↔ camelCase wire convention (e.g. `:working-directory` ↔
 | `:auto-restart?` | boolean | `true` | Auto-restart on crash |
 | `:notification-queue-size` | number | `4096` | Max queued protocol notifications |
 | `:router-queue-size` | number | `4096` | Max queued non-session notifications |
+| `:request-handler-threads` | number | `16` | Max reverse-RPC handlers (hooks, sessionFs, factories, user input, etc.) executing concurrently. Handlers run on a bounded worker pool owned by the connection, never on core.async dispatch |
+| `:request-handler-queue-size` | number | `256` | Max reverse RPCs queued once every worker is busy. Beyond `threads + queue-size` outstanding requests the runtime receives an explicit `-32000` `request_handler_saturated` error |
 | `:tool-timeout-ms` | number | `120000` | Timeout for tool handlers returning channels |
 | `:cwd` | string | nil | Working directory for CLI process |
 | `:env` | map | nil | Environment variables |

--- a/resources/github/copilot_sdk/api_surface.edn
+++ b/resources/github/copilot_sdk/api_surface.edn
@@ -541,6 +541,8 @@
   :github.copilot-sdk.specs/remote?
   :github.copilot-sdk.specs/rename
   :github.copilot-sdk.specs/repository
+  :github.copilot-sdk.specs/request-handler-queue-size
+  :github.copilot-sdk.specs/request-handler-threads
   :github.copilot-sdk.specs/request-headers
   :github.copilot-sdk.specs/request-id
   :github.copilot-sdk.specs/requested-schema

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -159,6 +159,8 @@
    :auto-restart? false
    :notification-queue-size 4096
    :router-queue-size 4096
+   :request-handler-threads proto/default-request-handler-threads
+   :request-handler-queue-size proto/default-request-handler-queue-size
    :tool-timeout-ms 120000
    :env nil})
 
@@ -224,6 +226,14 @@
     - :auto-restart? - **DEPRECATED**: This option has no effect and will be removed in a future release.
     - :notification-queue-size - Max queued protocol notifications (default: 4096)
     - :router-queue-size - Max queued non-session notifications (default: 4096)
+    - :request-handler-threads - Max reverse-RPC handlers (hooks, sessionFs, factories,
+                       user input, etc.) executing concurrently (default: 16). Handlers run on
+                       a bounded worker pool owned by the connection, never on core.async
+                       dispatch, so a handler that blocks cannot grow threads without limit.
+    - :request-handler-queue-size - Max reverse RPCs queued once every worker is busy
+                       (default: 256). Beyond `threads + queue-size` outstanding requests the
+                       runtime receives an explicit `-32000` `request_handler_saturated`
+                       error rather than the request being dropped or stalled.
     - :tool-timeout-ms - Timeout for tool calls that return a channel (default: 120000)
     - :env           - Environment variables map
     - :github-token  - GitHub token for authentication (sets COPILOT_SDK_AUTH_TOKEN env var)
@@ -315,6 +325,14 @@
    (when-let [size (:router-queue-size opts)]
      (when (<= size 0)
        (throw (ex-info "router-queue-size must be > 0" {:router-queue-size size}))))
+   (when-let [threads (:request-handler-threads opts)]
+     (when (<= threads 0)
+       (throw (ex-info "request-handler-threads must be > 0"
+                       {:request-handler-threads threads}))))
+   (when-let [size (:request-handler-queue-size opts)]
+     (when (<= size 0)
+       (throw (ex-info "request-handler-queue-size must be > 0"
+                       {:request-handler-queue-size size}))))
    (when-let [timeout (:tool-timeout-ms opts)]
      (when (<= timeout 0)
        (throw (ex-info "tool-timeout-ms must be > 0" {:tool-timeout-ms timeout}))))
@@ -862,6 +880,12 @@
       (when (seq lines)
         (str/join "\n" lines)))))
 
+(defn- delivered-chan
+  "A channel already holding `v`, matching the reverse-request handler contract
+   `(fn [method params] -> channel)`."
+  [v]
+  (doto (chan 1) (async/put! v) (async/close!)))
+
 (defn- setup-request-handler!
   "Set up handler for incoming requests (hooks, user input, sessionFs, etc.).
 
@@ -870,92 +894,103 @@
    `session.event` — see [[handle-v3-tool-requested!]] and
    [[handle-v3-permission-requested!]] — not as server→client RPCs. The v2
    `tool.call` / `permission.request` dispatcher cases were removed
-   alongside upstream PR #1378."
+   alongside upstream PR #1378.
+
+   This is a plain dispatch function, not a `go` block: `protocol` invokes it on
+   its bounded reverse-request worker pool, so branches that do ordinary
+   blocking work (e.g. `systemMessage.transform` callbacks) run under that
+   bound instead of on core.async dispatch. Branches that delegate to a
+   `session/handle-*` function return its channel directly rather than parking
+   on it."
   [client]
-  (let [{:keys [connection-io]} @(:state client)]
-    (proto/set-request-handler! connection-io
-                                (fn [method params]
-                                  (go
-                                    (case method
-                                      ;; Exit Plan Mode request (upstream PR #1228)
-                                      "exitPlanMode.request"
-                                      (let [{:keys [session-id]} params
-                                            request (dissoc params :session-id)]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-exit-plan-mode-request! client session-id request))))
+  (let [{:keys [connection-io]} @(:state client)
+        session? (fn [session-id] (get-in @(:state client) [:sessions session-id]))
+        unknown-session (fn [session-id]
+                          (delivered-chan
+                           {:error {:code -32001 :message (str "Unknown session: " session-id)}}))]
+    (proto/set-request-handler!
+     connection-io
+     (fn [method params]
+       (case method
+         ;; Exit Plan Mode request (upstream PR #1228)
+         "exitPlanMode.request"
+         (let [{:keys [session-id]} params
+               request (dissoc params :session-id)]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-exit-plan-mode-request! client session-id request)))
 
-                                      ;; Auto Mode Switch request (upstream PR #1228)
-                                      "autoModeSwitch.request"
-                                      (let [{:keys [session-id]} params
-                                            request (dissoc params :session-id)]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-auto-mode-switch-request! client session-id request))))
+         ;; Auto Mode Switch request (upstream PR #1228)
+         "autoModeSwitch.request"
+         (let [{:keys [session-id]} params
+               request (dissoc params :session-id)]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-auto-mode-switch-request! client session-id request)))
 
-                                      ;; User input request (PR #269)
-                                      "userInput.request"
-                                      (let [{:keys [session-id question choices allow-freeform]} params]
-                                        (log/debug "User input request for session " session-id ": " question)
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-user-input-request! client session-id
-                                                                                  {:question question
-                                                                                   :choices choices
-                                                                                   :allow-freeform allow-freeform}))))
+         ;; User input request (PR #269)
+         "userInput.request"
+         (let [{:keys [session-id question choices allow-freeform]} params]
+           (log/debug "User input request for session " session-id ": " question)
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-user-input-request! client session-id
+                                                 {:question question
+                                                  :choices choices
+                                                  :allow-freeform allow-freeform})))
 
-                                      ;; Bearer-token provider request (PR #1748)
-                                      "providerToken.getToken"
-                                      (let [{:keys [session-id provider-name]} params]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-provider-token-request!
-                                               client session-id provider-name))))
+         ;; Bearer-token provider request (PR #1748)
+         "providerToken.getToken"
+         (let [{:keys [session-id provider-name]} params]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-provider-token-request! client session-id provider-name)))
 
-                                      ;; Hooks invocation (PR #269)
-                                      "hooks.invoke"
-                                      (let [{:keys [session-id hook-type input]} params]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-hooks-invoke! client session-id hook-type input))))
+         ;; Hooks invocation (PR #269)
+         "hooks.invoke"
+         (let [{:keys [session-id hook-type input]} params]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-hooks-invoke! client session-id hook-type input)))
 
-                                      "factory.execute"
-                                      (let [{:keys [session-id]} params]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-factory-execute!
-                                               client session-id params))))
+         "factory.execute"
+         (let [{:keys [session-id]} params]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-factory-execute! client session-id params)))
 
-                                      "factory.abort"
-                                      (let [{:keys [session-id run-id]} params]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-factory-abort!
-                                               client session-id run-id))))
+         "factory.abort"
+         (let [{:keys [session-id run-id]} params]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-factory-abort! client session-id run-id)))
 
-                                      ;; System message transform (PR #816)
-                                      "systemMessage.transform"
-                                      (let [{:keys [session-id sections]} params]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          {:result (session/handle-system-message-transform
-                                                    client session-id sections)}))
+         ;; System message transform (PR #816). Runs inline on the reverse-request
+         ;; worker, so the registered transform callbacks are covered by the
+         ;; handler concurrency bound.
+         "systemMessage.transform"
+         (let [{:keys [session-id sections]} params]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (delivered-chan
+              {:result (session/handle-system-message-transform
+                        client session-id sections)})))
 
-                                      ;; SessionFs operations (upstream PR #917, sqlite added in #1299)
-                                      ("sessionFs.readFile" "sessionFs.writeFile" "sessionFs.appendFile"
-                                                            "sessionFs.exists" "sessionFs.stat" "sessionFs.mkdir"
-                                                            "sessionFs.readdir" "sessionFs.readdirWithTypes"
-                                                            "sessionFs.rm" "sessionFs.rename"
-                                                            "sessionFs.sqliteQuery"
-                                                            "sessionFs.sqliteTransaction"
-                                                            "sessionFs.sqliteExists")
-                                      (let [{:keys [session-id]} params]
-                                        (if-not (get-in @(:state client) [:sessions session-id])
-                                          {:error {:code -32001 :message (str "Unknown session: " session-id)}}
-                                          (<! (session/handle-session-fs-request!
-                                               client session-id method params))))
+         ;; SessionFs operations (upstream PR #917, sqlite added in #1299)
+         ("sessionFs.readFile" "sessionFs.writeFile" "sessionFs.appendFile"
+                               "sessionFs.exists" "sessionFs.stat" "sessionFs.mkdir"
+                               "sessionFs.readdir" "sessionFs.readdirWithTypes"
+                               "sessionFs.rm" "sessionFs.rename"
+                               "sessionFs.sqliteQuery"
+                               "sessionFs.sqliteTransaction"
+                               "sessionFs.sqliteExists")
+         (let [{:keys [session-id]} params]
+           (if-not (session? session-id)
+             (unknown-session session-id)
+             (session/handle-session-fs-request! client session-id method params)))
 
-                                      {:error {:code -32601 :message (str "Unknown method: " method)}}))))))
+         (delivered-chan
+          {:error {:code -32601 :message (str "Unknown method: " method)}}))))))
 
 (defn- connect-stdio!
   "Connect via stdio to the CLI process."

--- a/src/github/copilot_sdk/protocol.clj
+++ b/src/github/copilot_sdk/protocol.clj
@@ -13,6 +13,7 @@
    reader to throw AsynchronousCloseException and exit gracefully."
   (:require [clojure.data.json :as json]
             [clojure.core.async :as async :refer [go-loop <! >!! <!! chan close! put!]]
+            [clojure.core.async.impl.protocols :as async-protocols]
             [clojure.string :as str]
             [github.copilot-sdk.logging :as log]
             [github.copilot-sdk.util :as util])
@@ -352,7 +353,12 @@
   [request-handler outgoing-ch method id params]
   (try
     (let [result (if request-handler
-                   (<!! (request-handler method params))
+                   (let [result-ch (request-handler method params)]
+                     (when-not (satisfies? async-protocols/ReadPort result-ch)
+                       (throw (ex-info "Request handler must return a core.async channel"
+                                       {:method method
+                                        :returned-type (some-> result-ch class str)})))
+                     (<!! result-ch))
                    {:error {:code -32601 :message "Method not found"}})]
       (if-let [error (:error result)]
         (do
@@ -369,7 +375,7 @@
       ;; Expected: `disconnect` interrupts workers still inside a handler.
       (.interrupt (Thread/currentThread))
       (log/debug "Reverse request worker interrupted for id=" id))
-    (catch Throwable t
+    (catch Exception t
       (log/error "Request handler exception for method=" method " id=" id ": " (ex-message t))
       (put! outgoing-ch {:jsonrpc "2.0"
                          :id id

--- a/src/github/copilot_sdk/protocol.clj
+++ b/src/github/copilot_sdk/protocol.clj
@@ -383,14 +383,21 @@
                                  :message (str "Internal error: " (ex-message t))}}))))
 
 (defn- reject-request!
-  "Answer a reverse request that the saturated worker pool refused.
+  "Answer a reverse request that the worker pool refused.
 
-   Overload is reported to the peer as an explicit JSON-RPC error: the request
-   is never silently dropped, and the reader thread is never blocked waiting
-   for capacity."
+   Saturation and shutdown are reported as explicit JSON-RPC errors. The
+   reader thread never blocks waiting for capacity."
   [^ThreadPoolExecutor executor ^AtomicLong rejected-requests outgoing-ch method id]
   (if (.isShutdown executor)
-    (log/debug "Ignoring request during shutdown: method=" method " id=" id)
+    (do
+      (log/debug "Rejecting request during shutdown: method=" method " id=" id)
+      (put! outgoing-ch
+            {:jsonrpc "2.0"
+             :id id
+             :error {:code -32000
+                     :message "Connection closed"
+                     :data (util/clj->wire {:code "connection_closed"
+                                            :method method})}}))
     (let [queue (.getQueue executor)
           max-concurrency (.getMaximumPoolSize executor)
           queue-size (+ (.size queue) (.remainingCapacity queue))
@@ -856,8 +863,9 @@
     ;; registering a new entry we'd miss.
     (drain-pending! state-atom {:code -32000 :message "Connection closed"})
 
-    ;; Release reverse-request workers before closing outgoing-ch, so a handler
-    ;; that is mid-flight can still emit its response.
+    ;; Interrupt running handlers and abandon queued reverse requests before
+    ;; closing outgoing-ch. A request rejected during this shutdown window gets
+    ;; a best-effort connection-closed response.
     (shutdown-request-executor! (:request-executor conn))
 
     ;; Close outgoing channel first to stop write go-loop

--- a/src/github/copilot_sdk/protocol.clj
+++ b/src/github/copilot_sdk/protocol.clj
@@ -6,12 +6,13 @@
    - core.async channels for message flow
    - Single reader thread puts to incoming-ch
    - Writer go-loop takes from outgoing-ch
+   - Reverse requests run on a bounded worker pool owned by the connection
    - State is managed externally (passed in as atom)
    
    This design allows clean shutdown: closing NIO channels causes
    reader to throw AsynchronousCloseException and exit gracefully."
   (:require [clojure.data.json :as json]
-            [clojure.core.async :as async :refer [go go-loop <! >! >!! <!! chan close! put!]]
+            [clojure.core.async :as async :refer [go-loop <! >!! <!! chan close! put!]]
             [clojure.string :as str]
             [github.copilot-sdk.logging :as log]
             [github.copilot-sdk.util :as util])
@@ -20,9 +21,33 @@
            [java.nio.channels Channels ReadableByteChannel WritableByteChannel ClosedChannelException]
            [java.nio.channels AsynchronousCloseException]
            [java.nio.charset StandardCharsets]
-           [java.util.concurrent LinkedBlockingQueue TimeUnit]))
+           [java.util.concurrent ArrayBlockingQueue LinkedBlockingQueue
+            RejectedExecutionException ThreadFactory ThreadPoolExecutor
+            ThreadPoolExecutor$AbortPolicy TimeUnit]
+           [java.util.concurrent.atomic AtomicLong]))
 
 (def ^:private content-length-header "Content-Length: ")
+
+(def ^:private request-worker-thread-name-prefix
+  "Thread-name prefix for a connection's reverse-request worker pool.
+
+   Reverse request handlers are arbitrary caller code, so they always run on a
+   thread with this prefix — never on core.async `go` dispatch. In core.async
+   1.8 `go` dispatch shares the process-wide unbounded cached `:io` executor,
+   so blocking there grows that pool without bound."
+  "jsonrpc-request-worker-")
+
+(def ^:no-doc default-request-handler-threads
+  "Default cap on concurrently executing reverse request handlers.
+
+   Implementation support for `client`'s option defaults, not documented API."
+  16)
+
+(def ^:no-doc default-request-handler-queue-size
+  "Default number of reverse requests queued before overload is reported.
+
+   Implementation support for `client`'s option defaults, not documented API."
+  256)
 
 ;; -----------------------------------------------------------------------------
 ;; NIO-based Message Framing (Content-Length based, vscode-jsonrpc compatible)
@@ -116,7 +141,54 @@
             outgoing-ch                   ; channel for outgoing messages
             notification-queue            ; queue for notifications to avoid blocking reader
             notification-thread           ; Thread
-            read-thread])                 ; Thread
+            read-thread                   ; Thread
+            request-executor              ; bounded pool running reverse request handlers
+            rejected-requests             ; AtomicLong of overload-rejected reverse requests
+            dropped-notifications])       ; AtomicLong of notifications dropped on a full queue
+
+(defn- request-worker-thread-factory
+  []
+  (let [counter (AtomicLong.)]
+    (reify ThreadFactory
+      (newThread [_ runnable]
+        (doto (Thread. ^Runnable runnable
+                       (str request-worker-thread-name-prefix (.incrementAndGet counter)))
+          (.setDaemon true))))))
+
+(defn- make-request-executor
+  "Bounded worker pool that executes reverse request handlers.
+
+   Handlers are arbitrary caller code that may block, so they must not run on
+   core.async `go` dispatch. Concurrency is capped at `threads`, bursts are
+   absorbed by a bounded queue, and further submissions are rejected so the
+   caller can answer with an explicit overload error instead of blocking the
+   reader thread or silently discarding the request. Core threads time out, so
+   an idle connection holds no worker threads."
+  ^ThreadPoolExecutor [threads queue-size]
+  (doto (ThreadPoolExecutor. (int threads) (int threads)
+                             60 TimeUnit/SECONDS
+                             (ArrayBlockingQueue. (int queue-size))
+                             (request-worker-thread-factory)
+                             (ThreadPoolExecutor$AbortPolicy.))
+    (.allowCoreThreadTimeOut true)))
+
+(defn- connection-stats
+  "Snapshot of a connection's worker and queue counters, for diagnostics and
+   tests.
+
+   - `:dropped-notifications` — notifications discarded because the bounded
+     notification queue was full
+   - `:rejected-requests` — reverse requests answered with an overload error
+     because the handler pool was saturated
+   - `:active-request-workers` / `:queued-requests` — current pool occupancy
+   - `:request-workers-terminated?` — whether the handler pool has shut down"
+  [conn]
+  (let [^ThreadPoolExecutor executor (:request-executor conn)]
+    {:dropped-notifications (.get ^AtomicLong (:dropped-notifications conn))
+     :rejected-requests (.get ^AtomicLong (:rejected-requests conn))
+     :active-request-workers (.getActiveCount executor)
+     :queued-requests (.size (.getQueue executor))
+     :request-workers-terminated? (.isTerminated executor)}))
 
 ;; State path helpers
 (defn- conn-state [state-atom] (get @state-atom :connection))
@@ -266,36 +338,91 @@
 
     :else wire-result))
 
+(defn- run-request-handler!
+  "Execute one reverse request and answer the peer.
+
+   Runs on a worker thread, never inside `go`: `request-handler` is arbitrary
+   caller code that may perform ordinary blocking Clojure or Java work before
+   it returns its result channel.
+
+   There is deliberately no timeout around the handler's result. A wedged
+   handler occupies exactly one worker; the pool bound and the overload error
+   in [[handle-request!]] are what make that visible, rather than a fallback
+   that hides it."
+  [request-handler outgoing-ch method id params]
+  (try
+    (let [result (if request-handler
+                   (<!! (request-handler method params))
+                   {:error {:code -32601 :message "Method not found"}})]
+      (if-let [error (:error result)]
+        (do
+          (log/debug "Request error response: " error)
+          (put! outgoing-ch {:jsonrpc "2.0" :id id :error (util/clj->wire error)}))
+        (do
+          (log/debug "Request success response for id=" id)
+          (put! outgoing-ch {:jsonrpc "2.0" :id id
+                             :result (preserve-outgoing-opaque-fields
+                                      method
+                                      (:result result)
+                                      (util/clj->wire (:result result)))}))))
+    (catch InterruptedException _
+      ;; Expected: `disconnect` interrupts workers still inside a handler.
+      (.interrupt (Thread/currentThread))
+      (log/debug "Reverse request worker interrupted for id=" id))
+    (catch Throwable t
+      (log/error "Request handler exception for method=" method " id=" id ": " (ex-message t))
+      (put! outgoing-ch {:jsonrpc "2.0"
+                         :id id
+                         :error {:code -32603
+                                 :message (str "Internal error: " (ex-message t))}}))))
+
+(defn- reject-request!
+  "Answer a reverse request that the saturated worker pool refused.
+
+   Overload is reported to the peer as an explicit JSON-RPC error: the request
+   is never silently dropped, and the reader thread is never blocked waiting
+   for capacity."
+  [^ThreadPoolExecutor executor ^AtomicLong rejected-requests outgoing-ch method id]
+  (if (.isShutdown executor)
+    (log/debug "Ignoring request during shutdown: method=" method " id=" id)
+    (let [queue (.getQueue executor)
+          max-concurrency (.getMaximumPoolSize executor)
+          queue-size (+ (.size queue) (.remainingCapacity queue))
+          total (.incrementAndGet rejected-requests)]
+      (log/warn "Reverse request handler pool saturated, rejecting request: method=" method
+                " id=" id " max-concurrency=" max-concurrency
+                " queue-size=" queue-size " rejected-total=" total)
+      (put! outgoing-ch
+            {:jsonrpc "2.0"
+             :id id
+             :error {:code -32000
+                     :message "Reverse request handler pool saturated"
+                     :data (util/clj->wire {:code "request_handler_saturated"
+                                            :method method
+                                            :max-concurrency max-concurrency
+                                            :queue-size queue-size})}}))))
+
 (defn- handle-request!
-  "Handle an incoming request message (e.g., tool.call). Sends response via outgoing-ch."
-  [state-atom outgoing-ch msg]
-  (go
-    (let [request-handler (:request-handler (conn-state state-atom))
-          id (:id msg)
-          method (:method msg)
-          params (:params msg)]
-      (log/debug "Received request: method=" method " id=" id)
-      (try
-        (let [result (if request-handler
-                       (<! (request-handler method params))
-                       {:error {:code -32601 :message "Method not found"}})]
-          (if (:error result)
-            (do
-              (log/debug "Request error response: " (:error result))
-              (>! outgoing-ch {:jsonrpc "2.0" :id id :error (util/clj->wire (:error result))}))
-            (do
-              (log/debug "Request success response for id=" id)
-              (>! outgoing-ch {:jsonrpc "2.0" :id id
-                               :result (preserve-outgoing-opaque-fields
-                                        method
-                                        (:result result)
-                                        (util/clj->wire (:result result)))}))))
-        (catch Exception e
-          (log/error "Request handler exception: " (ex-message e))
-          (>! outgoing-ch {:jsonrpc "2.0"
-                           :id id
-                           :error {:code -32603
-                                   :message (str "Internal error: " (ex-message e))}}))))))
+  "Submit an incoming request message (e.g. hooks.invoke) to the connection's
+   bounded reverse-request worker pool.
+
+   Called on the reader thread. Submission is non-blocking, so the reader keeps
+   routing responses and notifications while handlers run."
+  [conn msg]
+  (let [{:keys [state-atom outgoing-ch]} conn
+        ^ThreadPoolExecutor executor (:request-executor conn)
+        request-handler (:request-handler (conn-state state-atom))
+        id (:id msg)
+        method (:method msg)
+        params (:params msg)]
+    (log/debug "Received request: method=" method " id=" id)
+    (try
+      (.execute executor
+                ^Runnable (fn []
+                            (run-request-handler! request-handler outgoing-ch
+                                                  method id params)))
+      (catch RejectedExecutionException _
+        (reject-request! executor (:rejected-requests conn) outgoing-ch method id)))))
 
 (defn- restore-extension-context-payloads
   "Restore the opaque `:payload` of each `extension_context` attachment from
@@ -485,7 +612,7 @@
 (defn- dispatch-message!
   "Route incoming message to appropriate handler."
   [conn msg]
-  (let [{:keys [state-atom incoming-ch outgoing-ch]} conn]
+  (let [{:keys [state-atom]} conn]
     ;; Responses need the originating request method to restore opaque factory
     ;; result values, so defer normalization until handle-response! claims the
     ;; pending entry.
@@ -493,16 +620,18 @@
       (handle-response! state-atom msg)
       (let [normalized (normalize-incoming msg)]
         (cond
-          ;; Request (has id and method) - handle and respond
+          ;; Request (has id and method) - hand off to the bounded worker pool
           (and (:id normalized) (:method normalized))
-          (handle-request! state-atom outgoing-ch normalized)
+          (handle-request! conn normalized)
 
           ;; Notification (has method, no id) - put to incoming-ch for routing
           (:method normalized)
           (do
             (log/debug "Received notification: method=" (:method normalized))
             (when-not (.offer ^LinkedBlockingQueue (:notification-queue conn) normalized)
-              (log/debug "Dropping notification due to full queue")))
+              (let [total (.incrementAndGet ^AtomicLong (:dropped-notifications conn))]
+                (log/warn "Dropping notification due to full queue: method="
+                          (:method normalized) " dropped-total=" total))))
 
           :else nil)))))
 
@@ -629,7 +758,8 @@
         write-ch (Channels/newChannel out)
         incoming-ch (chan 1024)
         outgoing-ch (chan 1024)
-        queue-size (or (get-in @state-atom [:options :notification-queue-size]) 4096)
+        options (get @state-atom :options)
+        queue-size (or (:notification-queue-size options) 4096)
         notification-queue (LinkedBlockingQueue. queue-size)
         conn (map->Connection
               {:read-channel read-ch
@@ -640,7 +770,14 @@
                :outgoing-ch outgoing-ch
                :notification-queue notification-queue
                :notification-thread nil
-               :read-thread nil})]
+               :read-thread nil
+               :request-executor (make-request-executor
+                                  (or (:request-handler-threads options)
+                                      default-request-handler-threads)
+                                  (or (:request-handler-queue-size options)
+                                      default-request-handler-queue-size))
+               :rejected-requests (AtomicLong.)
+               :dropped-notifications (AtomicLong.)})]
 
     ;; Start writer loop
     (start-write-loop! conn)
@@ -674,6 +811,30 @@
       (log/debug "JSON-RPC connection established")
       (assoc conn :read-thread thread))))
 
+(defn- shutdown-request-executor!
+  "Stop the reverse-request worker pool.
+
+   Blocked handlers are interrupted so a wedged handler cannot delay disconnect
+   indefinitely. A pool that still has not terminated is reported rather than
+   silently ignored — a handler that swallows interruption is real diagnostic
+   information. Idempotent.
+
+   An interrupted wait is re-flagged on the calling thread rather than
+   swallowed, but is never propagated: `disconnect` must always reach the
+   channel closes and thread joins that follow it. A later teardown join may
+   legitimately consume the flag."
+  [^ThreadPoolExecutor executor]
+  (when executor
+    (.shutdownNow executor)
+    (let [terminated? (try
+                        (.awaitTermination executor 1000 TimeUnit/MILLISECONDS)
+                        (catch InterruptedException _
+                          (.interrupt (Thread/currentThread))
+                          false))]
+      (when-not terminated?
+        (log/warn "Reverse request handler pool did not terminate within 1000ms; "
+                  (.getActiveCount executor) " handler(s) still running")))))
+
 (defn disconnect
   "Close the connection gracefully.
    Closes NIO channels which causes reader thread to exit via AsynchronousCloseException."
@@ -688,6 +849,10 @@
     ;; clearing :running? so a concurrent send-request fails fast rather than
     ;; registering a new entry we'd miss.
     (drain-pending! state-atom {:code -32000 :message "Connection closed"})
+
+    ;; Release reverse-request workers before closing outgoing-ch, so a handler
+    ;; that is mid-flight can still emit its response.
+    (shutdown-request-executor! (:request-executor conn))
 
     ;; Close outgoing channel first to stop write go-loop
     (close! (:outgoing-ch conn))

--- a/src/github/copilot_sdk/specs.clj
+++ b/src/github/copilot_sdk/specs.clj
@@ -48,6 +48,8 @@
 (s/def ::auto-restart? boolean?)
 (s/def ::notification-queue-size pos-int?)
 (s/def ::router-queue-size pos-int?)
+(s/def ::request-handler-threads pos-int?)
+(s/def ::request-handler-queue-size pos-int?)
 (s/def ::tool-timeout-ms pos-int?)
 (s/def ::env (s/map-of string? (s/nilable string?)))
 ;; Authentication options (PR #237)
@@ -215,6 +217,7 @@
   #{:cli-path :cli-args :cli-url :cwd :port
     :use-stdio? :log-level :auto-start? :auto-restart?
     :notification-queue-size :router-queue-size
+    :request-handler-threads :request-handler-queue-size
     :tool-timeout-ms :env :github-token :use-logged-in-user?
     :is-child-process? :on-list-models :telemetry :on-get-trace-context
     :on-github-telemetry
@@ -228,6 +231,7 @@
     (s/keys :opt-un [::cli-path ::cli-args ::cli-url ::cwd ::port
                      ::use-stdio? ::log-level ::auto-start? ::auto-restart?
                      ::notification-queue-size ::router-queue-size
+                     ::request-handler-threads ::request-handler-queue-size
                      ::tool-timeout-ms ::env ::github-token ::use-logged-in-user?
                      ::is-child-process? ::on-list-models ::telemetry ::on-get-trace-context
                      ::on-github-telemetry

--- a/test/github/copilot_sdk/reverse_rpc_test.clj
+++ b/test/github/copilot_sdk/reverse_rpc_test.clj
@@ -252,7 +252,7 @@
           (protocol/disconnect conn))))))
 
 (deftest test-response-and-error-delivery
-  (testing "results, handler errors, exceptions, and missing handlers all answer"
+  (testing "results, handler errors, contract violations, and exceptions all answer"
     (let [{:keys [conn ->client <-client]} (open-connection {})]
       (try
         (protocol/set-request-handler!
@@ -264,14 +264,16 @@
              "sessionFs.sqliteQuery" (delivered {:result {:rows [{:user_id 7}]
                                                           :rows-affected 0}})
              "handler-error" (delivered {:error {:code -32001 :message "nope"}})
+             "nil-handler" nil
              "boom" (throw (ex-info "handler blew up" {}))
              (delivered {:error {:code -32601 :message "Unknown method"}}))))
         (doseq [[id method] [["ok" "ok"]
                              ["sql" "sessionFs.sqliteQuery"]
                              ["err" "handler-error"]
+                             ["nil" "nil-handler"]
                              ["boom" "boom"]]]
           (write-framed! ->client (request id method {})))
-        (let [responses (collect-by-id! <-client 4 5000)]
+        (let [responses (collect-by-id! <-client 5 5000)]
           (is (not= ::timeout responses))
           (when (not= ::timeout responses)
             (is (= 1 (get-in responses ["ok" :result :someKey]))
@@ -281,6 +283,9 @@
             (is (= 0 (get-in responses ["sql" :result :rowsAffected]))
                 "sibling SDK fields are still converted")
             (is (= -32001 (get-in responses ["err" :error :code])))
+            (is (= -32603 (get-in responses ["nil" :error :code])))
+            (is (str/includes? (get-in responses ["nil" :error :message])
+                               "must return a core.async channel"))
             (is (= -32603 (get-in responses ["boom" :error :code]))
                 "a throwing handler becomes an internal error")
             (is (str/includes? (get-in responses ["boom" :error :message])

--- a/test/github/copilot_sdk/reverse_rpc_test.clj
+++ b/test/github/copilot_sdk/reverse_rpc_test.clj
@@ -1,0 +1,383 @@
+(ns github.copilot-sdk.reverse-rpc-test
+  "Reverse-RPC (server→client request) execution policy.
+
+   These tests drive the real NIO/JSON-RPC transport over piped streams — no
+   protocol mocking — and assert the bounded worker contract:
+
+   - arbitrary handler code runs on the connection's own bounded worker pool,
+     never on core.async `go` dispatch
+   - concurrency never exceeds the configured bound
+   - saturation produces an explicit JSON-RPC error, not a silent drop or stall
+   - the reader thread stays responsive while every worker is blocked
+   - `disconnect` terminates blocked workers
+   - notification-queue overflow is counted and warned (ASY-003 evidence)"
+  (:require [clojure.core.async :as async :refer [chan put! close! >!!]]
+            [clojure.data.json :as json]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [github.copilot-sdk.protocol :as protocol])
+  (:import [java.io InputStream OutputStream PipedInputStream PipedOutputStream]
+           [java.nio.charset StandardCharsets]
+           [java.util.concurrent CountDownLatch TimeUnit]))
+
+(def ^:private pipe-buffer (* 256 1024))
+
+;; The worker-pool diagnostics are protocol-internal. Bind the private Vars once
+;; here rather than widening the production API for tests.
+(def ^:private worker-thread-name-prefix
+  (var-get #'protocol/request-worker-thread-name-prefix))
+
+(defn- connection-stats
+  [conn]
+  (#'protocol/connection-stats conn))
+
+;; -----------------------------------------------------------------------------
+;; Framed JSON-RPC helpers (mirror the Content-Length framing the SDK speaks)
+;; -----------------------------------------------------------------------------
+
+(defn- write-framed!
+  [^OutputStream out msg]
+  (let [body (.getBytes ^String (json/write-str msg) StandardCharsets/UTF_8)]
+    (.write out (.getBytes (str "Content-Length: " (alength body) "\r\n\r\n")
+                           StandardCharsets/UTF_8))
+    (.write out body)
+    (.flush out)))
+
+(defn- read-header-line
+  [^InputStream in]
+  (let [sb (StringBuilder.)]
+    (loop []
+      (let [b (.read in)]
+        (cond
+          (neg? b) (when (pos? (.length sb)) (str sb))
+          (= b 10) (str sb)
+          (= b 13) (recur)
+          :else (do (.append sb (char b)) (recur)))))))
+
+(defn- read-framed
+  "Read one Content-Length framed JSON message, or nil on EOF."
+  [^InputStream in]
+  (loop [headers {}]
+    (if-let [line (read-header-line in)]
+      (if (str/blank? line)
+        (let [n (parse-long (get headers "content-length"))
+              buf (byte-array n)]
+          (loop [off 0]
+            (when (< off n)
+              (let [r (.read in buf off (- n off))]
+                (when (neg? r) (throw (ex-info "EOF mid-message" {:expected n})))
+                (recur (+ off r)))))
+          (json/read-str (String. buf StandardCharsets/UTF_8) :key-fn keyword))
+        (let [[k v] (str/split line #": " 2)]
+          (recur (assoc headers (str/lower-case (str/trim k)) (str/trim (or v ""))))))
+      nil)))
+
+(defn- collect-by-id!
+  "Read `n` framed messages, returning `{id -> message}`. Returns `::timeout`
+   when fewer than `n` arrive within `timeout-ms`."
+  [in n timeout-ms]
+  (let [f (future (into {} (map (juxt :id identity)) (repeatedly n #(read-framed in))))
+        result (deref f timeout-ms ::timeout)]
+    (when (= ::timeout result)
+      (future-cancel f))
+    result))
+
+(defn- wait-for
+  [pred timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (pred) true
+        (< (System/currentTimeMillis) deadline) (do (Thread/sleep 5) (recur))
+        :else false))))
+
+(defn- open-connection
+  "Wire a real protocol connection to piped streams.
+
+   Returns `:conn`, the `:->client` stream the fake server writes requests to,
+   and the `:<-client` stream the fake server reads responses from."
+  [options]
+  (let [->client (PipedOutputStream.)
+        client-in (PipedInputStream. ->client pipe-buffer)
+        client-out (PipedOutputStream.)
+        <-client (PipedInputStream. client-out pipe-buffer)
+        state-atom (atom {:connection (protocol/initial-connection-state)
+                          :options options})]
+    {:conn (protocol/connect client-in client-out state-atom)
+     :state-atom state-atom
+     :->client ->client
+     :<-client <-client}))
+
+(defn- request
+  [id method params]
+  {:jsonrpc "2.0" :id id :method method :params params})
+
+(defn- delivered
+  "A channel already holding `v`, matching the request-handler contract."
+  [v]
+  (doto (chan 1) (put! v) (close!)))
+
+(defn- blocking-handler
+  "Request handler that records entry, blocks until `release` counts down, then
+   answers. `entered` counts handlers currently inside the handler body;
+   `peak` records the high-water mark; `threads` records the thread names.
+
+   The count is decremented in a `finally` so an interrupted handler — the
+   `disconnect` path — is observed to unwind."
+  [{:keys [entered peak threads release]}]
+  (fn [_method _params]
+    (when threads (swap! threads conj (.getName (Thread/currentThread))))
+    (let [now (swap! entered inc)]
+      (when peak (swap! peak max now)))
+    (try
+      (.await ^CountDownLatch release 10 TimeUnit/SECONDS)
+      (finally
+        (swap! entered dec)))
+    (delivered {:result {}})))
+
+;; -----------------------------------------------------------------------------
+;; ASY-004 — bounded execution policy
+;; -----------------------------------------------------------------------------
+
+(deftest test-handler-runs-on-bounded-worker-not-go-dispatch
+  (testing "arbitrary handler code executes on the connection's worker pool"
+    (let [{:keys [conn ->client]} (open-connection {:request-handler-threads 2
+                                                    :request-handler-queue-size 2})
+          release (CountDownLatch. 1)
+          threads (atom #{})
+          entered (atom 0)]
+      (try
+        (protocol/set-request-handler!
+         conn (blocking-handler {:entered entered :threads threads :release release}))
+        (write-framed! ->client (request "r1" "hooks.invoke" {}))
+        (is (true? (wait-for #(= 1 @entered) 2000))
+            "handler should be entered")
+        (is (= 1 (count @threads)))
+        (is (str/starts-with? (first @threads) worker-thread-name-prefix)
+            (str "handler must not run on core.async dispatch; ran on "
+                 (pr-str (first @threads))))
+        (finally
+          (.countDown release)
+          (protocol/disconnect conn))))))
+
+(deftest test-concurrency-is-bounded
+  (testing "no more handlers run concurrently than :request-handler-threads"
+    (let [{:keys [conn ->client]} (open-connection {:request-handler-threads 2
+                                                    :request-handler-queue-size 4})
+          release (CountDownLatch. 1)
+          entered (atom 0)
+          peak (atom 0)]
+      (try
+        (protocol/set-request-handler!
+         conn (blocking-handler {:entered entered :peak peak :release release}))
+        (dotimes [i 6]
+          (write-framed! ->client (request (str "r" i) "hooks.invoke" {})))
+        (is (true? (wait-for #(= 2 @entered) 2000))
+            "both workers should be busy")
+        (is (false? (wait-for #(> @entered 2) 500))
+            "concurrency must never exceed the configured bound")
+        (is (= 2 @peak))
+        (is (= 2 (:active-request-workers (connection-stats conn))))
+        (is (pos? (:queued-requests (connection-stats conn)))
+            "excess requests queue rather than running")
+        (finally
+          (.countDown release)
+          (protocol/disconnect conn))))))
+
+(deftest test-saturation-returns-explicit-error
+  (testing "requests beyond threads+queue get an explicit JSON-RPC failure"
+    (let [{:keys [conn ->client <-client]} (open-connection {:request-handler-threads 2
+                                                             :request-handler-queue-size 2})
+          release (CountDownLatch. 1)
+          entered (atom 0)]
+      (try
+        (protocol/set-request-handler!
+         conn (blocking-handler {:entered entered :release release}))
+        ;; 2 execute, 2 queue, the 5th has nowhere to go.
+        (dotimes [i 5]
+          (write-framed! ->client (request (str "r" i) "hooks.invoke" {})))
+        (let [responses (collect-by-id! <-client 1 3000)]
+          (is (not= ::timeout responses)
+              "an over-capacity request must be answered, not dropped or stalled")
+          (when (not= ::timeout responses)
+            (let [msg (get responses "r4")]
+              (is (some? msg) "the over-capacity request is the one rejected")
+              (is (= -32000 (get-in msg [:error :code])))
+              (is (= "request_handler_saturated" (get-in msg [:error :data :code])))
+              (is (= "hooks.invoke" (get-in msg [:error :data :method])))
+              (is (= 2 (get-in msg [:error :data :maxConcurrency])))
+              (is (= 2 (get-in msg [:error :data :queueSize]))))))
+        (is (= 1 (:rejected-requests (connection-stats conn))))
+        (testing "accepted requests still complete once handlers unblock"
+          (.countDown release)
+          (let [responses (collect-by-id! <-client 4 5000)]
+            (is (not= ::timeout responses))
+            (when (not= ::timeout responses)
+              (is (= #{"r0" "r1" "r2" "r3"} (set (keys responses))))
+              (is (every? #(contains? % :result) (vals responses))))))
+        (finally
+          (.countDown release)
+          (protocol/disconnect conn))))))
+
+(deftest test-router-stays-responsive-while-workers-are-blocked
+  (testing "the reader thread keeps routing while every worker is blocked"
+    (let [{:keys [conn ->client]} (open-connection {:request-handler-threads 1
+                                                    :request-handler-queue-size 1})
+          release (CountDownLatch. 1)
+          entered (atom 0)]
+      (try
+        (protocol/set-request-handler!
+         conn (blocking-handler {:entered entered :release release}))
+        (dotimes [i 3]
+          (write-framed! ->client (request (str "r" i) "hooks.invoke" {})))
+        (is (true? (wait-for #(= 1 @entered) 2000)))
+        (testing "notifications are still dispatched"
+          (write-framed! ->client {:jsonrpc "2.0" :method "session.event"
+                                   :params {:sessionId "s1"}})
+          (let [notif (async/alt!! (protocol/notifications conn) ([v] v)
+                                   (async/timeout 2000) ([_] ::timeout))]
+            (is (not= ::timeout notif))
+            (is (= "session.event" (:method notif)))))
+        (testing "responses to in-flight client requests still resolve"
+          (let [resp-ch (protocol/send-request conn "ping" {})
+                id (ffirst (get-in @(:state-atom conn) [:connection :pending-requests]))]
+            (is (some? id))
+            (write-framed! ->client {:jsonrpc "2.0" :id id :result {:pong true}})
+            (let [result (async/alt!! resp-ch ([v] v)
+                                      (async/timeout 2000) ([_] ::timeout))]
+              (is (not= ::timeout result))
+              (is (true? (get-in result [:result :pong]))))))
+        (finally
+          (.countDown release)
+          (protocol/disconnect conn))))))
+
+(deftest test-response-and-error-delivery
+  (testing "results, handler errors, exceptions, and missing handlers all answer"
+    (let [{:keys [conn ->client <-client]} (open-connection {})]
+      (try
+        (protocol/set-request-handler!
+         conn
+         (fn [method _params]
+           (case method
+             "ok" (delivered {:result {:some-key 1}})
+             ;; Opaque SQL column names must survive the wire conversion.
+             "sessionFs.sqliteQuery" (delivered {:result {:rows [{:user_id 7}]
+                                                          :rows-affected 0}})
+             "handler-error" (delivered {:error {:code -32001 :message "nope"}})
+             "boom" (throw (ex-info "handler blew up" {}))
+             (delivered {:error {:code -32601 :message "Unknown method"}}))))
+        (doseq [[id method] [["ok" "ok"]
+                             ["sql" "sessionFs.sqliteQuery"]
+                             ["err" "handler-error"]
+                             ["boom" "boom"]]]
+          (write-framed! ->client (request id method {})))
+        (let [responses (collect-by-id! <-client 4 5000)]
+          (is (not= ::timeout responses))
+          (when (not= ::timeout responses)
+            (is (= 1 (get-in responses ["ok" :result :someKey]))
+                "results are converted to wire shape")
+            (is (= [{:user_id 7}] (get-in responses ["sql" :result :rows]))
+                "opaque SQL column names are preserved verbatim")
+            (is (= 0 (get-in responses ["sql" :result :rowsAffected]))
+                "sibling SDK fields are still converted")
+            (is (= -32001 (get-in responses ["err" :error :code])))
+            (is (= -32603 (get-in responses ["boom" :error :code]))
+                "a throwing handler becomes an internal error")
+            (is (str/includes? (get-in responses ["boom" :error :message])
+                               "handler blew up"))))
+        (finally
+          (protocol/disconnect conn))))))
+
+(deftest test-missing-handler-answers-method-not-found
+  (testing "with no registered handler the peer still gets a response"
+    (let [{:keys [conn ->client <-client]} (open-connection {})]
+      (try
+        (write-framed! ->client (request "r1" "hooks.invoke" {}))
+        (let [responses (collect-by-id! <-client 1 3000)]
+          (is (not= ::timeout responses))
+          (when (not= ::timeout responses)
+            (is (= -32601 (get-in responses ["r1" :error :code])))))
+        (finally
+          (protocol/disconnect conn))))))
+
+(deftest test-disconnect-terminates-blocked-workers
+  (testing "disconnect shuts the worker pool down instead of leaking threads"
+    (let [{:keys [conn ->client]} (open-connection {:request-handler-threads 2
+                                                    :request-handler-queue-size 2})
+          release (CountDownLatch. 1)
+          entered (atom 0)]
+      (try
+        (protocol/set-request-handler!
+         conn (blocking-handler {:entered entered :release release}))
+        (dotimes [i 2]
+          (write-framed! ->client (request (str "r" i) "hooks.invoke" {})))
+        (is (true? (wait-for #(= 2 @entered) 2000)))
+        (let [started (System/currentTimeMillis)]
+          (protocol/disconnect conn)
+          (is (< (- (System/currentTimeMillis) started) 5000)
+              "disconnect must not wait on a wedged handler indefinitely"))
+        (is (true? (:request-workers-terminated? (connection-stats conn)))
+            "worker pool is terminated after disconnect")
+        (is (true? (wait-for #(zero? @entered) 2000))
+            "blocked handlers are interrupted and unwind")
+        (finally
+          (.countDown release))))))
+
+(deftest test-disconnect-completes-when-caller-thread-is-interrupted
+  (testing "an interrupted caller still gets a full teardown"
+    ;; `awaitTermination` declares InterruptedException; letting it escape would
+    ;; skip the channel closes and thread joins that follow it in `disconnect`.
+    ;; The handler below swallows the `shutdownNow` interrupt, so the pool is
+    ;; guaranteed to still be running when `awaitTermination` is reached.
+    (let [{:keys [conn ->client]} (open-connection {:request-handler-threads 1
+                                                    :request-handler-queue-size 1})
+          release (CountDownLatch. 1)
+          entered (atom 0)
+          read-channel (:read-channel conn)
+          write-channel (:write-channel conn)]
+      (try
+        (protocol/set-request-handler!
+         conn
+         (fn [_method _params]
+           (swap! entered inc)
+           (loop []
+             (when-not (try (.await release 10 TimeUnit/SECONDS)
+                            (catch InterruptedException _ false))
+               (recur)))
+           (delivered {:result {}})))
+        (write-framed! ->client (request "r1" "hooks.invoke" {}))
+        (is (true? (wait-for #(= 1 @entered) 2000)))
+        (.interrupt (Thread/currentThread))
+        (protocol/disconnect conn)
+        (is (false? (.isOpen ^java.nio.channels.ReadableByteChannel read-channel))
+            "read channel must still be closed")
+        (is (false? (.isOpen ^java.nio.channels.WritableByteChannel write-channel))
+            "write channel must still be closed")
+        (finally
+          ;; Teardown's joins may or may not have consumed the flag; make sure
+          ;; it never leaks into a later test.
+          (Thread/interrupted)
+          (.countDown release))))))
+
+;; -----------------------------------------------------------------------------
+;; ASY-003 — notification-queue overflow is observable
+;; -----------------------------------------------------------------------------
+
+(deftest test-notification-overflow-is-counted-and-warned
+  (testing "a saturated notification queue records an explicit drop count"
+    ;; Stall the dispatcher by filling `incoming-ch`, then overrun a
+    ;; deliberately tiny notification queue.
+    (let [{:keys [conn ->client]} (open-connection {:notification-queue-size 1})
+          incoming (protocol/notifications conn)]
+      (try
+        (dotimes [i 1024]
+          (>!! incoming {:method "filler" :params {:i i}}))
+        (is (zero? (:dropped-notifications (connection-stats conn))))
+        (dotimes [i 8]
+          (write-framed! ->client {:jsonrpc "2.0" :method "session.event"
+                                   :params {:sessionId (str "s" i)}}))
+        (is (true? (wait-for #(pos? (:dropped-notifications (connection-stats conn)))
+                             3000))
+            "overflowing the configured queue must be counted, not silent")
+        (finally
+          (protocol/disconnect conn))))))

--- a/test/github/copilot_sdk/reverse_rpc_test.clj
+++ b/test/github/copilot_sdk/reverse_rpc_test.clj
@@ -219,6 +219,25 @@
           (.countDown release)
           (protocol/disconnect conn))))))
 
+(deftest test-shutdown-rejection-returns-connection-closed-error
+  (testing "a reverse request racing with shutdown gets a best-effort response"
+    (let [{:keys [conn <-client]} (open-connection {})]
+      (try
+        (.shutdownNow ^java.util.concurrent.ThreadPoolExecutor
+         (:request-executor conn))
+        (#'protocol/handle-request!
+         conn (request "closing" "hooks.invoke" {}))
+        (let [responses (collect-by-id! <-client 1 3000)]
+          (is (not= ::timeout responses))
+          (when (not= ::timeout responses)
+            (is (= -32000 (get-in responses ["closing" :error :code])))
+            (is (= "connection_closed"
+                   (get-in responses ["closing" :error :data :code])))
+            (is (= "hooks.invoke"
+                   (get-in responses ["closing" :error :data :method])))))
+        (finally
+          (protocol/disconnect conn))))))
+
 (deftest test-router-stays-responsive-while-workers-are-blocked
   (testing "the reader thread keeps routing while every worker is blocked"
     (let [{:keys [conn ->client]} (open-connection {:request-handler-threads 1


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Reverse JSON-RPC request handlers — hooks, `sessionFs.*`, factories, user input, provider tokens, system message transforms — are arbitrary caller code that may block before returning a result. They were invoked from inside a core.async `go` block, where only channel parking is safe. This puts handler execution on a bounded worker pool owned by the connection instead.

The concrete harm was worse than "wrong thread pool". In core.async 1.8, `go` dispatch resolves to the same process-wide unbounded cached `:io` executor that `thread-call` uses, so blocked handlers grew a shared, JVM-global pool at whatever rate the runtime chose to send reverse requests. A 32-request probe with handlers blocking before returning entered all 32 concurrently on `async-io-*` threads; the same probe now caps at the configured bound on `jsonrpc-request-worker-*` threads.

### Behavior

The reader thread only submits work, so it keeps routing responses and notifications while every worker is busy — router responsiveness is structural rather than something the pool size has to be tuned to preserve. Once `:request-handler-threads` + `:request-handler-queue-size` (16 + 256) requests are outstanding, the runtime receives an explicit `-32000` `request_handler_saturated` error carrying the method and the configured limits. Previously such a request would queue indefinitely. The defaults sit far above realistic reverse-RPC concurrency, so hosts should not observe the error in practice.

Saturation uses `AbortPolicy` rather than `CallerRunsPolicy`: running an overflow handler on the caller would execute it on the reader thread, which is exactly the property this change exists to protect. Core threads time out, so an idle connection holds no worker threads.

Teardown interrupts blocked handlers and waits briefly for the pool. That wait is interrupt-safe — an already-cancelled caller cannot abandon `disconnect` partway and leave the NIO channels and transport threads live. Requests still queued but unstarted at teardown are not answered; the transport is going away, so no response was deliverable anyway.

Notification-queue overflow, previously a debug-only log with no counter, is now warned and counted alongside handler rejections. Those counters are protocol-internal diagnostics. `:request-handler-threads` and `:request-handler-queue-size` are the only new public keys — Clojure-side tuning knobs with no upstream SDK counterpart, so this does not move the parity surface.

### Non-goals

No timeout was added around handler execution. A timeout would hide a wedged handler behind a synthetic failure; instead a wedged handler occupies exactly one worker and becomes visible through the bound, the overload error, and the counters.

The notification-drop path gets observability only. The saturation test demonstrates that drops are reachable and counted, not that a terminal session event can be lost, so no event prioritization, retry, preservation, or transport redesign is included here.
