### PR TITLE
fix: normalize client ownership flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed (client lifecycle)
+- Internally managed clients now store `:external-server? false` instead of
+  `nil`, preserving process ownership semantics while satisfying the public
+  client spec under instrumentation. External URI and child-process clients
+  remain `true`. Addresses `COR-004`.
+
 ### Added (helper lifecycle)
 - **Scope-bound helper event sequences** -- `github.copilot-sdk.helpers/with-query-seq`
   binds the same bounded event sequence shape as `query-seq!` for the dynamic

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -357,7 +357,7 @@
                   merged)
          child-process? (:is-child-process? opts)
          cli-url? (boolean (:cli-url opts))
-         external? (or cli-url? child-process?)
+         external? (boolean (or cli-url? child-process?))
          {:keys [host port]} (when cli-url?
                                (parse-cli-url (:cli-url opts)))
          ;; tcp-connection-token (upstream PR #1176): use the user-provided

--- a/test/github/copilot_sdk/helper_lifecycle_test.clj
+++ b/test/github/copilot_sdk/helper_lifecycle_test.clj
@@ -45,7 +45,7 @@
   (let [copilot-client (sdk/client {:auto-start? false})
         [in out] (mock/client-streams *mock-server*)]
     (client/connect-with-streams! copilot-client in out)
-    (assoc copilot-client :external-server? false)))
+    copilot-client))
 
 (defn- call-with-single-helper-client
   [f]

--- a/test/github/copilot_sdk_test.clj
+++ b/test/github/copilot_sdk_test.clj
@@ -131,6 +131,12 @@
     (let [c (copilot/client {:is-child-process? true :use-stdio? true :auto-start? false})]
       (is (some? c)))))
 
+(deftest internally-managed-client-has-boolean-ownership-flag
+  (let [c (copilot/client {:auto-start? false})]
+    (is (false? (:external-server? c)))
+    (is (s/valid? ::specs/client c)
+        (s/explain-str ::specs/client c))))
+
 ;; =============================================================================
 ;; URL Parsing Tests (matching JS SDK client.test.ts)
 ;; =============================================================================


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

> Wave 3 merge order: first of three.

Normalizes the client runtime-ownership marker at construction so every client satisfies the public boolean invariant. Internally managed clients now store `false`; URI and child-process clients remain `true`.

### Design notes

- Fixes the value at its production point rather than weakening the spec or adding consumer fallbacks.
- Process ownership and teardown behavior remain unchanged because existing consumers already treated the prior `nil` value as falsey.
- The regression exercises the public constructor path and removes the test-only normalization that previously hid the mismatch.
