### PR TITLE
test: cover public async behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ All notable changes to this project will be documented in this file. This change
   interns are explicitly excluded, and snapshot generation preserves the
   caller's spec-instrumentation state. The canonical `bb api-surface:update`
   task regenerates the complete contract.
+- Added focused behavioral coverage for async Factory facade routing and error
+  handling, lifecycle macro ownership order, transformed and sliding-buffered
+  event subscriptions, pending interaction envelopes, UI elicitation, and
+  workspace-path propagation across session producers.
 
 ### Fixed (documentation)
 - Codox topic generation now assigns deterministic output identities from source

--- a/test/github/copilot_sdk/events_behavior_test.clj
+++ b/test/github/copilot_sdk/events_behavior_test.clj
@@ -1,0 +1,53 @@
+(ns github.copilot-sdk.events-behavior-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [github.copilot-sdk :as sdk]
+            [github.copilot-sdk.mock-server :as mock]
+            [github.copilot-sdk.public-behavior-support :as support]))
+
+(use-fixtures :each support/with-piped-client)
+
+(deftest events-to-chan-applies-tool-event-filter
+  (let [session (sdk/create-session support/*test-client* {:session-id "filtered-events"})
+        events-ch (sdk/events->chan
+                   session
+                   {:xf (filter (comp sdk/tool-events :type))})
+        session-id (sdk/session-id session)]
+    (mock/send-session-event! support/*mock-server* session-id
+                              :copilot/session.snapshot_rewind
+                              {:upToEventId "before-tool" :eventsRemoved 0})
+    (mock/send-session-event! support/*mock-server* session-id
+                              :copilot/tool.execution_start
+                              {:toolCallId "tool-1"
+                               :toolName "search"
+                               :arguments {}})
+    (is (= :copilot/tool.execution_start
+           (:type (support/read-within!! events-ch))))
+    (sdk/unsubscribe-events! session events-ch)))
+
+(deftest unsubscribe-events-closes-owned-channel
+  (let [session (sdk/create-session support/*test-client* {:session-id "unsubscribe-events"})
+        events-ch (sdk/events->chan session)]
+    (sdk/unsubscribe-events! session events-ch)
+    (is (nil? (support/read-within!! events-ch)))))
+
+(deftest events-to-chan-retains-latest-value-in-sliding-buffer
+  (let [session (sdk/create-session support/*test-client* {:session-id "sliding-events"})
+        processed (promise)
+        xf (keep (fn [event]
+                   (let [sequence (get-in event [:data :events-removed])]
+                     (if (= 4 sequence)
+                       (do
+                         (deliver processed :all-processed)
+                         nil)
+                       event))))
+        events-ch (sdk/events->chan session {:buffer 1 :xf xf})
+        session-id (sdk/session-id session)]
+    (doseq [sequence (range 1 5)]
+      (mock/send-session-event! support/*mock-server* session-id
+                                :copilot/session.snapshot_rewind
+                                {:upToEventId (str "event-" sequence)
+                                 :eventsRemoved sequence}))
+    (is (= :all-processed (deref processed 5000 ::timeout)))
+    (is (= 3 (get-in (support/read-within!! events-ch)
+                     [:data :events-removed])))
+    (sdk/unsubscribe-events! session events-ch)))

--- a/test/github/copilot_sdk/factory_async_behavior_test.clj
+++ b/test/github/copilot_sdk/factory_async_behavior_test.clj
@@ -1,0 +1,135 @@
+(ns github.copilot-sdk.factory-async-behavior-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [github.copilot-sdk :as sdk]
+            [github.copilot-sdk.factory :as factory]
+            [github.copilot-sdk.mock-server :as mock]
+            [github.copilot-sdk.public-behavior-support :as support]))
+
+(use-fixtures :each support/with-piped-client)
+
+(defn- thrown-by [f]
+  (try
+    (f)
+    nil
+    (catch Throwable error
+      error)))
+
+(deftest async-factory-facade-routes-all-wrappers-and-arities
+  (let [session (sdk/create-session support/*test-client* {:session-id "factory-session"})
+        session-id (sdk/session-id session)
+        requests (atom [])
+        cases
+        [{:label "<run-factory! default arity"
+          :call #(sdk/<run-factory! session "review")
+          :requests [["session.factory.run"
+                      {:sessionId session-id :name "review" :args {} :options {}}]]}
+         {:label "<run-factory! options arity"
+          :call #(sdk/<run-factory! session "review"
+                                    {:args {:topic "routing"}
+                                     :limits {:max-ai-credits 2}})
+          :requests [["session.factory.run"
+                      {:sessionId session-id
+                       :name "review"
+                       :args {:topic "routing"}
+                       :options {:limits {:maxAiCredits 2}}}]]}
+         {:label "<resume-factory! default arity"
+          :call #(sdk/<resume-factory! session "run-1")
+          :requests [["session.factory.resume"
+                      {:sessionId session-id :runId "run-1"}]]}
+         {:label "<resume-factory! options arity"
+          :call #(sdk/<resume-factory! session "run-1"
+                                       {:limits {:timeout-seconds 30}})
+          :requests [["session.factory.resume"
+                      {:sessionId session-id
+                       :runId "run-1"
+                       :limits {:timeoutSeconds 30}}]]}
+         {:label "<get-factory-run"
+          :call #(sdk/<get-factory-run session "run-1")
+          :requests [["session.factory.getRun"
+                      {:sessionId session-id :runId "run-1"}]]}
+         {:label "<wait-for-factory-run! default arity"
+          :call #(sdk/<wait-for-factory-run! session "run-1")
+          :requests [["session.factory.getRun"
+                      {:sessionId session-id :runId "run-1"}]]}
+         {:label "<list-factory-runs"
+          :call #(sdk/<list-factory-runs session)
+          :requests [["session.factory.listRuns" {:sessionId session-id}]]}
+         {:label "<get-factory-run-detail"
+          :call #(sdk/<get-factory-run-detail session "run-1")
+          :requests [["session.factory.getRunDetail"
+                      {:sessionId session-id :runId "run-1"}]]}
+         {:label "<get-factory-run-progress default arity"
+          :call #(sdk/<get-factory-run-progress session "run-1")
+          :requests [["session.factory.getRunProgress"
+                      {:sessionId session-id :runId "run-1"}]]}
+         {:label "<get-factory-run-progress options arity"
+          :call #(sdk/<get-factory-run-progress session "run-1"
+                                                {:cursor "next" :limit 2})
+          :requests [["session.factory.getRunProgress"
+                      {:sessionId session-id
+                       :runId "run-1"
+                       :cursor "next"
+                       :limit 2}]]}
+         {:label "<cancel-factory-run!"
+          :call #(sdk/<cancel-factory-run! session "run-1")
+          :requests [["session.factory.cancel"
+                      {:sessionId session-id :runId "run-1"}]]}]]
+    (mock/set-request-hook!
+     support/*mock-server*
+     (fn [method params]
+       (swap! requests conj [method params])))
+    (doseq [{:keys [label call] :as case} cases]
+      (testing label
+        (reset! requests [])
+        (is (some? (support/read-value-then-close!! (call))))
+        (is (= (:requests case) @requests))))))
+
+(deftest async-wait-facade-preserves-options-arity
+  (let [session ::session
+        options {:cancel-chan ::cancel-chan :poll-interval-ms 17}
+        calls (atom [])
+        delivered {:run-id "run-1" :status :completed}]
+    (with-redefs-fn
+      {#'factory/<wait-for-run!
+       (fn [actual-session run-id actual-options]
+         (swap! calls conj [actual-session run-id actual-options])
+         (async/to-chan! [delivered]))}
+      (fn []
+        (is (= delivered
+               (support/read-value-then-close!!
+                (sdk/<wait-for-factory-run! session "run-1" options))))))
+    (is (= [[session "run-1" options]] @calls))))
+
+(deftest async-factory-facade-delivers-rpc-failure-then-closes
+  (let [session (sdk/create-session support/*test-client* {:session-id "factory-error-session"})]
+    (mock/set-request-hook!
+     support/*mock-server*
+     (fn [method _]
+       (when (= "session.factory.getRun" method)
+         (throw (ex-info "factory lookup failed" {:code -32050})))))
+    (let [value (support/read-value-then-close!!
+                 (sdk/<get-factory-run session "missing"))]
+      (is (instance? Throwable value))
+      (is (= "factory lookup failed" (ex-message value))))))
+
+(deftest factory-resume-maps-known-errors-and-passes-through-unknown-errors
+  (let [session (sdk/create-session support/*test-client* {:session-id "factory-resume-session"})]
+    (doseq [{:keys [wire-code expected-code]}
+            [{:wire-code "not_found" :expected-code :not-found}
+             {:wire-code "future_factory_error" :expected-code nil}]]
+      (testing wire-code
+        (mock/set-request-hook!
+         support/*mock-server*
+         (fn [method _]
+           (when (= "session.factory.resume" method)
+             (throw (ex-info "resume failed"
+                             {:code -32051
+                              :data {:code wire-code :detail "preserved"}})))))
+        (let [error (thrown-by #(factory/resume! session "run-1"))]
+          (is (instance? clojure.lang.ExceptionInfo error))
+          (if expected-code
+            (is (= {:type :factory-resume-error :code expected-code}
+                   (ex-data error)))
+            (is (= {:code "future_factory_error" :detail "preserved"}
+                   (get-in (ex-data error) [:error :data])))))))))

--- a/test/github/copilot_sdk/lifecycle_macros_behavior_test.clj
+++ b/test/github/copilot_sdk/lifecycle_macros_behavior_test.clj
@@ -1,0 +1,148 @@
+(ns github.copilot-sdk.lifecycle-macros-behavior-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [github.copilot-sdk :as sdk]))
+
+(deftest with-client-and-with-session-own-resources-in-order
+  (let [calls (atom [])]
+    (with-redefs-fn
+      {#'sdk/client (fn [& args]
+                      (swap! calls conj [:client (vec args)])
+                      ::client)
+       #'sdk/start! (fn [client]
+                      (swap! calls conj [:start client]))
+       #'sdk/stop! (fn [client]
+                     (swap! calls conj [:stop client]))}
+      (fn []
+        (sdk/with-client [client {:log-level :debug}]
+          (swap! calls conj [:body client]))))
+    (is (= [[:client [{:log-level :debug}]]
+            [:start ::client]
+            [:body ::client]
+            [:stop ::client]]
+           @calls)))
+
+  (let [calls (atom [])]
+    (with-redefs-fn
+      {#'sdk/create-session (fn [client opts]
+                              (swap! calls conj [:create-session client opts])
+                              ::session)
+       #'sdk/disconnect! (fn [session]
+                           (swap! calls conj [:disconnect session]))}
+      (fn []
+        (sdk/with-session [session ::client {:model "test"}]
+          (swap! calls conj [:body session]))))
+    (is (= [[:create-session ::client {:model "test"}]
+            [:body ::session]
+            [:disconnect ::session]]
+           @calls))))
+
+(deftest with-client-session-supports-all-binding-forms
+  (let [run-case
+        (fn [invoke]
+          (let [calls (atom [])]
+            (with-redefs-fn
+              {#'sdk/client (fn [& args]
+                              (swap! calls conj [:client (vec args)])
+                              ::client)
+               #'sdk/start! (fn [client]
+                              (swap! calls conj [:start client]))
+               #'sdk/stop! (fn [client]
+                             (swap! calls conj [:stop client]))
+               #'sdk/create-session (fn [client opts]
+                                      (swap! calls conj [:create-session client opts])
+                                      ::session)
+               #'sdk/disconnect! (fn [session]
+                                   (swap! calls conj [:disconnect session]))}
+              #(invoke calls))
+            @calls))
+        session-opts {:model "test"}
+        client-opts {:log-level :debug}
+        cases
+        [{:label "anonymous client with defaults"
+          :invoke (fn [calls]
+                    (sdk/with-client-session [session {:model "test"}]
+                      (swap! calls conj [:body session])))
+          :expected [[:client []]
+                     [:start ::client]
+                     [:create-session ::client session-opts]
+                     [:body ::session]
+                     [:disconnect ::session]
+                     [:stop ::client]]}
+         {:label "anonymous client with options"
+          :invoke (fn [calls]
+                    (sdk/with-client-session [{:log-level :debug} session {:model "test"}]
+                      (swap! calls conj [:body session])))
+          :expected [[:client [client-opts]]
+                     [:start ::client]
+                     [:create-session ::client session-opts]
+                     [:body ::session]
+                     [:disconnect ::session]
+                     [:stop ::client]]}
+         {:label "named client with defaults"
+          :invoke (fn [calls]
+                    (sdk/with-client-session [client session {:model "test"}]
+                      (swap! calls conj [:body client session])))
+          :expected [[:client []]
+                     [:start ::client]
+                     [:create-session ::client session-opts]
+                     [:body ::client ::session]
+                     [:disconnect ::session]
+                     [:stop ::client]]}
+         {:label "named client with options"
+          :invoke (fn [calls]
+                    (sdk/with-client-session [client {:log-level :debug} session {:model "test"}]
+                      (swap! calls conj [:body client session])))
+          :expected [[:client [client-opts]]
+                     [:start ::client]
+                     [:create-session ::client session-opts]
+                     [:body ::client ::session]
+                     [:disconnect ::session]
+                     [:stop ::client]]}]]
+    (doseq [{:keys [label invoke expected]} cases]
+      (testing label
+        (is (= expected (run-case invoke)))))))
+
+(deftest lifecycle-macros-preserve-body-and-setup-exceptions
+  (let [calls (atom [])
+        body-error (ex-info "body failed" {:phase :body})
+        caught
+        (with-redefs-fn
+          {#'sdk/create-session (fn [_ _]
+                                  (swap! calls conj :create-session)
+                                  ::session)
+           #'sdk/disconnect! (fn [_]
+                               (swap! calls conj :disconnect))}
+          (fn []
+            (try
+              (sdk/with-session [session ::client {}]
+                (swap! calls conj :body)
+                (throw body-error))
+              (catch Throwable error
+                error))))]
+    (is (identical? body-error caught))
+    (is (= [:create-session :body :disconnect] @calls)))
+
+  (let [calls (atom [])
+        setup-error (ex-info "session setup failed" {:phase :setup})
+        caught
+        (with-redefs-fn
+          {#'sdk/client (fn []
+                          (swap! calls conj :client)
+                          ::client)
+           #'sdk/start! (fn [_]
+                          (swap! calls conj :start))
+           #'sdk/stop! (fn [_]
+                         (swap! calls conj :stop))
+           #'sdk/create-session (fn [_ _]
+                                  (swap! calls conj :create-session)
+                                  (throw setup-error))
+           #'sdk/disconnect! (fn [_]
+                               (swap! calls conj :disconnect))}
+          (fn []
+            (try
+              (sdk/with-client-session [session {}]
+                (swap! calls conj [:body session]))
+              (catch Throwable error
+                error))))]
+    (is (identical? setup-error caught))
+    (is (= [:client :start :create-session :stop] @calls))))

--- a/test/github/copilot_sdk/mock_server.clj
+++ b/test/github/copilot_sdk/mock_server.clj
@@ -464,8 +464,10 @@
                   (write-message (:writer server)
                                  {:jsonrpc "2.0"
                                   :id (:id msg)
-                                  :error {:code (or (:code error-data) -32603)
-                                          :message (.getMessage e)}}))))
+                                  :error (cond-> {:code (or (:code error-data) -32603)
+                                                  :message (.getMessage e)}
+                                           (contains? error-data :data)
+                                           (assoc :data (:data error-data)))}))))
             ;; It's a notification (has :method but no :id) — process silently
             (try
               (handle-request server msg)

--- a/test/github/copilot_sdk/public_behavior_support.clj
+++ b/test/github/copilot_sdk/public_behavior_support.clj
@@ -1,0 +1,47 @@
+(ns github.copilot-sdk.public-behavior-support
+  (:require [clojure.core.async :as async]
+            [github.copilot-sdk :as sdk]
+            [github.copilot-sdk.client :as client]
+            [github.copilot-sdk.mock-server :as mock]))
+
+(def ^:dynamic *mock-server* nil)
+(def ^:dynamic *test-client* nil)
+
+(defn with-piped-client
+  [test-fn]
+  (let [server (mock/start-mock-server! (mock/create-mock-server))
+        sdk-client (sdk/client {:auto-start? false})
+        [in out] (mock/client-streams server)]
+    (client/connect-with-streams! sdk-client in out)
+    (binding [*mock-server* server
+              *test-client* sdk-client]
+      (try
+        (test-fn)
+        (finally
+          (try
+            (sdk/stop! sdk-client)
+            (finally
+              (mock/stop-mock-server! server))))))))
+
+(defn read-within!!
+  ([ch]
+   (read-within!! ch 5000))
+  ([ch timeout-ms]
+   (let [timeout-ch (async/timeout timeout-ms)
+         [value port] (async/alts!! [ch timeout-ch])]
+     (when (= port timeout-ch)
+       (throw (ex-info "Timed out reading channel" {:timeout-ms timeout-ms})))
+     value)))
+
+(defn read-value-then-close!!
+  ([ch]
+   (read-value-then-close!! ch 5000))
+  ([ch timeout-ms]
+   (let [value (read-within!! ch timeout-ms)
+         after-value (read-within!! ch timeout-ms)]
+     (when (nil? value)
+       (throw (ex-info "Channel closed before delivering a value" {})))
+     (when (some? after-value)
+       (throw (ex-info "Channel delivered more than one value"
+                       {:first value :second after-value})))
+     value)))

--- a/test/github/copilot_sdk/session_interactions_behavior_test.clj
+++ b/test/github/copilot_sdk/session_interactions_behavior_test.clj
@@ -1,0 +1,148 @@
+(ns github.copilot-sdk.session-interactions-behavior-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [github.copilot-sdk :as sdk]
+            [github.copilot-sdk.mock-server :as mock]
+            [github.copilot-sdk.public-behavior-support :as support]
+            [github.copilot-sdk.session :as session]))
+
+(use-fixtures :each support/with-piped-client)
+
+(deftest ui-elicitation-sends-exact-request-and-normalizes-response
+  (let [requests (atom [])
+        _ (mock/set-request-hook!
+           support/*mock-server*
+           (fn [method params]
+             (cond
+               (= "session.create" method)
+               {::mock/merge-response
+                {:capabilities {:ui {:elicitation true}}}}
+
+               (= "session.ui.elicitation" method)
+               (do
+                 (swap! requests conj [method params])
+                 {::mock/merge-response
+                  {:content {:environment "production"}}}))))
+        copilot-session (sdk/create-session support/*test-client*
+                                            {:session-id "elicitation-session"})
+        schema {:type "object"
+                :properties {"environment" {:type "string"
+                                            :enum ["staging" "production"]}}
+                :required ["environment"]}
+        result (sdk/ui-elicitation! copilot-session
+                                    {:message "Choose an environment"
+                                     :requested-schema schema})]
+    (is (= [["session.ui.elicitation"
+             {:sessionId "elicitation-session"
+              :message "Choose an environment"
+              :requestedSchema
+              {:type "object"
+               :properties {:environment {:type "string"
+                                          :enum ["staging" "production"]}}
+               :required ["environment"]}}]]
+           @requests))
+    (is (= {:action "accept"
+            :content {:environment "production"}}
+           result))))
+
+(deftest async-pending-tool-call-returns-raw-result-envelope-then-closes
+  (let [requests (atom [])
+        copilot-session (sdk/create-session support/*test-client*
+                                            {:session-id "pending-tool-session"})
+        _ (mock/set-request-hook!
+           support/*mock-server*
+           (fn [method params]
+             (when (= "session.tools.handlePendingToolCall" method)
+               (swap! requests conj [method params]))))
+        envelope
+        (support/read-value-then-close!!
+         (sdk/<handle-pending-tool-call!
+          copilot-session
+          {:request-id "tool-request-1"
+           :result "completed"}))]
+    (is (= [["session.tools.handlePendingToolCall"
+             {:sessionId "pending-tool-session"
+              :requestId "tool-request-1"
+              :result {:textResultForLlm "completed"
+                       :resultType "success"
+                       :toolTelemetry {}}}]]
+           @requests))
+    (is (= {:ok true} (:result envelope)))
+    (is (nil? (:error envelope)))))
+
+(deftest async-pending-permission-returns-raw-error-envelope-then-closes
+  (let [requests (atom [])
+        copilot-session (sdk/create-session support/*test-client*
+                                            {:session-id "pending-permission-session"})
+        _ (mock/set-request-hook!
+           support/*mock-server*
+           (fn [method params]
+             (when (= "session.permissions.handlePendingPermissionRequest" method)
+               (swap! requests conj [method params])
+               (throw (ex-info "permission response rejected"
+                               {:code -32060
+                                :data {:reason "stale-request"}})))))
+        envelope
+        (support/read-value-then-close!!
+         (sdk/<handle-pending-permission-request!
+          copilot-session
+          {:request-id "permission-request-1"
+           :result {:kind :approve-once}}))]
+    (is (= [["session.permissions.handlePendingPermissionRequest"
+             {:sessionId "pending-permission-session"
+              :requestId "permission-request-1"
+              :result {:kind "approve-once"}}]]
+           @requests))
+    (is (= {:code -32060
+            :message "permission response rejected"
+            :data {:reason "stale-request"}}
+           (:error envelope)))
+    (is (nil? (:result envelope)))))
+
+(deftest workspace-path-flows-from-session-producers-to-public-accessor
+  (let [cases
+        [{:label "sync create"
+          :method "session.create"
+          :session-id "workspace-create-sync"
+          :produce #(sdk/create-session support/*test-client*
+                                        {:session-id "workspace-create-sync"})}
+         {:label "async create"
+          :method "session.create"
+          :session-id "workspace-create-async"
+          :produce #(support/read-value-then-close!!
+                     (sdk/<create-session support/*test-client*
+                                          {:session-id "workspace-create-async"}))}
+         {:label "sync resume"
+          :method "session.resume"
+          :session-id "workspace-resume-sync"
+          :produce #(sdk/resume-session support/*test-client*
+                                        "workspace-resume-sync" {})}
+         {:label "async resume"
+          :method "session.resume"
+          :session-id "workspace-resume-async"
+          :produce #(support/read-value-then-close!!
+                     (sdk/<resume-session support/*test-client*
+                                          "workspace-resume-async" {}))}]]
+    (doseq [{:keys [label method session-id produce]} cases]
+      (testing label
+        (when (= method "session.resume")
+          (swap! (:sessions support/*mock-server*)
+                 assoc session-id {:id session-id}))
+        (let [workspace (str "/workspaces/" session-id)]
+          (mock/set-request-hook!
+           support/*mock-server*
+           (fn [request-method _]
+             (when (= method request-method)
+               {::mock/merge-response {:workspacePath workspace}})))
+          (let [copilot-session (produce)]
+            (is (= workspace (sdk/workspace-path copilot-session)))))))))
+
+(deftest sessions-fork-normalizes-workspace-path-in-response
+  (let [copilot-session (sdk/create-session support/*test-client*
+                                            {:session-id "fork-source"})]
+    (mock/set-request-hook!
+     support/*mock-server*
+     (fn [method _]
+       (when (= "sessions.fork" method)
+         {::mock/merge-response {:workspacePath "/workspaces/forked"}})))
+    (is (= "/workspaces/forked"
+           (:workspace-path (session/sessions-fork! copilot-session))))))


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Adds focused, deterministic public behavior coverage for async Factory facade routing and error semantics, lifecycle macro ownership order, transformed and sliding-buffered event subscriptions, pending interaction envelopes, UI elicitation, and workspace-path propagation.

### Design notes

- Async transport tests use a real piped JSON-RPC client/server and bounded channel assertions for value delivery and closure.
- Lifecycle macro tests use narrow facade seams to verify emitted ownership order and exception preservation; real resource cleanup remains covered by examples and E2E tests.
- The test mock preserves structured JSON-RPC error data so Factory resume error mapping and passthrough behavior are observable.

### Scope

This PR changes no production behavior and does not include the planned integration-test split.