### PR TITLE
fix: unify cleanup diagnostics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,6 +191,7 @@ src/github/copilot_sdk/
 ├── util.clj         # Wire conversion (camelCase ↔ kebab-case), MCP helpers
 ├── protocol.clj     # JSON-RPC 2.0 protocol over NIO channels
 ├── process.clj      # CLI process management (spawning, lifecycle)
+├── teardown.clj     # Shared teardown-outcome contract (expected vs unexpected cleanup failures)
 ├── logging.clj      # Logging facade via clojure.tools.logging
 └── generated/       # AUTO-GENERATED — produced by `bb codegen`. Do not edit.
     ├── event_specs.clj  # clojure.spec for upstream session events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,63 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed (cleanup diagnostics and failed-connect teardown)- **A rejected handshake no longer retains transport resources** --
+  `connect-with-streams!` set `:status :error` and rethrew without releasing
+  anything it had built, so a rejected protocol version left the JSON-RPC
+  connection, its reader/writer/dispatcher threads, and the reverse-request
+  executor live. A retry then overwrote `:connection-io`, orphaning them with no
+  remaining handle. It now runs the same teardown as a failed `start!`, so a
+  caller can retry without cleanup of its own.
+- **One cleanup path** -- `start!`, `stop!`, `force-stop!`, and
+  `connect-with-streams!` each hand-rolled the same router/connection/socket/
+  process sequence (or, in one case, none of it). They now share
+  `release-transport!`, parameterized by how the child process should be
+  released. `stop!`'s RPC ordering (`runtime.shutdown` before transport
+  teardown, graceful wait before signalling) is unchanged.
+- **Expected and unexpected teardown failures are no longer conflated** --
+  closing a socket or channel and joining a finished thread are idempotent by
+  contract, so a step that throws is either an interruption of the calling
+  thread or a genuine failure that left the resource live. Blanket
+  `(catch Exception _)` branches in `protocol/disconnect`, `process/destroy!`,
+  and the client teardown paths made the second case invisible. Unexpected
+  failures now carry the operation and resource identity and reach the caller
+  through the existing contract: `stop!` returns them in its error vector,
+  `force-stop!` and a failed `start!` log them. Expected outcomes stay quiet,
+  interrupts are re-flagged rather than swallowed, and a failing step never
+  short-circuits the steps that follow it.
+- **`stderr-reader` distinguishes a closed stream from a real read failure** --
+  an `IOException` is now classified by process liveness: once the child has
+  exited its stderr is expected to fail and is logged at debug, but a stderr
+  failure while the child is still running hides its diagnostics and is warned
+  with the Throwable and resource identity instead of discarded.
+- **A child that outlives a forced kill is no longer reported as clean
+  teardown** -- `destroy!` ignored the boolean from the wait that follows
+  `destroyForcibly`, and `destroy-forcibly!` (the `force-stop!` path) sent
+  SIGKILL without waiting at all. In both cases a surviving process produced no
+  failures and the client cleared `:process`, discarding the only handle to a
+  live process. Both paths now share one confirm step: the child is signalled,
+  then waited on for a bounded window, and a survivor is reported as an
+  unexpected failure carrying `:operation :wait-for-exit`, `:resource :process`,
+  and the `:stage`/`:timeout-ms` that elapsed. The client keeps the process
+  handle whenever process teardown reported a failure. `force-stop!` still
+  returns `nil`, and the wait ends as soon as the child dies, so the bound is a
+  worst case rather than a fixed delay.
+
+### Fixed (logging)
+- **The logging facade preserves Throwable-first semantics** -- every macro
+  expanded to `(str ...)` over all arguments, so a Throwable was flattened into
+  the message text (class and message only, no stack trace) and never reached
+  the backend as a throwable. `debug`/`info`/`warn`/`error` now dispatch on the
+  first argument and pass a leading Throwable through `clojure.tools.logging`'s
+  portable `(log level throwable message)` arity, so backends render stack
+  traces again. Every argument is evaluated exactly once and only after the
+  level is known to be enabled, so a disabled level costs nothing however
+  expensive its arguments are. Message rendering for calls without a leading
+  Throwable is unchanged.
+- Removed the full `json/write-str` dump of outgoing permission responses from
+  the protocol writer's debug logging; the adjacent message-id line already
+  identifies the message without serializing its payload.
+
 ### Changed (reverse-RPC execution policy)
 - **Reverse request handlers run on a bounded worker pool** -- server-to-client RPC
   handlers (hooks, `sessionFs.*`, factories, user input, provider tokens,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
-### Fixed (cleanup diagnostics and failed-connect teardown)- **A rejected handshake no longer retains transport resources** --
+### Fixed (cleanup diagnostics and failed-connect teardown)
+- **A rejected handshake no longer retains transport resources** --
   `connect-with-streams!` set `:status :error` and rethrew without releasing
   anything it had built, so a rejected protocol version left the JSON-RPC
   connection, its reader/writer/dispatcher threads, and the reverse-request

--- a/doc/reference/API.md
+++ b/doc/reference/API.md
@@ -203,6 +203,12 @@ timeout or error the SDK falls back to terminating the process (SIGTERM, then
 SIGKILL). Connecting to an external server (`:cli-url`) skips the shutdown RPC and
 the process is left running. (upstream [PR #1667](https://github.com/github/copilot-sdk/pull/1667))
 
+Returns a vector of any errors encountered during cleanup — a failed session
+disconnect, a failed `runtime.shutdown`, or a transport resource that could not
+be released. An empty vector means everything shut down cleanly. Errors are
+reported rather than thrown, so a single failure never leaves the rest of the
+teardown undone.
+
 #### `force-stop!`
 
 ```clojure
@@ -212,6 +218,13 @@ the process is left running. (upstream [PR #1667](https://github.com/github/copi
 Force stop the CLI server without graceful RPCs. It closes local session event
 subscriptions and releases in-flight session work before closing the transport
 and terminating an SDK-owned process. Use when `stop!` takes too long.
+
+The forced kill is confirmed rather than assumed: the child is signalled and
+then waited on for a bounded window. A child that survives is logged with its
+resource identity, and its handle is kept in client state so the host is never
+left holding no reference to a live process. The wait ends as soon as the child
+dies, so it is a worst-case bound, not a fixed delay. `force-stop!` still
+returns `nil`.
 
 #### `client-options`
 

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -11,6 +11,7 @@
             [github.copilot-sdk.specs :as specs]
             [github.copilot-sdk.session :as session]
             [github.copilot-sdk.util :as util]
+            [github.copilot-sdk.teardown :as td]
             [github.copilot-sdk.logging :as log])
   (:import [java.net Socket]
            [java.util.concurrent LinkedBlockingQueue]))
@@ -1197,6 +1198,88 @@
   [_request _ctx]
   {:kind :no-result})
 
+(defn- release-router!
+  "Stop notification routing and release its thread and channels.
+
+   Returns a vector of unexpected teardown failures. Idempotent: the state keys
+   are cleared, so a second call is a no-op."
+  [client]
+  (swap! (:state client) assoc :router-running? false)
+  (let [{:keys [router-thread router-ch lifecycle-ch]} @(:state client)
+        failures (td/collect
+                  [(when-let [^Thread t router-thread]
+                     (td/attempt {:operation :join :resource :router-thread}
+                                 (.interrupt t)
+                                 (.join t 500)))])]
+    (when router-ch (close! router-ch))
+    (when lifecycle-ch (close! lifecycle-ch))
+    (swap! (:state client) assoc
+           :router-ch nil :router-queue nil :router-thread nil :lifecycle-ch nil)
+    failures))
+
+(defn- release-transport!
+  "Release the client-owned transport: notification router, JSON-RPC
+   connection, socket, and — per `:process` — an SDK-owned child process.
+
+   `:process` is `:none` (the caller owns the process, or there is none),
+   `:graceful` (SIGTERM, then SIGKILL if it overstays), or `:forcible`
+   (SIGKILL). When `:wait-for-exit-ms` is set, a process that has already been
+   asked to shut down is first given that long to exit on its own.
+
+   Every step runs even when an earlier one fails, and the whole sequence is
+   idempotent. Returns a vector of unexpected teardown failures.
+
+   The process handle is cleared only once the child is confirmed gone: a kill
+   that failed leaves `:process` in place so the host keeps its only reference
+   to a live process."
+  [client {:keys [process wait-for-exit-ms] :or {process :none}}]
+  (let [router-failures (release-router! client)
+        state @(:state client)
+        {:keys [connection-io socket]} state
+        proc-handle (:process state)
+        own-process? (boolean (and (not= process :none)
+                                   (not (:external-server? client))
+                                   proc-handle))
+        process-failures
+        (if-not own-process?
+          []
+          (if (= process :forcible)
+            (td/attempt-collecting {:operation :destroy-forcibly :resource :process}
+                                   (proc/destroy-forcibly! proc-handle))
+            (td/attempt-collecting {:operation :destroy :resource :process}
+                                   ;; A runtime that already accepted
+                                   ;; `runtime.shutdown` gets to exit on its own
+                                   ;; before we signal it.
+                                   (if (and wait-for-exit-ms
+                                            (proc/wait-for-exit! proc-handle wait-for-exit-ms))
+                                     []
+                                     (proc/destroy! proc-handle)))))
+        failures
+        (td/collect
+         (concat
+          router-failures
+          (when connection-io
+            (td/attempt-collecting {:operation :disconnect :resource :connection}
+                                   (proto/disconnect connection-io)))
+          [(when socket
+             (td/attempt {:operation :close :resource :socket}
+                         (.close ^Socket socket)))]
+          process-failures))]
+    (swap! (:state client) assoc :connection nil :connection-io nil :socket nil)
+    ;; Only drop the process handle once the child is confirmed gone. Clearing
+    ;; it after a failed kill would discard the only reference to a live
+    ;; process, leaving the host no way to retry or report it.
+    (when (and own-process? (empty? process-failures))
+      (swap! (:state client) assoc :process nil))
+    failures))
+
+(defn- log-teardown-failures!
+  "Report teardown failures that no caller-visible return value carries."
+  [failures]
+  (doseq [^Throwable failure failures]
+    (log/warn failure "Client teardown step failed"))
+  failures)
+
 (defn start!
   "Start the CLI server and establish connection.
    Blocks until connected or throws on error.
@@ -1287,26 +1370,8 @@
           ;; left as :error (not :disconnected) so callers can distinguish a
           ;; failed start from a clean stop.
             (swap! (:state client) assoc :stopping? true)
-          ;; Tear down the notification router if it was started before the
-          ;; failure (mirrors stop!), so its dispatcher thread/channel don't leak.
-            (swap! (:state client) assoc :router-running? false)
-            (when-let [^Thread router-thread (:router-thread @(:state client))]
-              (.interrupt router-thread)
-              (try (.join router-thread 500) (catch Exception _)))
-            (when-let [router-ch (:router-ch @(:state client))]
-              (close! router-ch))
-            (when-let [lifecycle-ch (:lifecycle-ch @(:state client))]
-              (close! lifecycle-ch))
-            (swap! (:state client) assoc :router-ch nil :router-queue nil :router-thread nil :lifecycle-ch nil)
-            (let [{:keys [connection-io socket process]} @(:state client)]
-              (when connection-io
-                (try (proto/disconnect connection-io) (catch Exception _)))
-              (when socket
-                (try (.close ^Socket socket) (catch Exception _)))
-              (when (and (not (:external-server? client)) process)
-                (try (proc/destroy! process) (catch Exception _))))
-            (swap! (:state client) assoc :status :error :connection nil
-                   :connection-io nil :socket nil :process nil :actual-port nil)
+            (log-teardown-failures! (release-transport! client {:process :graceful}))
+            (swap! (:state client) assoc :status :error :actual-port nil)
             (throw e)))))))
 
 (defn stop!
@@ -1329,18 +1394,12 @@
   (swap! (:state client) assoc :stopping? true)
   (let [errors (atom [])
         runtime-shutdown-completed? (atom false)
-        {:keys [sessions session-io process connection-io socket]} @(:state client)]
+        {:keys [sessions process connection-io]} @(:state client)]
     (try
-      ;; 0. Stop notification routing
-      (swap! (:state client) assoc :router-running? false)
-      (when-let [^Thread router-thread (:router-thread @(:state client))]
-        (.interrupt router-thread)
-        (try (.join router-thread 500) (catch Exception _)))
-      (when-let [router-ch (:router-ch @(:state client))]
-        (close! router-ch))
-      (when-let [lifecycle-ch (:lifecycle-ch @(:state client))]
-        (close! lifecycle-ch))
-      (swap! (:state client) assoc :router-ch nil :router-queue nil :router-thread nil :lifecycle-ch nil)
+      ;; 0. Stop notification routing. Done before the session disconnects and
+      ;; the runtime.shutdown RPC below; release-transport! then finds it
+      ;; already released.
+      (swap! errors into (release-router! client))
 
       ;; 1. Disconnect all sessions
       (doseq [[session-id _] sessions]
@@ -1354,7 +1413,8 @@
 
       ;; 1b. Ask SDK-owned runtimes to flush and clean up before tearing down
       ;; their transport/process. External runtimes may be shared, so we only
-      ;; close our connection to them (see step 2). Bounded by a 10s timeout.
+      ;; close our connection to them (see release-transport!). Bounded by a
+      ;; 10s timeout.
       (when (and connection-io process (not (:external-server? client)))
         (try
           (proto/send-request! connection-io "runtime.shutdown" {} 10000)
@@ -1363,36 +1423,13 @@
             (swap! errors conj
                    (ex-info "Failed to gracefully shut down runtime" {} e)))))
 
-      ;; 2. Close connection (non-blocking, may leave read thread blocked for stdio)
-      (when connection-io
-        (try
-          (proto/disconnect connection-io)
-          (catch Exception e
-            (swap! errors conj
-                   (ex-info "Failed to close connection" {} e))))
-        (swap! (:state client) assoc :connection nil :connection-io nil))
-
-      ;; 3. Close socket (TCP mode)
-      (when socket
-        (try
-          (.close ^Socket socket)
-          (catch Exception e
-            (swap! errors conj
-                   (ex-info "Failed to close socket" {} e))))
-        (swap! (:state client) assoc :socket nil))
-
-      ;; 4. Terminate the CLI process (this also unblocks any stdio read thread).
-      ;; When runtime.shutdown succeeded, give the child up to 10s to exit on its
-      ;; own first; only force-kill (SIGTERM->wait->SIGKILL) if it overstays.
-      (when (and (not (:external-server? client)) process)
-        (try
-          (when-not (and @runtime-shutdown-completed?
-                         (proc/wait-for-exit! process 10000))
-            (proc/destroy! process))
-          (catch Exception e
-            (swap! errors conj
-                   (ex-info "Failed to kill CLI process" {} e))))
-        (swap! (:state client) assoc :process nil))
+      ;; 2. Release connection, socket, and the SDK-owned process. When
+      ;; runtime.shutdown succeeded, give the child up to 10s to exit on its own
+      ;; before signalling it.
+      (swap! errors into
+             (release-transport! client
+                                 {:process :graceful
+                                  :wait-for-exit-ms (when @runtime-shutdown-completed? 10000)}))
 
       (swap! (:state client) assoc :status :disconnected :actual-port nil
              :models-cache nil :lifecycle-handlers {}
@@ -1405,49 +1442,30 @@
   "Force stop the CLI server without graceful RPCs.
 
    Releases locally-owned session resources before dropping client ownership, then
-   closes the transport and terminates an SDK-owned process."
+   closes the transport and terminates an SDK-owned process.
+
+   The forced kill is confirmed: the child is signalled and then waited on for a
+   bounded window, because a signal that was merely sent proves nothing. A child
+   that survives is logged with its resource identity and its handle is kept in
+   client state, so the host is never left holding no reference to a live
+   process. The wait ends as soon as the child dies, so it is a worst-case
+   bound rather than a fixed delay."
   [client]
   (swap! (:state client) assoc :stopping? true :lifecycle-handlers {})
 
-  (let [{:keys [connection-io socket process sessions]} @(:state client)
-        session-ids (keys sessions)]
-    (try
-      ;; Release event roots and send locks while their state is still reachable.
-      (doseq [session-id session-ids]
-        (session/teardown-local! client session-id))
-      (swap! (:state client) assoc :sessions {} :session-io {})
+  (let [session-ids (keys (:sessions @(:state client)))]
+    ;; Release event roots and send locks while their state is still reachable.
+    (doseq [session-id session-ids]
+      (session/teardown-local! client session-id))
+    (swap! (:state client) assoc :sessions {} :session-io {})
 
-      ;; Stop notification routing
-      (swap! (:state client) assoc :router-running? false)
-      (when-let [^Thread router-thread (:router-thread @(:state client))]
-        (.interrupt router-thread)
-        (try (.join router-thread 500) (catch Exception _)))
-      (when-let [router-ch (:router-ch @(:state client))]
-        (close! router-ch))
-      (when-let [lifecycle-ch (:lifecycle-ch @(:state client))]
-        (close! lifecycle-ch))
-      (swap! (:state client) assoc :router-ch nil :router-queue nil :router-thread nil :lifecycle-ch nil)
-
-      ;; Force close connection
-      (when connection-io
-        (try (proto/disconnect connection-io) (catch Exception _)))
-
-      ;; Force close socket
-      (when socket
-        (try (.close ^Socket socket) (catch Exception _)))
-
-      ;; Force kill process
-      (when (and (not (:external-server? client)) process)
-        (try (proc/destroy-forcibly! process) (catch Exception _)))
-      (finally
-        nil)))
+    (log-teardown-failures! (release-transport! client {:process :forcible})))
 
   (swap! (:state client) merge
          {:status :disconnected
           :connection nil
           :connection-io nil
           :socket nil
-          :process nil
           :actual-port nil
           :router-ch nil
           :router-queue nil
@@ -3345,5 +3363,10 @@
         (swap! (:state client) assoc :status :connected)
         nil
         (catch Exception e
+          ;; Reuse the same teardown as a failed start! so a rejected handshake
+          ;; leaves no connection, router, or reverse-request executor behind
+          ;; and the caller can retry without cleanup of its own. The streams
+          ;; belong to the caller, so no process is touched.
+          (log-teardown-failures! (release-transport! client {:process :none}))
           (swap! (:state client) assoc :status :error)
           (throw e))))))

--- a/src/github/copilot_sdk/logging.clj
+++ b/src/github/copilot_sdk/logging.clj
@@ -8,25 +8,48 @@
 ;; Re-export tools.logging macros for SDK use
 ;; Users can configure logging backend (SLF4J) as they prefer
 
+(defn- log-form
+  "Build the expansion for a facade logging macro.
+
+   A leading Throwable is handed to the backend as a throwable so it keeps the
+   backend's stack-trace rendering; the remaining arguments form the message.
+   Otherwise every argument is concatenated into the message as before.
+
+   Every argument is evaluated exactly once, and only after the level is known
+   to be enabled: the whole form sits inside `enabled?`, so a disabled level
+   costs nothing no matter how expensive the arguments are.
+
+   Only tools.logging's portable `(log level throwable message)` arity is used,
+   so this works on any SLF4J backend. Both `enabled?` and `log` capture the
+   calling namespace, so events stay attributed to the caller rather than to
+   this facade."
+  [level args]
+  `(when (log/enabled? ~level)
+     (let [args# [~@args]
+           throwable?# (instance? Throwable (first args#))]
+       (log/log ~level
+                (when throwable?# (first args#))
+                (apply str (if throwable?# (rest args#) args#))))))
+
 (defmacro debug
-  "Log a debug message."
+  "Log a debug message. A leading Throwable is attached to the log event."
   [& args]
-  `(log/debug (str ~@args)))
+  (log-form :debug args))
 
 (defmacro info
-  "Log an info message."
+  "Log an info message. A leading Throwable is attached to the log event."
   [& args]
-  `(log/info (str ~@args)))
+  (log-form :info args))
 
 (defmacro warn
-  "Log a warning message."
+  "Log a warning message. A leading Throwable is attached to the log event."
   [& args]
-  `(log/warn (str ~@args)))
+  (log-form :warn args))
 
 (defmacro error
-  "Log an error message."
+  "Log an error message. A leading Throwable is attached to the log event."
   [& args]
-  `(log/error (str ~@args)))
+  (log-form :error args))
 
 ;; Legacy compatibility - no-op since logging config is via SLF4J backend
 (defn set-log-level!

--- a/src/github/copilot_sdk/process.clj
+++ b/src/github/copilot_sdk/process.clj
@@ -1,7 +1,9 @@
 (ns github.copilot-sdk.process
   "Process management for spawning and managing the Copilot CLI."
   (:require [clojure.core.async :as async :refer [chan close! >!!]]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [github.copilot-sdk.logging :as log]
+            [github.copilot-sdk.teardown :as td])
   (:import [java.lang ProcessBuilder ProcessBuilder$Redirect]
            [java.io File]
            [java.net Socket]))
@@ -163,29 +165,82 @@
         :stderr (.getErrorStream process)
         :exit-chan exit-chan}))))
 
+(def ^:private forcible-wait-timeout-ms
+  "How long to wait for a SIGKILLed child to actually disappear."
+  2000)
+
+(defn- force-kill-and-confirm!
+  "SIGKILL `p` and confirm it is gone within `forcible-wait-timeout-ms`.
+
+   Returns a vector of unexpected teardown failures: the signal call throwing,
+   the wait throwing, or the child still running once the window elapses. An
+   empty vector means the child is confirmed dead."
+  [^Process p]
+  (let [exited? (volatile! false)
+        step {:operation :wait-for-exit :resource :process
+              :stage :forcible :timeout-ms forcible-wait-timeout-ms}
+        signal-failure (td/attempt {:operation :destroy-forcibly :resource :process}
+                                   (.destroyForcibly p))
+        wait-failure (td/attempt step
+                                 (vreset! exited?
+                                          (.waitFor p forcible-wait-timeout-ms
+                                                    java.util.concurrent.TimeUnit/MILLISECONDS)))]
+    (td/collect
+     [signal-failure
+      wait-failure
+      ;; The wait returning false means the child outlived SIGKILL. Only report
+      ;; it when the wait itself did not already fail, so one condition is not
+      ;; reported twice.
+      (when (and (nil? wait-failure) (not @exited?))
+        (td/failure step))])))
+
 (defn destroy!
-  "Destroy the process gracefully with timeout."
+  "Destroy the process gracefully with timeout.
+
+   Returns a vector of `ex-info` values describing *unexpected* teardown
+   failures; an interrupted wait is re-flagged on the calling thread rather
+   than reported. Every step runs even when an earlier one fails.
+
+   A process that is still running after the forced kill window is itself an
+   unexpected failure: it is reported with `:operation :wait-for-exit`,
+   `:resource :process`, and the `:stage`/`:timeout-ms` that failed, so callers
+   never mistake a surviving child for a clean teardown."
   ([^ManagedProcess mp]
    (destroy! mp 5000))
   ([^ManagedProcess mp timeout-ms]
-   (when-let [^Process p (:process mp)]
-     (.destroy p)
-     ;; Wait for process to exit with timeout
-     (let [exited (try
-                    (.waitFor p timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)
-                    (catch Exception _ false))]
-       (when-not exited
-         ;; Force kill if still running
-         (.destroyForcibly p)
-         (try
-           (.waitFor p 2000 java.util.concurrent.TimeUnit/MILLISECONDS)
-           (catch Exception _)))))))
+   (if-let [^Process p (:process mp)]
+     (let [exited? (volatile! false)
+           graceful-step {:operation :wait-for-exit :resource :process
+                          :stage :graceful :timeout-ms timeout-ms}
+           destroy-failure (td/attempt {:operation :destroy :resource :process}
+                                       (.destroy p))
+           wait-failure (td/attempt graceful-step
+                                    (vreset! exited?
+                                             (.waitFor p timeout-ms
+                                                       java.util.concurrent.TimeUnit/MILLISECONDS)))]
+       (if @exited?
+         (td/collect [destroy-failure wait-failure])
+         ;; Still running (or the wait itself failed): force kill, then confirm.
+         (td/collect (concat [destroy-failure wait-failure]
+                             (force-kill-and-confirm! p)))))
+     [])))
 
 (defn destroy-forcibly!
-  "Force destroy the process."
+  "Force destroy the process, then confirm it is gone.
+
+   Sends SIGKILL and waits up to a bounded window for the child to disappear,
+   because a signal that was merely *sent* proves nothing: without the wait a
+   surviving child is indistinguishable from a dead one, and the caller would
+   discard its only handle to a live process.
+
+   Returns `[]` only when the child is confirmed exited; otherwise a vector of
+   identity-rich `ex-info` failures (`:operation`, `:resource`, `:stage`,
+   `:timeout-ms`). The wait ends as soon as the child dies, so the bound is a
+   worst case, not a fixed delay."
   [^ManagedProcess mp]
-  (when-let [^Process p (:process mp)]
-    (.destroyForcibly p)))
+  (if-let [^Process p (:process mp)]
+    (force-kill-and-confirm! p)
+    []))
 
 (defn alive?
   "Check if process is still running."
@@ -269,7 +324,16 @@
           (when-let [line (.readLine reader)]
             (>!! ch {:type :stderr :line line})
             (recur)))
-        (catch Exception _)
+        (catch java.io.IOException e
+          ;; Process liveness is the signal that separates the two cases: once
+          ;; the child is gone its stderr is expected to fail, but losing
+          ;; stderr while the child is still running hides its diagnostics.
+          (if (alive? mp)
+            (log/warn e "Failed to read CLI stderr while the process is still alive"
+                      " resource=stderr")
+            (log/debug "stderr reader stopped after CLI exit: " (ex-message e))))
+        (catch Exception e
+          (log/warn e "Unexpected failure reading CLI stderr resource=stderr"))
         (finally
           (close! ch))))
     ch))

--- a/src/github/copilot_sdk/protocol.clj
+++ b/src/github/copilot_sdk/protocol.clj
@@ -16,6 +16,7 @@
             [clojure.core.async.impl.protocols :as async-protocols]
             [clojure.string :as str]
             [github.copilot-sdk.logging :as log]
+            [github.copilot-sdk.teardown :as td]
             [github.copilot-sdk.util :as util])
   (:import [java.io InputStream OutputStream IOException]
            [java.nio ByteBuffer]
@@ -714,13 +715,6 @@
                              (when-let [msg (.poll write-queue 100 java.util.concurrent.TimeUnit/MILLISECONDS)]
                                (when (and (:running? (conn-state state-atom)) (.isOpen write-channel))
                                  (try
-                                   (when (and (:id msg)
-                                              (not (:method msg))
-                                              (map? (:result msg))
-                                              (or (contains? (:result msg) :kind)
-                                                  (and (map? (:result (:result msg)))
-                                                       (contains? (:result (:result msg)) :kind))))
-                                     (log/debug "Sending permission response: " (json/write-str msg)))
                                    (log/debug "Writing message: " (if (:id msg) (str "id=" (:id msg)) "notification"))
                                    (write-message! write-channel msg)
                                    (.flush output-stream)
@@ -850,7 +844,11 @@
 
 (defn disconnect
   "Close the connection gracefully.
-   Closes NIO channels which causes reader thread to exit via AsynchronousCloseException."
+   Closes NIO channels which causes reader thread to exit via AsynchronousCloseException.
+
+   Returns a vector of `ex-info` values describing *unexpected* teardown
+   failures; expected close/interruption outcomes are not reported. Every step
+   runs even when an earlier one fails, and the whole sequence is idempotent."
   [conn]
   (log/debug "Disconnecting JSON-RPC connection")
   (let [state-atom (:state-atom conn)]
@@ -871,28 +869,33 @@
     ;; Close outgoing channel first to stop write go-loop
     (close! (:outgoing-ch conn))
 
-    ;; Interrupt writer thread if it exists
-    (when-let [^Thread writer (:writer-thread (conn-state state-atom))]
-      (.interrupt writer)
-      (try (.join writer 500) (catch Exception _)))
+    (let [failures
+          (td/collect
+           [;; Interrupt writer thread if it exists
+            (when-let [^Thread writer (:writer-thread (conn-state state-atom))]
+              (td/attempt {:operation :join :resource :writer-thread}
+                          (.interrupt writer)
+                          (.join writer 500)))
 
-    ;; Interrupt notification dispatcher thread
-    (when-let [^Thread thread (:notification-thread (conn-state state-atom))]
-      (.interrupt thread)
-      (try (.join thread 500) (catch Exception _)))
+            ;; Interrupt notification dispatcher thread
+            (when-let [^Thread thread (:notification-thread (conn-state state-atom))]
+              (td/attempt {:operation :join :resource :notification-thread}
+                          (.interrupt thread)
+                          (.join thread 500)))
 
-    ;; Close NIO channels - this unblocks any blocked reads
-    (try (.close ^ReadableByteChannel (:read-channel conn)) (catch Exception _))
-    (try (.close ^WritableByteChannel (:write-channel conn)) (catch Exception _))
+            ;; Close NIO channels - this unblocks any blocked reads
+            (td/attempt {:operation :close :resource :read-channel}
+                        (.close ^ReadableByteChannel (:read-channel conn)))
+            (td/attempt {:operation :close :resource :write-channel}
+                        (.close ^WritableByteChannel (:write-channel conn)))
 
-    ;; Wait for read thread to exit
-    (when-let [^Thread thread (:read-thread conn)]
-      (try
-        (.interrupt thread)
-        (.join thread 1000)
-        (catch Exception _)))
-
-    (log/debug "JSON-RPC connection closed")))
+            ;; Wait for read thread to exit
+            (when-let [^Thread thread (:read-thread conn)]
+              (td/attempt {:operation :join :resource :read-thread}
+                          (.interrupt thread)
+                          (.join thread 1000)))])]
+      (log/debug "JSON-RPC connection closed")
+      failures)))
 
 (defn- remove-pending-by-chan!
   "Remove a pending request entry by channel identity."

--- a/src/github/copilot_sdk/teardown.clj
+++ b/src/github/copilot_sdk/teardown.clj
@@ -1,0 +1,68 @@
+(ns github.copilot-sdk.teardown
+  "One teardown-outcome contract shared by the client, protocol, and process
+   layers.
+
+   Closing a socket, closing an NIO channel, and joining a finished thread are
+   idempotent by contract: they do not throw when the resource is already gone.
+   A teardown step that *does* throw is therefore either an interruption of the
+   calling thread or a genuine failure that left the resource live. Collapsing
+   both into `(catch Exception _)` is what makes a leaked resource invisible.
+
+   `attempt` keeps the two apart: expected outcomes are silent, unexpected ones
+   become an `ex-info` carrying the operation and resource identity so the
+   caller can return or log it. Nothing is propagated, so a failing step cannot
+   short-circuit the steps that follow it."
+  (:import [java.nio.channels ClosedChannelException]))
+
+(defn expected-failure?
+  "True when `t` is a normal outcome of releasing a resource that is already
+   closing: interruption of the calling thread, or a channel some other
+   teardown step already closed."
+  [^Throwable t]
+  (or (instance? InterruptedException t)
+      (instance? ClosedChannelException t)))
+
+(defn failure
+  "Build the `ex-info` reported for an unexpected teardown failure.
+   `step` is a `{:operation _ :resource _}` map identifying what was released,
+   plus any extra context (stage, timeout) worth carrying to the caller.
+
+   `cause` is optional: a resource can fail to be released without anything
+   being thrown, e.g. a process that is still alive after a forced kill."
+  ([step] (failure step nil))
+  ([step ^Throwable cause]
+   (ex-info (str (name (:operation step)) " failed for " (name (:resource step)))
+            step
+            cause)))
+
+(defn collect
+  "Drop the nils from a sequence of `attempt` results."
+  [results]
+  (into [] (remove nil?) results))
+
+(defmacro attempt
+  "Run a teardown step for effect. Returns nil on success or on an expected
+   close/interruption outcome, otherwise the `failure` for `step`.
+
+   An interrupt is re-flagged on the calling thread rather than swallowed, so
+   later cancellation logic still observes it, but is never propagated:
+   teardown must always reach the steps that follow."
+  [step & body]
+  `(try
+     ~@body
+     nil
+     (catch InterruptedException _#
+       (.interrupt (Thread/currentThread))
+       nil)
+     (catch Exception e#
+       (when-not (expected-failure? e#)
+         (failure ~step e#)))))
+
+(defmacro attempt-collecting
+  "Like `attempt`, but `body` itself returns a vector of teardown failures (a
+   nested teardown). Returns those failures together with any failure raised by
+   the call itself."
+  [step & body]
+  `(let [collected# (volatile! nil)
+         thrown# (attempt ~step (vreset! collected# (do ~@body)))]
+     (collect (conj (vec @collected#) thrown#))))

--- a/test/github/copilot_sdk/force_stop_test.clj
+++ b/test/github/copilot_sdk/force_stop_test.clj
@@ -91,7 +91,8 @@
     (with-redefs [protocol/disconnect
                   (fn [_]
                     (reset! handlers-at-disconnect
-                            (:lifecycle-handlers @(:state client))))]
+                            (:lifecycle-handlers @(:state client)))
+                    [])]
       (sdk/force-stop! client))
     (is (= {} @handlers-at-disconnect))))
 

--- a/test/github/copilot_sdk/integration_test.clj
+++ b/test/github/copilot_sdk/integration_test.clj
@@ -9149,7 +9149,7 @@
           killed? (atom false)]
       (swap! (:state *test-client*) assoc :process {:placeholder true})
       (with-redefs [proc/wait-for-exit! (fn [_ _] (reset! waited? true) true)
-                    proc/destroy! (fn [_] (reset! killed? true))]
+                    proc/destroy! (fn [_] (reset! killed? true) [])]
         (sdk/stop! *test-client*))
       (is @waited? "stop! waits for natural exit after runtime.shutdown succeeds")
       (is (not @killed?)
@@ -9159,7 +9159,7 @@
     (let [killed? (atom false)]
       (swap! (:state *test-client*) assoc :process {:placeholder true})
       (with-redefs [proc/wait-for-exit! (fn [_ _] false)
-                    proc/destroy! (fn [_] (reset! killed? true))]
+                    proc/destroy! (fn [_] (reset! killed? true) [])]
         (sdk/stop! *test-client*))
       (is @killed?
           "stop! kills the child if it does not exit within the graceful window")))
@@ -9174,7 +9174,7 @@
                         (throw (ex-info "boom" {})))
                       nil)
                     proc/wait-for-exit! (fn [_ _] (reset! waited? true) true)
-                    proc/destroy! (fn [_] (reset! killed? true))]
+                    proc/destroy! (fn [_] (reset! killed? true) [])]
         (sdk/stop! *test-client*))
       (is (not @waited?)
           "stop! does not wait for natural exit when runtime.shutdown failed")

--- a/test/github/copilot_sdk/teardown_test.clj
+++ b/test/github/copilot_sdk/teardown_test.clj
@@ -1,0 +1,410 @@
+(ns github.copilot-sdk.teardown-test
+  "Teardown diagnostics and failed-connect cleanup (R7: COR-001, IDI-001, IDI-002).
+
+   These tests pin observable behavior: a rejected handshake must retain no
+   transport resources, a Throwable must reach the logging backend as a
+   Throwable, expected close outcomes must stay quiet, and unexpected ones must
+   be reported with the identity of the resource that failed."
+  (:require [clojure.core.async :as async]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.logging :as ctl]
+            [clojure.tools.logging.impl :as impl]
+            [clojure.tools.logging.test :as log-test]
+            [github.copilot-sdk :as sdk]
+            [github.copilot-sdk.client :as client]
+            [github.copilot-sdk.logging :as log]
+            [github.copilot-sdk.mock-server :as mock]
+            [github.copilot-sdk.process :as proc]
+            [github.copilot-sdk.protocol :as protocol])
+  (:import [java.io IOException]
+           [java.nio.channels ClosedChannelException ReadableByteChannel WritableByteChannel]))
+
+;; -----------------------------------------------------------------------------
+;; COR-001 - a rejected handshake must not retain transport resources
+;; -----------------------------------------------------------------------------
+
+(deftest rejected-handshake-releases-connection-and-allows-retry
+  (testing "connect-with-streams! releases the connection it built when the
+            protocol version is rejected, so a caller can retry without
+            performing cleanup of its own"
+    (let [server (mock/create-mock-server)
+          _ (reset! (:protocol-version server) 2)
+          _ (mock/start-mock-server! server)
+          c (sdk/client {:auto-start? false})
+          [in out] (mock/client-streams server)
+          rejected-conn (atom nil)
+          real-connect protocol/connect]
+      (try
+        (with-redefs [protocol/connect (fn [i o state-atom]
+                                         (let [conn (real-connect i o state-atom)]
+                                           (reset! rejected-conn conn)
+                                           conn))]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"(?i)protocol.*version"
+                                (client/connect-with-streams! c in out))))
+
+        (let [s @(:state c)]
+          (is (= :error (:status s)))
+          (is (false? (some? (:connection s))) "connection state must be released")
+          (is (false? (some? (:connection-io s))) "connection IO must be released"))
+
+        (let [conn @rejected-conn]
+          (is (some? conn) "the reproducer must have observed the built connection")
+          (is (.isShutdown ^java.util.concurrent.ThreadPoolExecutor
+               (:request-executor conn))
+              "the reverse-request executor must be shut down")
+          (let [^Thread read-thread (:read-thread conn)]
+            (.join read-thread 2000)
+            (is (not (.isAlive read-thread))
+                "the reader thread must have exited")))
+
+        (finally
+          (mock/stop-mock-server! server)))
+
+      ;; Retry against a fresh server with no caller-side cleanup at all.
+      (let [server2 (mock/start-mock-server! (mock/create-mock-server))
+            [in2 out2] (mock/client-streams server2)]
+        (try
+          (client/connect-with-streams! c in2 out2)
+          (is (= :connected (:status @(:state c))))
+          (finally
+            (try (sdk/disconnect! c) (catch Exception _))
+            (mock/stop-mock-server! server2)))))))
+
+;; -----------------------------------------------------------------------------
+;; IDI-001 - the logging facade must preserve Throwable-first semantics
+;; -----------------------------------------------------------------------------
+
+(deftest throwable-reaches-the-logging-backend-as-a-throwable
+  (testing "a leading Throwable is handed to the backend as a throwable, not
+            stringified into the message"
+    (let [boom (ex-info "boom" {:resource :read-channel})]
+      (log-test/with-log
+        (log/error boom "failed to close read channel")
+        (let [entries (vec (log-test/the-log))]
+          (is (= 1 (count entries)))
+          (let [entry (first entries)]
+            (is (identical? boom (:throwable entry))
+                "the backend must receive the Throwable itself")
+            (is (= "failed to close read channel" (:message entry))
+                "the message must not absorb the Throwable")))))))
+
+(deftest non-throwable-logging-is-unchanged
+  (testing "messages without a leading Throwable keep their existing rendering
+            and stay attributed to the calling namespace"
+    (log-test/with-log
+      (log/debug "Writing message: " "id=7")
+      (let [entry (first (log-test/the-log))]
+        (is (nil? (:throwable entry)))
+        (is (= "Writing message: id=7" (:message entry)))
+        (is (= (find-ns 'github.copilot-sdk.teardown-test) (:logger-ns entry))
+            "the log event must be attributed to the caller, not the facade")))))
+
+(defn- disabled-logger-factory
+  "A real LoggerFactory whose loggers report every level as disabled."
+  []
+  (let [logger (reify impl/Logger
+                 (enabled? [_ _level] false)
+                 (write! [_ _level _throwable _message] nil))]
+    (reify impl/LoggerFactory
+      (name [_] "disabled-test-factory")
+      (get-logger [_ _logger-ns] logger))))
+
+(deftest disabled-logging-evaluates-no-arguments
+  (testing "a disabled level evaluates neither the leading nor the trailing
+            arguments, so expensive arguments cost nothing"
+    (let [leading-calls (atom 0)
+          trailing-calls (atom 0)]
+      (binding [ctl/*logger-factory* (disabled-logger-factory)]
+        (log/debug (do (swap! leading-calls inc) "leading")
+                   (do (swap! trailing-calls inc) "trailing")))
+      (is (zero? @leading-calls) "the leading argument must stay unevaluated")
+      (is (zero? @trailing-calls) "trailing arguments must stay unevaluated"))))
+
+(deftest enabled-logging-evaluates-each-argument-exactly-once
+  (testing "an enabled level evaluates every supplied argument exactly once"
+    (let [leading-calls (atom 0)
+          trailing-calls (atom 0)]
+      (log-test/with-log
+        (log/warn (do (swap! leading-calls inc) "leading ")
+                  (do (swap! trailing-calls inc) "trailing"))
+        (is (= "leading trailing" (:message (first (log-test/the-log))))))
+      (is (= 1 @leading-calls) "the leading argument must be evaluated once")
+      (is (= 1 @trailing-calls) "trailing arguments must be evaluated once"))))
+
+(deftest throwable-argument-is-evaluated-exactly-once
+  (testing "a leading Throwable expression is evaluated once and still reaches
+            the backend as a throwable"
+    (let [boom (ex-info "boom" {})
+          calls (atom 0)]
+      (log-test/with-log
+        (log/error (do (swap! calls inc) boom) "cleanup failed")
+        (let [entry (first (log-test/the-log))]
+          (is (identical? boom (:throwable entry)))
+          (is (= "cleanup failed" (:message entry)))
+          (is (= (find-ns 'github.copilot-sdk.teardown-test) (:logger-ns entry)))))
+      (is (= 1 @calls) "the Throwable argument must be evaluated once"))))
+
+;; -----------------------------------------------------------------------------
+;; IDI-002 - expected vs unexpected teardown outcomes
+;; -----------------------------------------------------------------------------
+
+(defn- recording-read-channel
+  [closed on-close]
+  (reify ReadableByteChannel
+    (read [_ _buf] -1)
+    (isOpen [_] true)
+    (close [_]
+      (swap! closed conj :read-channel)
+      (when on-close (throw (on-close))))))
+
+(defn- recording-write-channel
+  [closed]
+  (reify WritableByteChannel
+    (write [_ buf] (.remaining buf))
+    (isOpen [_] true)
+    (close [_] (swap! closed conj :write-channel))))
+
+(defn- fault-injecting-conn
+  "Build a Connection whose only live resources are the two NIO channels, so a
+   teardown failure can be injected without a real peer."
+  [closed on-read-close]
+  (protocol/map->Connection
+   {:read-channel (recording-read-channel closed on-read-close)
+    :write-channel (recording-write-channel closed)
+    :state-atom (atom {:connection (protocol/initial-connection-state)})
+    :outgoing-ch (async/chan 1)}))
+
+(deftest expected-close-failure-stays-quiet
+  (testing "an already-closed channel is a normal teardown outcome"
+    (let [closed (atom [])
+          conn (fault-injecting-conn closed #(ClosedChannelException.))]
+      (log-test/with-log
+        (let [failures (protocol/disconnect conn)]
+          (is (= [] failures) "an expected close must not be reported")
+          (is (empty? (filter (comp #{:warn :error} :level) (log-test/the-log)))
+              "an expected close must not be logged above debug"))))))
+
+(deftest unexpected-close-failure-is-reported-with-resource-identity
+  (testing "a close that genuinely fails is reported, and teardown still
+            completes the steps that follow it"
+    (let [closed (atom [])
+          conn (fault-injecting-conn closed #(IOException. "boom"))
+          failures (protocol/disconnect conn)]
+      (is (= 1 (count failures)))
+      (let [failure (first failures)]
+        (is (= {:operation :close :resource :read-channel}
+               (select-keys (ex-data failure) [:operation :resource])))
+        (is (= "boom" (ex-message (ex-cause failure)))))
+      (is (= [:read-channel :write-channel] @closed)
+          "a failed step must not short-circuit the remaining teardown"))))
+
+(deftest disconnect-is-idempotent
+  (testing "a second disconnect reports nothing new"
+    (let [closed (atom [])
+          conn (fault-injecting-conn closed nil)]
+      (is (= [] (protocol/disconnect conn)))
+      (is (= [] (protocol/disconnect conn))))))
+
+(deftest unexpected-process-teardown-failure-is-reported
+  (testing "destroy! reports a process that cannot be waited on"
+    (let [p (proxy [Process] []
+              (destroy [] nil)
+              (destroyForcibly [] this)
+              (isAlive [] true)
+              (waitFor
+                ([] 0)
+                ([_timeout _unit] (throw (IOException. "waitFor exploded")))))
+          failures (proc/destroy! (proc/map->ManagedProcess {:process p}) 10)]
+      (is (seq failures) "an unexpected process failure must be reported")
+      (is (every? #(= :process (:resource (ex-data %))) failures))
+      (is (some #(= :wait-for-exit (:operation (ex-data %))) failures)))))
+
+(deftest process-teardown-without-failure-reports-nothing
+  (testing "a process that exits promptly produces no teardown failures"
+    (let [p (proxy [Process] []
+              (destroy [] nil)
+              (destroyForcibly [] this)
+              (isAlive [] false)
+              (waitFor
+                ([] 0)
+                ([_timeout _unit] true)))]
+      (is (= [] (proc/destroy! (proc/map->ManagedProcess {:process p}) 10))))))
+
+(defn- surviving-process
+  "A Process that never dies: every wait reports that it is still running."
+  []
+  (proxy [Process] []
+    (destroy [] nil)
+    (destroyForcibly [] this)
+    (isAlive [] true)
+    (waitFor
+      ([] 0)
+      ([_timeout _unit] false))
+    (exitValue [] (throw (IllegalThreadStateException.)))
+    (getInputStream [] nil)
+    (getOutputStream [] nil)
+    (getErrorStream [] nil)))
+
+(deftest process-surviving-forced-kill-is-reported
+  (testing "a child that outlives the forced kill window is an unexpected
+            failure, not a clean teardown"
+    (let [failures (proc/destroy! (proc/map->ManagedProcess {:process (surviving-process)}) 10)]
+      (is (seq failures) "a surviving process must never report clean teardown")
+      (let [survival (first (filter #(= :forcible (:stage (ex-data %))) failures))]
+        (is (some? survival) "the forced-kill stage must be identified")
+        (is (= {:operation :wait-for-exit :resource :process :stage :forcible}
+               (select-keys (ex-data survival) [:operation :resource :stage])))
+        (is (pos? (:timeout-ms (ex-data survival)))
+            "the failure must carry the window that elapsed")))))
+
+(deftest stop-retains-the-handle-of-a-process-it-could-not-kill
+  (testing "stop! surfaces the surviving process and keeps the only handle to it"
+    (let [c (sdk/client {:auto-start? false})
+          mp (proc/map->ManagedProcess {:process (surviving-process)})]
+      (swap! (:state c) assoc :status :connected :process mp)
+      (let [errors (client/stop! c)]
+        (is (some #(= :process (:resource (ex-data %))) errors)
+            "the surviving process must reach the caller")
+        (is (identical? mp (:process @(:state c)))
+            "the handle to a live process must not be discarded")))))
+
+(defn- exiting-process
+  "A Process that dies as soon as it is asked to."
+  []
+  (proxy [Process] []
+    (destroy [] nil)
+    (destroyForcibly [] this)
+    (isAlive [] false)
+    (waitFor
+      ([] 0)
+      ([_timeout _unit] true))
+    (exitValue [] 0)
+    (getInputStream [] nil)
+    (getOutputStream [] nil)
+    (getErrorStream [] nil)))
+
+(deftest force-stop-retains-the-handle-of-a-process-that-survives-the-kill
+  (testing "force-stop! confirms the forced kill: a child that ignores it is
+            logged with its resource identity and its handle is kept"
+    (let [c (sdk/client {:auto-start? false})
+          mp (proc/map->ManagedProcess {:process (surviving-process)})]
+      (swap! (:state c) assoc :status :connected :process mp)
+      (log-test/with-log
+        (is (nil? (client/force-stop! c)) "force-stop! still returns nil")
+        (let [warnings (filter (comp #{:warn :error} :level) (log-test/the-log))]
+          (is (seq warnings) "a surviving process must be logged")
+          (is (some #(some-> (:throwable %) ex-data :resource (= :process)) warnings)
+              "the log entry must carry the failing resource as a Throwable")
+          (is (some #(some-> (:throwable %) ex-data :stage (= :forcible)) warnings)
+              "the forced-kill stage must be identified")))
+      (is (identical? mp (:process @(:state c)))
+          "the handle to a live process must not be discarded")
+      (is (= :disconnected (:status @(:state c)))))))
+
+(deftest force-stop-clears-the-handle-of-a-process-it-killed
+  (testing "a confirmed forced kill releases the handle and stays quiet"
+    (let [c (sdk/client {:auto-start? false})
+          mp (proc/map->ManagedProcess {:process (exiting-process)})]
+      (swap! (:state c) assoc :status :connected :process mp)
+      (log-test/with-log
+        (is (nil? (client/force-stop! c)) "force-stop! still returns nil")
+        (is (empty? (filter (comp #{:warn :error} :level) (log-test/the-log)))
+            "a confirmed kill must not be reported as a failure"))
+      (is (nil? (:process @(:state c)))
+          "a confirmed-dead process must release its handle")
+      (is (= :disconnected (:status @(:state c)))))))
+
+(deftest forcible-destroy-confirms-exit
+  (testing "destroy-forcibly! reports [] only when the child is confirmed gone"
+    (is (= [] (proc/destroy-forcibly!
+               (proc/map->ManagedProcess {:process (exiting-process)}))))
+    (let [failures (proc/destroy-forcibly!
+                    (proc/map->ManagedProcess {:process (surviving-process)}))]
+      (is (seq failures) "a signal that was merely sent must not report success")
+      (let [survival (first failures)]
+        (is (= {:operation :wait-for-exit :resource :process :stage :forcible}
+               (select-keys (ex-data survival) [:operation :resource :stage])))
+        (is (pos? (:timeout-ms (ex-data survival))))))))
+
+;; -----------------------------------------------------------------------------
+;; stderr classification depends on whether the child is still alive
+;; -----------------------------------------------------------------------------
+
+(defn- exploding-stderr-stream
+  [^IOException boom]
+  (proxy [java.io.InputStream] []
+    (read
+      ([] (throw boom))
+      ([_b] (throw boom))
+      ([_b _off _len] (throw boom)))))
+
+(defn- read-stderr-until-closed!
+  "Drain a stderr channel until the reader thread closes it."
+  [ch]
+  (loop [] (when (some? (async/<!! ch)) (recur))))
+
+(deftest stderr-failure-while-process-is-alive-is-reported
+  (testing "losing stderr while the child still runs hides its diagnostics, so
+            it is warned with the Throwable and resource identity"
+    (let [boom (IOException. "stderr exploded")
+          mp (proc/map->ManagedProcess {:stderr (exploding-stderr-stream boom)
+                                        :process (surviving-process)})]
+      (log-test/with-log
+        (read-stderr-until-closed! (proc/stderr-reader mp))
+        (let [warnings (filter (comp #{:warn :error} :level) (log-test/the-log))]
+          (is (seq warnings) "a live-process stderr failure must be warned")
+          (is (some #(identical? boom (:throwable %)) warnings)
+              "the Throwable must reach the backend intact")
+          (is (some #(str/includes? (str (:message %)) "stderr") warnings)
+              "the log must identify the failing resource"))))))
+
+(deftest stderr-failure-after-process-exit-stays-quiet
+  (testing "once the child is gone its stderr is expected to fail"
+    (let [dead (proxy [Process] []
+                 (isAlive [] false)
+                 (destroy [] nil)
+                 (destroyForcibly [] this)
+                 (waitFor ([] 0) ([_t _u] true)))
+          mp (proc/map->ManagedProcess {:stderr (exploding-stderr-stream (IOException. "closed"))
+                                        :process dead})]
+      (log-test/with-log
+        (read-stderr-until-closed! (proc/stderr-reader mp))
+        (is (empty? (filter (comp #{:warn :error} :level) (log-test/the-log)))
+            "an expected stderr close must not be warned")))))
+
+;; -----------------------------------------------------------------------------
+;; Client teardown contract wiring
+;; -----------------------------------------------------------------------------
+
+(deftest stop-surfaces-transport-failures-in-its-error-vector
+  (testing "stop! reports an unexpected connection teardown failure through its
+            existing return contract"
+    (let [c (sdk/client {:auto-start? false})
+          closed (atom [])]
+      (swap! (:state c) assoc
+             :status :connected
+             :connection-io (fault-injecting-conn closed #(IOException. "boom")))
+      (let [errors (client/stop! c)]
+        (is (some #(= :read-channel (:resource (ex-data %))) errors)
+            "the failure must reach the caller")
+        (is (nil? (:connection-io @(:state c)))
+            "state must still be released")
+        (is (= :disconnected (:status @(:state c))))))))
+
+(deftest force-stop-logs-transport-failures
+  (testing "force-stop! keeps returning nil but makes the failure observable"
+    (let [c (sdk/client {:auto-start? false})
+          closed (atom [])]
+      (swap! (:state c) assoc
+             :status :connected
+             :connection-io (fault-injecting-conn closed #(IOException. "boom")))
+      (log-test/with-log
+        (is (nil? (client/force-stop! c)))
+        (is (seq (filter (comp #{:warn :error} :level) (log-test/the-log)))
+            "an unexpected teardown failure must be logged")
+        (is (some #(some-> (:throwable %) ex-data :resource (= :read-channel))
+                  (log-test/the-log))
+            "the log entry must carry the failing resource as a Throwable"))
+      (is (nil? (:connection-io @(:state c)))))))


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Unifies client transport cleanup so failed starts and rejected stream handshakes cannot orphan connections, threads, executors, sockets, or child processes. Unexpected teardown failures now remain observable through the existing `stop!` error vector or Throwable-aware logging instead of being silently discarded.

### Design notes

- One idempotent cleanup path preserves existing graceful shutdown ordering while supporting local-only and forcible modes.
- Process handles are retained when exit cannot be confirmed, so callers do not lose their only reference to a live child.
- Expected interruption/closed-channel outcomes are classified explicitly; fatal JVM errors still propagate.
- Logging remains lazy when disabled and uses the portable `clojure.tools.logging` Throwable arity, preserving stack traces and caller namespace attribution.

This is the first Wave 2 PR; the send/wait and scoped-query changes can merge afterward.
