### PR TITLE
docs: codify durable SDK review guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,11 +51,40 @@ This SDK must maintain **strict API parity** with the official Node.js SDK (`@gi
 4. **Clojure-only additions** (convenience macros, core.async wrappers, internal tuning knobs) are fine
    as long as they don't conflict with the official API surface.
 
+5. **Prefer one canonical Clojure spelling.** Add compatibility aliases only
+   for demonstrated consumer need or an explicit compatibility policy. Prefer a
+   documented breaking correction over a speculative shim with no removal path.
+
+### Stable Upstream Recertification
+
+A stable recertification is a complete public-surface inventory at an exact
+upstream pin, not a scan of changed generated files.
+
+1. Inventory package-root exports and public types, `CopilotClient` builders and
+   methods, `CopilotSession` methods, extension/join paths, and relevant stable
+   tests. Generated RPC and CLI sources are wire evidence, not independent
+   parity requirements.
+2. Classify every delta as stable public, experimental, internal,
+   generated-only, or language-specific before deciding whether to port it.
+   Experimental subsystems require an explicit maintainer decision, accepted
+   ADR, or direct request.
+3. Trace each stable delta end to end: public export/type, applicable
+   create/resume/join or method builder, exact wire and omission semantics,
+   idiom spec/fdef/API snapshot, tests, docs, examples, and changelog.
+4. Apply the optional-field proof matrix in
+   `.github/skills/update-upstream/references/PROJECT.md`. Omission and JSON
+   `null` are different contracts.
+5. Keep validated historical evidence pinned to the source it describes. Add a
+   symbol-based post-baseline inventory rather than changing only an old hash
+   while retaining stale line or range claims.
+
+Use `.github/skills/update-upstream/SKILL.md` for the complete workflow and
+durable source mapping.
+
 ## Syncing with Upstream
 
-Upstream syncing is **automated** via the daily agentic workflow (`.github/workflows/upstream-sync.md`, runs weekdays). It discovers upstream `github/copilot-sdk` changes, plans idiomatic Clojure ports, implements them, runs full CI, and opens a draft PR for @krukow to review.
-
-To manually check for upstream changes that may need porting:
+Use `.github/skills/update-upstream/SKILL.md` to check or sync upstream
+changes. At minimum:
 
 1. Review merged PRs: https://github.com/github/copilot-sdk/pulls?q=is%3Apr+is%3Aclosed
 2. Compare with recent commits in this repository
@@ -201,6 +230,21 @@ This project emphasizes **rigor and correctness**, particularly for:
 - **Protocol/wire code** (JSON-RPC communication with CLI server)
 - **Sound process and resource management** robust error handling and cleanup to avoid leaking resources
 
+### Async and Lifecycle Invariants
+
+- Every resource-owning API must define ownership, cancellation, backpressure,
+  bounded blocking, and deterministic exactly-once cleanup.
+- Never run arbitrary blocking or user-supplied work on `go` dispatch or a
+  protocol reader thread. Use an explicit bounded execution facility.
+- Resource-owning lazy or streaming helpers require an explicit scope and
+  abandonment path; channel closure alone is not cancellation unless the API
+  defines it that way.
+- Preserve the primary failure across cleanup. Cleanup failures must remain
+  observable without replacing the exception that caused teardown.
+- Synchronize tests on observable state, requests, events, latches, futures, or
+  channel closure. Fixed sleeps are not completion, ordering, or absence
+  oracles.
+
 ### Spec Usage
 
 - Use `clojure.spec` for data validation at API boundaries
@@ -210,9 +254,23 @@ This project emphasizes **rigor and correctness**, particularly for:
 ### Testing
 
 - Unit tests for pure functions
-- Integration tests using mock server
+- Integration tests using the real protocol and deterministic mock server
 - E2E tests against real Copilot CLI
 - All examples serve as additional integration tests
+- Prefer table-driven and property-based tests for contract state spaces
+- Prefer real lightweight implementations over mocks of internal behavior
+- Test important public behavior and interaction boundaries, not facts already
+  guaranteed by the compiler or spec declaration alone
+- Use the smallest targeted gate while iterating, then the established full
+  repository gates before review
+
+### Performance Evidence
+
+Do not make cross-language parity or superiority claims from unmatched
+microbenchmarks or live service calls. Matched public SDK paths, fresh process
+pairs, predeclared analysis/abort rules, no trajectory-based selection, complete
+raw provenance, and careful non-significance language are non-negotiable.
+`benchmarks/README.md` and `benchmarks/METHODOLOGY.md` own the full protocol.
 
 ## Project Structure
 
@@ -261,6 +319,12 @@ and CI fails the PR if generated output is out of date. The idiom layer only
 moves under deliberate curator review. This is what makes the API both
 schema-faithful at the wire AND idiomatic in Clojure.
 
+Opaque JSON fields need recursive JSON validation and explicit tests for which
+key paths are preserved versus normalized; a broad `map?` contract is not
+enough. Treat schemas, generated Clojure, API snapshots, and generated docs as
+outputs of canonical pinned inputs. Follow the owning skill's deterministic
+regeneration gate when drift risk matters.
+
 ## Documentation
 
 All these must be updated as appropriate when making changes:
@@ -274,11 +338,19 @@ All these must be updated as appropriate when making changes:
 - `doc/auth/byok.md` - BYOK (Bring Your Own Key) provider guide
 - `doc/mcp/overview.md` - MCP server configuration guide
 - `doc/mcp/debugging.md` - MCP debugging and troubleshooting
+- `benchmarks/README.md` - Benchmark usage, evidence, and interpretation
+- `benchmarks/METHODOLOGY.md` - Confirmatory study protocol
 - `CHANGELOG.md` - Version history and changes (see below)
 - `AGENTS.md` - update this file when significant changes happen (e.g. Project Structure)
 
 Run `bb validate-docs` to check for broken links, unparseable code blocks, and structural issues.
-Use `/update-docs` skill (`.github/skills/update-docs/SKILL.md`) to regenerate docs after source changes.
+Invoke the repo-local `update-docs` skill
+(`.github/skills/update-docs/SKILL.md`) to regenerate docs after source changes.
+
+Examples are executable contract evidence. Keep them portable, bounded,
+fail-loud, and explicit about client, session, subscription, process, and
+channel cleanup. Generated API HTML is never an editing surface: fix canonical
+source/docstrings or Markdown, then regenerate it.
 
 ### Changelog
 

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,129 +1,45 @@
-# Documentation Guidelines
+---
+applyTo: "**/*.md"
+---
 
-This file provides guidelines for AI agents updating documentation in the copilot-sdk-clojure project.
+# Documentation Instructions
 
-## Documentation Style
+Follow [`doc/style.md`](../../doc/style.md) for prose, Clojure examples,
+terminology, headings, and links. Follow
+[`update-docs`](../skills/update-docs/SKILL.md) for the maintenance workflow.
+Do not duplicate either source here.
 
-Follow the conventions in [`doc/style.md`](../../doc/style.md):
+## Contract Evidence
 
-### Principles
+- Treat examples as executable API evidence; the update-docs skill owns the
+  portability, boundedness, inventory, and cleanup checklist.
+- Document stable public behavior and intentional experimental exclusions.
+  Keep transient audit findings, local evidence paths, and session history out
+  of evergreen documentation.
 
-1. **Code-first** — Lead with working Clojure examples, then explain
-2. **Progressive disclosure** — Simplest usage first, layer complexity
-3. **Direct tone** — Imperative mood, no filler ("simply", "just", "let's")
-4. **Clojure-idiomatic** — Use Clojure terminology and conventions
+## Canonical Inputs and Generated Outputs
 
-### Code Examples
+- Treat public source, specs, fdefs, examples, and hand-written Markdown as
+  canonical inputs.
+- Treat generated API HTML and other generated documentation as outputs.
+  Regenerate them with the owning task; never hand-edit generated files.
+- When source and generated documentation disagree, fix the canonical input and
+  regenerate.
 
-- All code blocks must be valid Clojure (parseable by `read-string`)
-- Show `require` forms so readers know which namespace to import
-- Use `;; =>` comments for return values
-- Use `;; prints:` comments for output
-- Include cleanup (`stop!`, `disconnect!`) in lifecycle examples
+## Cross-References and Changelog
 
-### Conventions
+- Use relative links within the repository and section anchors for specific
+  references.
+- `AGENTS.md` is a symlink to `.github/copilot-instructions.md`. Links authored
+  in that shared file must be full canonical GitHub URLs so they work from both
+  paths.
+- Update `doc/index.md` when documentation structure changes.
+- Add each user-visible change to `[Unreleased]` in `CHANGELOG.md`, grouped
+  under the appropriate Keep a Changelog category. Mark breaking changes
+  explicitly and use upstream-sync annotations only for upstream ports.
 
-- Use `copilot` as the alias for `github.copilot-sdk.client`
-- Use `h` as the alias for `github.copilot-sdk.helpers`
-- Use `session` as the alias for `github.copilot-sdk.session`
-- Prefer `def` over `let` in top-level examples for clarity
+## Validation
 
-### Terminology
-
-Use Clojure terms consistently:
-
-| Use | Don't use |
-|-----|-----------|
-| namespace | package, module |
-| var | variable, field |
-| map | object, dictionary, hash |
-| keyword | enum, symbol (unless literally a symbol) |
-| function | method |
-| atom | mutable variable |
-| channel | queue, stream (unless referring to core.async specifically) |
-| require | import |
-
-## Documentation Structure
-
-### Key Files
-
-- **`README.md`** - User-facing quick start and overview
-- **`doc/index.md`** - Documentation hub / table of contents
-- **`doc/reference/API.md`** - Detailed API reference for all public functions
-- **`doc/getting-started.md`** - Step-by-step tutorial for new users
-- **`doc/style.md`** - Documentation authoring style guide
-- **`doc/auth/index.md`** - Authentication guide (all methods, priority order)
-- **`doc/auth/byok.md`** - BYOK (Bring Your Own Key) provider guide
-- **`doc/mcp/overview.md`** - MCP server configuration guide
-- **`doc/mcp/debugging.md`** - MCP debugging and troubleshooting
-- **`examples/README.md`** - Example documentation with usage instructions
-- **`CHANGELOG.md`** - Version history (Keep a Changelog format)
-- **`AGENTS.md`** - Guidelines for AI agents (internal)
-
-### When to Update
-
-Update documentation when:
-
-- A public API function is added, changed, or removed
-- A new example is added to `examples/`
-- A configuration option is added or changed
-- Authentication or MCP behavior changes
-- Event types are added or modified
-- The doc structure itself changes (update `doc/index.md`)
-
-### Validation
-
-After making documentation changes, always run:
-
-```bash
-bb validate-docs
-```
-
-This checks for:
-- Broken internal links
-- Unparseable Clojure code blocks
-- Missing required files
-- Structural issues
-
-### Examples
-
-When adding new features:
-
-1. **Document in API.md** - Add function signature, parameters, return values, and examples
-2. **Add to examples/** - Create a working example demonstrating the feature
-3. **Update examples/README.md** - Document how to run the new example
-4. **Update CHANGELOG.md** - Add entry under `[Unreleased]` section
-5. **Validate** - Run `bb validate-docs` to ensure correctness
-
-## Changelog Conventions
-
-`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/):
-
-1. **Always update the `[Unreleased]` section** — add entries under `Added`, `Changed`, `Fixed`, or `Removed`
-2. **Group related entries** — use sub-headings like `### Added (CI/CD)` when appropriate
-3. **Upstream sync annotations** — when porting changes from an upstream copilot-sdk release, annotate
-   the sub-heading with the upstream version: `### Added (v0.1.24 sync)`. Individual entries should also
-   cite specific upstream PRs (e.g., "upstream PR #376"). Clojure-specific changes use other annotations
-   like `(CI/CD)`, `(documentation)`, or none.
-4. **Mark breaking changes** with `**BREAKING**:` prefix
-5. On release, the maintainer moves `[Unreleased]` entries to a versioned section. The release version
-   (`UPSTREAM.CLJ_PATCH`, e.g., `0.1.24.0`) encodes upstream parity.
-
-## Cross-References
-
-- Use **relative paths** between doc files: `[API Reference](reference/API.md)`
-- From repo root (README, AGENTS.md): `[API Reference](./doc/reference/API.md)`
-- From examples/: `[BYOK](../doc/auth/byok.md)`
-- Never use absolute filesystem paths
-- Link to specific sections with anchors: `[Events](reference/API.md#event-types)`
-
-## Documentation Framework
-
-This project uses standard Markdown documentation. While the style guide mentions Diátaxis framework concepts, the implementation uses simple Markdown files organized by purpose:
-
-- **Tutorials**: Getting started guides (`doc/getting-started.md`)
-- **How-to Guides**: Task-oriented guides (`doc/auth/`, `doc/mcp/`)
-- **Reference**: Technical API documentation (`doc/reference/API.md`)
-- **Explanation**: Conceptual documentation (embedded in guides)
-
-Keep documentation pragmatic and accessible to Clojure developers.
+Run `bb validate-docs` after documentation changes. When examples or public
+source changed, also run the owning executable example and repository gates
+specified in `AGENTS.md`.

--- a/.github/skills/update-docs/SKILL.md
+++ b/.github/skills/update-docs/SKILL.md
@@ -1,242 +1,84 @@
 ---
 name: update-docs
-description: Update SDK documentation by analyzing source code changes and regenerating affected doc pages. Use when new features are added, APIs change, or docs need refresh.
-allowed-tools: View, Grep, Glob, Edit, Create, Task, Bash
-user-invocable: true
+description: Use when public SDK behavior, examples, configuration, or documentation changes and the affected documentation must be updated and regenerated.
 ---
 
-# SDK Documentation Update Skill
+# Update SDK Documentation
 
-You are updating the documentation for the copilot-sdk-clojure project. Your goal is to keep docs accurate, comprehensive, and aligned with the source code.
+Keep documentation aligned with canonical public source and executable examples.
+Read `doc/style.md` and
+`.github/instructions/documentation.instructions.md` before editing.
 
-## Style Guide
+## 1. Identify the Contract Change
 
-**CRITICAL**: Before writing any documentation, read the full style guide at `doc/style.md`.
+Compare the branch with current default and map changed public source, specs,
+fdefs, examples, and hand-written docs to their consumers. Do not infer scope
+only from generated output.
 
-Key principles:
+| Area | Canonical inputs | Documentation |
+|------|------------------|---------------|
+| Public overview/install | `build.clj`, `deps.edn`, public facade | `README.md`, `doc/getting-started.md` |
+| Helpers | `src/github/copilot_sdk/helpers.clj`, specs, fdefs | `doc/reference/API.md`, `doc/getting-started.md` |
+| Client | `src/github/copilot_sdk/client.clj`, specs, fdefs | `doc/reference/API.md` |
+| Session | `src/github/copilot_sdk/session.clj`, specs, fdefs | `doc/reference/API.md` |
+| Tools | `src/github/copilot_sdk/tools.clj`, `tool_set.clj`, specs, fdefs | `doc/reference/API.md` |
+| Specs/fdefs | `src/github/copilot_sdk/specs.clj`, `instrument.clj` | `doc/reference/API.md` |
+| MCP | `src/github/copilot_sdk/util.clj`, `client.clj`, specs | `doc/mcp/overview.md`, `doc/mcp/debugging.md` |
+| Authentication | `src/github/copilot_sdk/client.clj`, specs | `doc/auth/` |
+| Events | public event sets, idiom specs, generated wire specs | `doc/reference/API.md` |
+| Examples | `examples/*.clj` | `README.md`, `examples/README.md`, related guides |
 
-1. **Code-first** — Lead with working Clojure examples, then explain
-2. **Progressive disclosure** — Simplest usage first, layer complexity
-3. **Direct tone** — Imperative mood, no filler ("simply", "just", "let's")
-4. **Clojure-idiomatic** — Use Clojure terminology (namespaces, vars, maps, keywords)
+Read enough source and tests to establish actual defaults, omission semantics,
+errors, lifecycle, and return values. Use a subagent only when the scope needs a
+separate substantial context; do direct reads for small changes.
 
-Every doc must pass the checklist in `doc/style.md` before completion.
+## 2. Update Canonical Documentation
 
-## Documentation Structure
+- Lead with complete, parseable Clojure examples.
+- Use the standard namespace aliases and include lifecycle cleanup.
+- Use tables for option maps, including types, defaults, omission behavior, and
+  experimental status.
+- Document stable behavior and intentional experimental exclusions.
+- Keep transient audit results, local paths, temporary failures, and session
+  history out of evergreen docs.
+- Update `doc/index.md` only when navigation or document structure changes.
+- Update `examples/README.md` when the executable example inventory changes.
+- Run `bb install-docs:sha` when the documented installation SHA moves, and
+  review the resulting `README.md` and getting-started changes.
+- Add a concise `[Unreleased]` changelog entry for user-visible changes.
 
-```
-doc/
-├── index.md              # Doc hub / navigation
-├── getting-started.md    # Step-by-step tutorial
-├── style.md              # Authoring conventions
-├── guides/               # Topic guides
-├── reference/
-│   └── API.md            # Complete API reference
-├── auth/
-│   ├── index.md          # Authentication overview
-│   └── byok.md           # Bring Your Own Key guide
-├── mcp/
-│   ├── overview.md       # MCP server integration
-│   └── debugging.md      # MCP troubleshooting
-└── api/                  # Auto-generated Codox HTML
-```
+## 3. Treat Examples as Executable Evidence
 
-## Source Code → Documentation Mapping
+Examples must be:
 
-| Doc Area | Primary Sources | Affected Docs |
-|----------|----------------|---------------|
-| Helpers API | `src/github/copilot_sdk/helpers.clj` | `doc/reference/API.md` (Helpers section), `doc/getting-started.md` |
-| Client API | `src/github/copilot_sdk/client.clj` | `doc/reference/API.md` (Client section) |
-| Session API | `src/github/copilot_sdk/session.clj` | `doc/reference/API.md` (Session section) |
-| Tools | `src/github/copilot_sdk/client.clj` (`define-tool`, `result-success`) | `doc/reference/API.md` (Tools section) |
-| Specs | `src/github/copilot_sdk/specs.clj`, `src/github/copilot_sdk/instrument.clj` | `doc/reference/API.md` |
-| MCP | `src/github/copilot_sdk/util.clj` (`mcp-server->wire`), `src/github/copilot_sdk/client.clj` | `doc/mcp/overview.md`, `doc/mcp/debugging.md` |
-| Auth/BYOK | `src/github/copilot_sdk/client.clj` (`:provider` in `create-session`) | `doc/auth/index.md`, `doc/auth/byok.md` |
-| Events | `src/github/copilot_sdk/client.clj` (`event-types`, `subscribe-events!`) | `doc/reference/API.md` (Events section) |
-| Examples | `examples/*.clj` | `examples/README.md`, related doc pages |
+- portable across supported environments;
+- bounded rather than dependent on indefinite waits;
+- fail-loud on invalid results;
+- explicit about client, session, subscription, process, and channel cleanup;
+- listed exactly once in the maintained example inventory.
 
-## Update Workflow
+Run affected examples. Do not convert a failing contract example into
+pseudocode.
 
-### 1. Identify Scope
+## 4. Regenerate Outputs
 
-If the user specifies a scope (e.g., "update mcp docs"), focus on that area only.
+Generated API HTML and other generated documentation are outputs, not editing
+surfaces. Fix the canonical source or Markdown, then run the owning generator.
+Never hand-edit generated files.
 
-If no scope is specified, scan for changes:
+Run `bb docs` after public docstrings change. When generator drift matters, run
+the generator twice from identical inputs and require the second run to produce
+no diff.
 
-```bash
-git diff --name-only HEAD~10 -- src/ examples/
-```
+## 5. Validate
 
-Map changed files to affected docs using the source mapping table above.
-
-### 2. Analyze Source Code
-
-For each affected area, use the `explore` agent to gather information:
-
-```
-task agent_type: explore
-prompt: "In /path/to/repo, find all public functions in src/github/copilot_sdk/helpers.clj. List function name, arglists, and docstring."
-```
-
-Key things to check in source:
-- Public function signatures (`defn`, `defmacro` — skip `defn-` private fns)
-- Docstrings
-- Spec definitions in `specs.clj` (option keys, types, defaults)
-- Default values and option maps
-- Event type constants
-
-### 3. Generate/Update Documentation in Parallel
-
-**IMPORTANT**: When multiple doc files need updates, use parallel `general-purpose` subagents via the `task` tool.
-
-For each doc file that needs updating, launch a subagent:
-
-```
-task agent_type: general-purpose
-prompt: |
-  You are updating Clojure SDK documentation.
-
-  **STYLE GUIDE**: Read and follow doc/style.md strictly:
-  - Lead with working Clojure code examples
-  - Short paragraphs (1-3 sentences max)
-  - Use tables for options/config keys
-  - Use imperative mood
-  - Show require forms in code blocks
-  - Use ;; => for return values
-
-  **YOUR TASK**: Update doc/reference/API.md — Helpers API section
-
-  **RESEARCH**: Analyze src/github/copilot_sdk/helpers.clj for:
-  - All public functions, their arglists, and docstrings
-  - Option keys accepted (check specs.clj for spec definitions)
-  - Return types and behavior
-
-  **REQUIREMENTS**:
-  - Update function signatures if changed
-  - Add any new functions
-  - Ensure code examples match current API
-  - Use relative links for cross-references
-```
-
-### 4. Update Examples README
-
-If examples changed, also update `examples/README.md`:
-- Verify all listed examples still exist as files
-- Update walkthroughs for changed examples
-- Add entries for new examples
-
-### 5. Regenerate Codox HTML
-
-After updating source docstrings or markdown docs, regenerate the Codox API HTML:
-
-```bash
-bb docs          # or: clojure -X:codox
-```
-
-This regenerates `doc/api/*.html` from source docstrings. Always run this after
-changing docstrings in `src/` so the HTML stays in sync with the source.
-
-### 6. Quality Gate
-
-After all updates, run validation:
+Run:
 
 ```bash
 bb validate-docs
 ```
 
-Fix any errors (broken links, unparseable code blocks) before finishing.
-
-Also verify:
-- [ ] Code examples use correct `require` aliases (`copilot`, `h`, `session`)
-- [ ] Tables have consistent formatting
-- [ ] Cross-references use relative paths
-- [ ] No filler language
-- [ ] `doc/index.md` links are up to date
-- [ ] `doc/api/` HTML is regenerated if source docstrings changed
-
-## Common Tasks
-
-### New Public Function Added
-
-1. Read the function from its source file
-2. Add to the appropriate section in `doc/reference/API.md`
-3. Include signature, description, options table, and example
-4. If it's a major feature, consider updating `doc/getting-started.md`
-
-### New Example Added
-
-1. Add entry to the examples table in `README.md`
-2. Add detailed walkthrough to `examples/README.md`
-3. Include difficulty level, concepts covered, and usage command
-
-### New Config/Session Option
-
-1. Read from `specs.clj` and `client.clj`
-2. Add to the session options table in `doc/reference/API.md`
-3. Add example usage if behavior is non-obvious
-
-### Auth/BYOK Changes
-
-1. Read from `client.clj` (create-session provider handling)
-2. Update `doc/auth/index.md` and/or `doc/auth/byok.md`
-3. Verify example provider configs still work
-
-### MCP Changes
-
-1. Read from `util.clj` (mcp-server->wire) and `client.clj`
-2. Update `doc/mcp/overview.md`
-3. Update `doc/mcp/debugging.md` if error handling changed
-
-## Arguments
-
-$ARGUMENTS
-
-### Usage Modes
-
-**Mode 1: Full docs refresh (default)**
-
-```
-/update-docs
-/update-docs all
-```
-
-Compares all source files against all docs. Updates everything out of sync.
-
-**Mode 2: Specific section**
-
-```
-/update-docs helpers
-/update-docs mcp
-/update-docs auth
-/update-docs getting-started
-```
-
-Only updates docs for the specified area. Valid: `helpers`, `client`, `session`, `tools`, `events`, `mcp`, `auth`, `getting-started`, `examples`.
-
-**Mode 3: Branch delta**
-
-```
-/update-docs branch
-```
-
-Compares your branch against `main`, identifies changed source files, and updates only affected docs.
-
-### Mode Detection
-
-Parse `$ARGUMENTS` to determine mode:
-
-1. If arguments contain `branch`: Use Mode 3 (branch delta)
-2. If arguments contain a section name: Use Mode 2 (specific section)
-3. If arguments are empty or `all`: Use Mode 1 (full refresh)
-
-### Branch Delta Workflow (Mode 3)
-
-```bash
-# Get changed source files vs main
-git diff --name-only main...HEAD -- src/ examples/
-
-# Map to affected docs using source mapping table
-# Launch parallel subagents for each affected doc
-```
-
-Example: If `src/github/copilot_sdk/helpers.clj` changed, update `doc/reference/API.md` (Helpers section) and `doc/getting-started.md`.
+Also run the smallest affected executable examples and repository gates
+required by `AGENTS.md`. Review the final diff for stale links, duplicate
+guidance, unparseable snippets, generated-file hand edits, and undocumented
+stable or experimental behavior.

--- a/.github/skills/update-upstream/SKILL.md
+++ b/.github/skills/update-upstream/SKILL.md
@@ -1,194 +1,184 @@
 ---
 name: update-upstream
-description: Use when syncing the Clojure Copilot SDK with upstream releases or checking for unported Node.js and Python SDK changes.
+description: Use when syncing the Clojure Copilot SDK with upstream releases or recertifying parity with the official Node.js SDK.
 compatibility: Requires authenticated copilot and gh CLIs, Clojure CLI, bb, and a local github/copilot-sdk checkout beside the primary checkout or specified by COPILOT_SDK_UPSTREAM.
 ---
 
-# Update Upstream Skill
+# Update Upstream
 
-Sync the copilot-sdk-clojure project with upstream [github/copilot-sdk](https://github.com/github/copilot-sdk) changes. This skill codifies the full upstream sync workflow — from discovery through implementation, review, docs, and PR creation.
+Sync or recertify this repository against an exact upstream pin. Read
+`AGENTS.md` at the repository root first, then read `references/PROJECT.md` for the authority map,
+classification rules, contract matrix, and wire notes.
 
-**Prerequisites**: Read `AGENTS.md` at the repo root for project structure, design philosophy, API compatibility rules, testing commands, and version management. Read `references/PROJECT.md` (relative to this skill) for upstream↔Clojure file mapping and wire conversion notes.
+## 1. Establish the Inputs
 
-## Process
+1. Refresh `origin/main` without checking out `main` in a linked worktree:
 
-### Phase 1: Discovery
-
-1. **Refresh `origin/main` without leaving the current worktree branch.**
-   Recently merged PRs may have already ported upstream changes:
-   ```
+   ```bash
    git fetch origin main
    git rev-list --left-right --count HEAD...origin/main
    ```
-   Never check out `main` inside a linked worktree; the primary checkout may
-   already have it checked out. If the current branch is only behind, run
-   `git merge --ff-only origin/main`. If it has diverged, use a fresh project
-   session from the default branch when available; otherwise ask the
-   maintainer before integrating `origin/main`.
-2. Resolve and fetch the upstream checkout using the tracked, worktree-safe
-   helper:
-   ```
+
+   Fast-forward only when the branch has no local commits. If it has diverged,
+   use a fresh project session from current default or ask before an additive
+   merge. Never rewrite history by default.
+
+2. Resolve and refresh the upstream checkout:
+
+   ```bash
    UPSTREAM_REPO="$(bash .github/skills/update-upstream/scripts/resolve-upstream.sh)" &&
    git -C "$UPSTREAM_REPO" fetch --prune --tags origin
    ```
-   The helper derives the primary checkout from Git's common directory, so it
-   works from both normal checkouts and linked worktrees. Set
-   `COPILOT_SDK_UPSTREAM` to override the sibling checkout location. Shell
-   tool calls do not share environment, so resolve `UPSTREAM_REPO` again in
-   each call or chain dependent commands together.
-3. Check the current Clojure SDK version in `build.clj` (format: `UPSTREAM.CLJ_PATCH` — see AGENTS.md § Version Management).
-4. List upstream commits since our last synced version:
-   ```
-   UPSTREAM_REPO="$(bash .github/skills/update-upstream/scripts/resolve-upstream.sh)" &&
-   git -C "$UPSTREAM_REPO" log --oneline <last-tag>..origin/main -- nodejs/
-   ```
-5. For each commit, classify:
-   - **Port** — Code changes to `nodejs/src/` (types, client, session, generated)
-   - **Skip** — CI/tooling, language-specific (Python/Go/.NET only)
 
-### Phase 2: Gap Analysis
+   Re-resolve `UPSTREAM_REPO` in each shell call. Never hard-code an absolute or
+   worktree-relative sibling path.
 
-Launch three parallel explore agents to build a comprehensive inventory. Use the file mapping in `references/PROJECT.md` to locate the right files.
+3. Record the exact upstream target commit and the current Clojure base before
+   analysis. Use exact pins in evidence so later reviews are reproducible.
 
-1. **Node.js SDK** — Resolve `$UPSTREAM_REPO`, then read the upstream files listed in references/PROJECT.md (types.ts, client.ts, session.ts, index.ts, generated/). Catalog all public types, methods, event types, and event data fields.
-2. **Python SDK** — Resolve `$UPSTREAM_REPO`, then read `python/copilot/client.py`, `session.py`, `__init__.py`, and `generated/`. Note behavioral differences from Node.js.
-3. **Clojure SDK** — Read all `src/github/copilot_sdk/*.clj`. Catalog public functions, specs, event sets, wire conversion.
+4. Locate any validated historical parity oracle. Keep its original pin,
+   symbols, and source ranges intact. Do not retarget an old evidence file by
+   replacing only its commit hash. Add a separate post-baseline delta inventory
+   for a newer target.
 
-Compare inventories to identify gaps:
-- New or changed public functions, types, or method signatures
-- New event types and event data fields
-- New config options or enum values
-- Behavioral changes — new guards, fields that gate logic, or shape changes to existing data
+## 2. Reconstruct the Stable Public Surface
 
-### Phase 3: Planning
+Stable recertification is a complete public-surface inventory at the target pin,
+not a changed-file grep or generated-schema scan.
 
-Create a structured plan in the session plan.md with:
-- **Code gaps** — Behavioral changes needed (HIGH priority)
-- **Spec gaps** — Missing fields/values (MEDIUM priority)
-- **Doc gaps** — Documentation needing updates
-- **Example gaps** — Missing examples for new features
-- **Idiomatic review** — Areas to check for Clojure idiom adherence
+1. Inventory the Node package root exports and public types.
+2. Inventory `CopilotClient` constructors, builders, and methods.
+3. Inventory `CopilotSession` methods and lifecycle behavior.
+4. Trace extension and join paths, including any distinct builders.
+5. Read relevant stable unit and end-to-end tests for behavior not explicit in
+   types.
+6. Use Python only as behavioral corroboration. Use CLI and generated protocol
+   sources only to understand wire behavior; neither creates a stable parity
+   requirement by itself.
 
-Show the plan to the user. Wait for approval before implementing.
+Classify every discovered delta as:
 
-### Phase 4: Implementation (Red/Green TDD)
+- stable public;
+- experimental;
+- internal;
+- generated-only; or
+- language-specific.
 
-For each code/spec change:
+Port stable public behavior. Experimental work requires an explicit maintainer
+decision, accepted ADR, or direct user request. Record intentional exclusions
+in durable evidence, docs, or an ADR so future audits do not rediscover them as
+unresolved gaps.
 
-1. **RED** — Write a failing test first in the focused namespace under `test/github/copilot_sdk/integration/`
-2. Run tests: `bb test` — confirm failure (it's OK to just run the tests you added as you iterate)
-3. **GREEN** — Implement the minimal change in `src/`
-4. Run tests again — confirm all pass (0 failures)
+## 3. Plan the End-to-End Contract
 
-See `references/PROJECT.md` for the upstream↔Clojure file mapping to know which source files to modify. See `AGENTS.md` § Instrumented Testing for the spec/fdef workflow when adding new public functions.
+For each stable public delta, create one row in a contract matrix covering:
 
-Wire format notes — see `references/PROJECT.md` § Wire Conversion Cheat Sheet. Key rule: camel-snake-kebab does **not** add `?` suffixes for booleans.
+1. public Node export or type;
+2. applicable create, resume, join, or method builder;
+3. exact wire key, nesting, enum spelling, and omission/null semantics;
+4. Clojure public name and idiomatic value shape;
+5. closed-key/value specs and registered fdefs;
+6. public API snapshot impact;
+7. targeted tests;
+8. docs, examples, and changelog.
 
-### Phase 5: Full Validation
+Apply the optional-field proof in `references/PROJECT.md` to every applicable
+builder and mutable update path. Keep separate create/resume/join builders
+consistent without assuming their accepted options are identical.
 
-Run the full CI pipeline (see `AGENTS.md` § Before Committing):
+Present the classified inventory and implementation plan for approval before
+changing production behavior.
+
+## 4. Implement Contract-First
+
+1. Write the smallest failing table-driven, property, or real-protocol test that
+   proves the missing behavior.
+2. Confirm the focused test fails for the intended reason.
+3. Implement the complete contract path, including specs, fdefs, API snapshot,
+   wire conversion, and every applicable builder.
+4. Re-run the focused gate before expanding scope.
+
+Preserve the wire/idiom boundary described in `AGENTS.md`. Generated wire specs
+remain schema-faithful and private; hand-curated specs define caller-facing
+Clojure values; generated coercion bridges deliberate differences. Opaque JSON
+requires recursive shape and key-preservation tests through every reachable
+notification and response path.
+
+For core.async work, prove ownership, cancellation, backpressure, bounded
+blocking, cleanup, and error precedence. Never run arbitrary blocking or
+user-supplied work on `go` dispatch. Replace sleeps with observable
+synchronization. Keep cleanup failures visible without replacing the primary
+failure.
+
+Prefer a canonical idiomatic API and an explicit breaking change over an
+unproven compatibility alias.
+
+Keep pre-existing issues outside the sync diff unless they block the port.
+Record and track them separately rather than expanding a parity change into
+unrelated cleanup.
+
+## 5. Regenerate Deterministically
+
+Regenerate schemas, code, API snapshots, and docs only from their canonical
+pinned inputs. Never hand-edit generated outputs.
+
+When generator drift is possible:
+
+1. run the owning generator;
+2. review the complete generated diff;
+3. run it again from identical inputs; and
+4. require the second run to produce no diff.
+
+## 6. Update Documentation and Examples
+
+Invoke the `update-docs` skill for canonical docs, examples, regeneration, and
+validation. Document stable behavior and intentional experimental exclusions
+without copying temporary audit notes into evergreen docs. Add a concise
+`[Unreleased]` changelog entry.
+
+## 7. Validate and Review
+
+Use the smallest targeted gates during iteration, then run:
 
 ```bash
 bb ci:full
 ```
 
-This runs E2E tests, examples, doc validation, and JAR build. If copilot CLI is unavailable, run `bb ci` instead.
+If authenticated end-to-end prerequisites are unavailable, run `bb ci` and
+state the limitation. Review example output, generated diffs, and the
+machine-readable parity inventory.
 
-Carefully review example output for regressions.
+Obtain independent review focused on stable-surface completeness, exact wire
+semantics, spec/fdef/API-snapshot coverage, Clojure idioms, concurrency and
+resource ownership, tests, and accidental experimental exposure. Address valid
+findings and explain false positives.
 
-### Phase 6: Multi-Model Code Review
+## 8. Publish and Converge Review
 
-Launch parallel code-review agents using two distinct model families (e.g., Claude Opus 4.7 and GPT-5.5 — or later if available). Different model families catch different categories of issues; use whichever specific models are currently available.
+If available, invoke a PR-authoring skill before creating or editing the pull
+request. Otherwise perform the same checks directly:
 
-Each reviewer gets the same context: what changed, why, and what to focus on (correctness, spec completeness, test coverage, Clojure idioms, wire conversion accuracy).
+1. confirm the branch is based on current `origin/main`;
+2. commit logical changes with a descriptive message that follows active
+   repository and attribution rules;
+3. push the current branch and create one focused pull request; and
+4. include the contract changes, validation, exclusions, and review findings in
+   the PR body.
 
-Compile a combined assessment table:
+If available, invoke the Copilot code-review workflow. Otherwise fetch exact
+Copilot review threads directly. Triage each comment on its merits, address
+valid findings, explain false positives, reply in the exact thread, resolve it,
+re-request review, and repeat until a new review round has no comments. Stop and
+ask the maintainer if convergence takes more than 10 rounds.
 
-| # | Finding | Source | Severity | Validity | Decision |
-|---|---------|--------|----------|----------|----------|
+## 9. Keep This Skill Current
 
-For each finding:
-- **Valid + actionable** → Fix it, re-run tests
-- **Valid + pre-existing** → Note as out of scope, track separately
-- **Invalid / false positive** → Document rationale for dismissal
+After a sync:
 
-Iterate: fix → re-test → re-review until no actionable findings remain.
+1. compare `AGENTS.md` project structure with the repository;
+2. compare `references/PROJECT.md` with the upstream public source layout;
+3. remove stale workflow steps and pitfalls;
+4. add a pitfall only when it generalizes to a recurring class of error.
 
-### Phase 7: Documentation
-
-Invoke the `update-docs` skill. See `AGENTS.md` § Documentation for the full list of doc files that may need updating.
-
-At minimum:
-1. Update `doc/reference/API.md` — new specs, event fields, behavior changes
-2. Update `CHANGELOG.md` — entries under `[Unreleased]` (see `AGENTS.md` § Changelog for formatting)
-3. Run `bb validate-docs`
-
-### Phase 8: PR Creation
-
-1. **Confirm the current worktree branch is based on current `origin/main`.**
-   Run `git fetch origin main` and inspect
-   `git rev-list --left-right --count HEAD...origin/main`. Do not check out
-   local `main`.
-2. Keep using the project session's existing branch. If running outside a
-   project worktree and still on the default branch, create a feature branch
-   with the app-native branch tool when available.
-3. Commit changes in logical commits to make them easy to review commit by commit and with descriptive message and `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
-4. Push and create PR with `gh pr create`
-5. PR body should include: summary, changes list, validation results, review findings table
-
-If the branch becomes stale after it has commits, do not rewrite history by
-default. Prefer a fresh project session from current `main`, or ask the
-maintainer before using an additive merge.
-
-### Phase 9: Reflecting on code review feedback.
-
-Once the PR is created, Copilot Code Review (and possibly humans) will provide code review feedback.
-
-run: /pr auto Consider Copilot Code Review feedback. For each piece of feedback, determine if its valid and important, or invalid (false positive) and/or not important. For all valid feedback, address it. For each piece of feedback (valid or not), comment in the thread for that particular feedback comment and explain how you addressed the feedback or your rationale for not addressing, or a suggestion for addressing in the future (create issues for future/follow up). Once all feedback is addressed/commented, rerequest a review, and continue iterating this processes until there is no more code review feedback - you should keep iterating this process until you see a review from Copilot Code Review which generates no comments, but no more than 10 rounds (to avoid exploding costs). If more than 10 rounds is needed, prompt the users asking what to do next.
-
-### Phase 10: Skill Self-Review
-
-After each upstream sync, review this skill itself for accuracy and relevance:
-
-1. **Project structure** — Compare the file listing in `AGENTS.md` § Project Structure against the actual contents of `src/github/copilot_sdk/`. Flag any new, renamed, or removed source files.
-2. **Upstream file mapping** — Compare the mapping table in `references/PROJECT.md` against the current upstream `nodejs/src/` directory. Flag new or removed upstream files.
-3. **Common Pitfalls** — Only propose a new pitfall if it generalizes to a *class* of recurring bug. Single-occurrence specifics belong in commit messages or PR descriptions, not here. Also flag listed pitfalls that no longer apply (e.g., refactored away).
-4. **Process phases** — Note any workflow steps that were awkward, missing, or unnecessary during this sync.
-
-If any drift is found, describe your findings to the user and propose specific edits to `SKILL.md`, `references/PROJECT.md`, or `AGENTS.md`. **Do not commit** the skill updates — wait for the maintainer to review and approve them.
-
-## Key Principles
-
-1. **API parity with upstream Node.js SDK.** Only port what the official SDK exposes. Don't add CLI-only features unless clearly marked experimental. See `AGENTS.md` § API Compatibility Rules.
-
-2. **Idiomatic Clojure, not a transliteration.** Use immutable data, core.async for events/concurrency, specs for validation, kebab-case keywords. See `AGENTS.md` § Design Philosophy.
-
-3. **Red/green TDD is mandatory.** Never implement without a failing test first. This catches wire conversion bugs (camelCase → kebab-case) and spec mismatches early.
-
-4. **Multi-model review catches different things.** Different model families tend to find different categories of issues — API contracts, logic/concurrency bugs, spec inconsistencies. Use at least two distinct families.
-
-5. **Wire conversion is the #1 source of bugs.** Always verify camelCase → kebab-case conversion for new fields. See `references/PROJECT.md` § Wire Conversion Cheat Sheet.
-
-6. **Event data specs use open maps.** `s/keys` allows extra keys, so new upstream fields pass through automatically. Add explicit specs for documentation and validation, not to gate functionality.
-
-7. **Pre-existing issues are out of scope.** If a reviewer finds a real issue that wasn't introduced by this sync, note it but don't fix it in the sync PR. Track separately.
-
-## Common Pitfalls
-
-Real recurring traps when porting upstream changes:
-
-1. **Data shapes are declared in multiple sites — find them all.** A new config option, event type, or permission kind typically lives in 3–5 places: a value spec, a closed-keys set, one or more `:opt-un` lists, a public set, and a docstring. Missing any one site causes the option to be silently stripped, the spec to go unenforced, or the value to be invisible to consumers. Grep for an existing analogous key and mirror every site.
-
-2. **Wire conversion happens once, at the boundary; don't convert again.** Inbound responses are normalized by `util/wire->clj` in `protocol/normalize-incoming`; outbound results are converted by `util/clj->wire`. RPC handlers, specs, tests, and event consumers work in idiomatic shapes (kebab-case). Escape hatches exist for opaque source-defined data (tool call arguments, custom-notification subject/payload) — these must be applied to **both** the notification path and the response path if the field is reachable via `session.getMessages` (historical events go through responses).
-
-3. **Public functions need an fdef registered in `instrument.clj`.** Use the `register-fdef!` macro — a plain `s/fdef` or one outside that file leaves a silent instrumentation gap, and integration tests (which run instrumented) won't enforce the spec.
-
-4. **Test fixtures: match the shape the layer actually produces.** Mock server responses use wire shape; client-side assertions use idiomatic shape. Production conversion (`util/wire->clj`) only transforms keyword keys — string-keyed fixtures silently bypass it and produce tests that pass for the wrong reason.
-
-5. **Outbound optional fields: match upstream's omit-vs-null behavior per RPC.** Don't reflexively gate an optional wire field on `contains?` and emit JSON `null`. Some patch RPCs (e.g. `session.options.update`) genuinely accept `null` to clear a value; others (e.g. `session.model.switchTo`) have no null variant in the schema — upstream spreads `...options`, dropping `undefined`. Check the upstream call site and the request schema: if the field has no null union, compute the wire value first and gate on `(some? v)` so a `nil` option omits the key instead of sending `null`.
-
-6. **`session.create` and `session.resume` build wire params in two separate functions — keep shared sub-shapes in a named helper.** `build-create-session-params` and `build-resume-session-params` both emit tool defs, system message, provider, MCP servers, custom agents, and commands. A new field on any shape sent by both must be added to both builders, or it ships on create and silently vanishes on resume. Funnel each shared sub-shape through one `*->wire` helper (e.g. `tool-def->wire`, `util/mcp-servers->wire`) rather than duplicating a `cond->` inline.
-
-7. **Sibling repositories must be resolved from Git's common directory, not the worktree root.** In a linked worktree, `../copilot-sdk` points inside the worktree container rather than beside the primary checkout. Always use `scripts/resolve-upstream.sh`; never hard-code an absolute path or derive the sibling from `git rev-parse --show-toplevel`.
-
-For the mechanics of camelCase ↔ kebab-case conversion (including the `?`-suffix rule), see the cheat sheet in `references/PROJECT.md`.
+Single-occurrence details belong in commits, pull requests, audit evidence, or
+ADRs, not in this skill.

--- a/.github/skills/update-upstream/references/PROJECT.md
+++ b/.github/skills/update-upstream/references/PROJECT.md
@@ -1,63 +1,118 @@
 # Upstream Sync Reference
 
-This reference supplements `AGENTS.md` (the canonical project reference) with sync-specific context.
+This reference supplements `AGENTS.md`, the canonical project reference.
 
-For project structure, testing commands, version format, changelog conventions, and code quality expectations, see `AGENTS.md`.
+## Authority Inventory
 
-## Upstream Checkout
+Inventory the complete official Node.js public surface at the selected exact
+pin.
 
-Resolve the local upstream checkout from any normal checkout or linked
-worktree:
+| Upstream source | Evidence |
+|-----------------|----------|
+| `nodejs/src/index.ts` | Package-root exports and supported public entry points |
+| `nodejs/src/types.ts` | Public options, config maps, result types, enums, and nullability |
+| `nodejs/src/client.ts` | `CopilotClient` construction, create/resume/join builders, and client methods |
+| `nodejs/src/session.ts` | `CopilotSession` methods, lifecycle, event handling, and method builders |
+| `nodejs/src/extension.ts` | Extension-facing public construction and session paths |
+| `nodejs/src/toolSet.ts` | Public tool-filter helpers |
+| `nodejs/test/` | Stable unit and end-to-end behavior, especially omission and lifecycle semantics |
+| `nodejs/src/generated/` | Wire signatures and event schemas; informative, not independently a stable parity requirement |
 
-```bash
-UPSTREAM_REPO="$(bash .github/skills/update-upstream/scripts/resolve-upstream.sh)"
+Treat Python as secondary corroboration. Treat CLI/runtime implementation as
+wire evidence, not public API authority.
+
+## Clojure Mapping
+
+| Contract area | Clojure source |
+|---------------|----------------|
+| Package facade and curated public values | `src/github/copilot_sdk.clj` |
+| Client construction and session builders | `src/github/copilot_sdk/client.clj` |
+| Session functions and lifecycle | `src/github/copilot_sdk/session.clj` |
+| Public convenience helpers | `src/github/copilot_sdk/helpers.clj` |
+| Tool helpers and filters | `src/github/copilot_sdk/tools.clj`, `src/github/copilot_sdk/tool_set.clj` |
+| Caller-facing shapes | `src/github/copilot_sdk/specs.clj` |
+| Public function contracts | `src/github/copilot_sdk/instrument.clj` |
+| Protocol and normalization | `src/github/copilot_sdk/protocol.clj`, `src/github/copilot_sdk/util.clj` |
+| Generated wire validation and coercion | `src/github/copilot_sdk/generated/` |
+| Versioned public compatibility snapshot | `resources/github/copilot_sdk/api_surface.edn` |
+
+## Delta Classification
+
+Assign exactly one classification before deciding whether to port a delta:
+
+| Class | Action |
+|-------|--------|
+| Stable public | Port and prove the full Clojure contract |
+| Experimental | Exclude unless explicitly approved; mark outside stable compatibility if ported |
+| Internal | Do not expose |
+| Generated-only | Use as wire evidence; do not infer public support |
+| Language-specific | Skip unless the Clojure design has an independently justified counterpart |
+
+Record intentional exclusions in durable evidence, docs, or an ADR.
+
+## Stable Delta Proof
+
+For every stable public delta, prove:
+
+```text
+Node export/type
+  -> applicable create/resume/join/method builder
+  -> exact wire shape and omission semantics
+  -> Clojure name and idiomatic value
+  -> closed spec + registered fdef + API snapshot
+  -> targeted tests
+  -> docs + examples + changelog
 ```
 
-The helper finds the primary `copilot-sdk-clojure` checkout through Git's
-common directory, then resolves its `copilot-sdk` sibling. Set
-`COPILOT_SDK_UPSTREAM` when the upstream checkout lives elsewhere. Re-resolve
-the variable in each shell tool call because shell environments do not
-persist between calls.
+Test optional fields with a table containing the states that apply: absent,
+`false`, `true`, empty, and `nil`. Omission and JSON `null` are different
+contracts. Reject explicit `nil` when an optional upstream type is non-null.
+Check that create/resume/join-only fields never appear in unrelated mutable
+updates.
 
-## Upstream ↔ Clojure File Mapping
+Public shapes are usually declared in several places: leaf specs, closed-key
+sets, one or more `s/keys` lists, public sets, builders, and docstrings. Grep for
+an analogous existing key and mirror every applicable declaration site. Missing
+one can silently strip an option, leave it unenforced, or hide it from callers.
 
-When syncing, map upstream changes to the corresponding Clojure files:
+## Wire and Idiom Boundary
 
-### Upstream (`$UPSTREAM_REPO`)
+Convert camelCase and kebab-case once at the protocol boundary.
 
-| Upstream File | Contains |
-|---------------|----------|
-| `nodejs/src/types.ts` | Canonical type definitions (`SessionConfig`, `MessageOptions`, etc.) |
-| `nodejs/src/client.ts` | `CopilotClient` methods, what params go on the wire |
-| `nodejs/src/session.ts` | `CopilotSession` methods, event handling |
-| `nodejs/src/index.ts` | Public exports (defines the public API surface) |
-| `nodejs/src/generated/session-events.ts` | All event types and data shapes |
-| `nodejs/src/generated/rpc.ts` | RPC method signatures |
-| `nodejs/src/toolSet.ts` | `ToolSet` / `BuiltInTools` tool-filter helpers |
+- Boolean conversion does not add a `?` suffix. Re-key caller-facing predicates
+  deliberately.
+- `wire->clj` transforms keyword keys; string-keyed fixture maps bypass that
+  conversion.
+- Mock-server requests are wire-shaped. Client assertions are idiomatic.
+- Generated wire specs validate raw schema-faithful values and are never public
+  API.
+- Hand-curated idiom specs define Clojure-native values and should use closed
+  maps where the upstream contract is exact.
+- Event data specs remain open for forward-compatible pass-through unless there
+  is a deliberate exact-map requirement. Add explicit field specs for public
+  documentation and validation; do not close an event map merely because a new
+  field was discovered.
+- Generated coercion records deliberate wire/idiom differences.
+- Opaque JSON needs recursive JSON specs and key-preservation tests, not a broad
+  `map?`. Cover live notifications and historical response paths when both can
+  carry the value.
 
-### Clojure Counterparts
+Use `handle-permission-request!` in `session.clj` as the reference for an RPC
+handler that returns idiomatic shapes and re-keys only the predicate leaf that
+requires it.
 
-| Upstream Area | Clojure File | Notes |
-|---------------|-------------|-------|
-| Types / config | `specs.clj` | Session config, event data, permissions, tools |
-| Client methods | `client.clj` | Broadcast handlers, create-client, create-session |
-| Session methods | `session.clj` | send/receive, UI convenience methods |
-| Curated public event sets | `copilot_sdk.clj` | Top-level `github.copilot-sdk` ns: hand-curated public `event-types` / `session-events` sets |
-| Generated event specs | `generated/event_specs.clj` | AUTO-GENERATED full `event-types` set + wire specs (`bb codegen`) |
-| RPC methods | `protocol.clj` | JSON-RPC protocol layer |
-| Tool-filter helpers | `tool_set.clj` | Source-qualified `:available-tools` / `:excluded-tools` patterns |
-| Public exports | `copilot_sdk.clj`, `client.clj`, `helpers.clj`, `tools.clj` | Public API surface |
-| Function specs | `instrument.clj` | fdefs for all public functions |
+## Evidence Maintenance
 
-## Wire Conversion Cheat Sheet
+Prefer symbol-based evidence over source line ranges. A validated historical
+oracle remains pinned to the source it actually inspected. When the target
+moves, add a separate delta inventory from that oracle to the new exact pin.
+Never replace only the old hash while retaining stale line or range claims.
 
-camelCase ↔ kebab-case is handled by `util/wire->clj` and `util/clj->wire` (camel-snake-kebab). Conversion happens **once**, at the protocol boundary.
+Parity evidence should make all stable deltas and intentional exclusions
+machine-readable and leave no unclassified rows.
 
-Test a conversion: `(csk/->kebab-case-keyword :yourCamelCaseField)`
+## Deterministic Outputs
 
-Mechanics worth remembering:
-
-- **Booleans don't get a `?` suffix.** `resolvedByHook` → `:resolved-by-hook`, not `:resolved-by-hook?`. Code that wants `?`-suffixed keywords (e.g., `:approved?`) must re-key manually. csk preserves an existing `?` if you pass it in.
-- **`wire->clj` only transforms keyword keys.** String-keyed maps pass through untouched. The mock server parses JSON with `:key-fn keyword` and does **not** apply `wire->clj`, so request-hook callbacks see camelCase keyword keys (e.g., `:remoteSession`).
-- **Opaque user data must be preserved.** Source-defined identifiers (`tool.call` arguments, `session.custom_notification` `:subject`/`:payload`) bypass conversion via explicit escape hatches in `protocol/normalize-incoming`. When adding a new event with opaque fields, apply the escape hatch on both the notification path and the response path (for `session.getMessages`).
-- **`handle-permission-request!`** in `session.clj` is the reference example for an RPC handler: returns idiomatic shapes and only manually re-keys what csk can't (`:approved?` → `:approved`).
+Schemas, generated Clojure, API snapshots, and generated docs are outputs of
+canonical pinned inputs. Follow the deterministic regeneration procedure in
+the owning skill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Changed (agent guidance)
+- Consolidated durable repository guidance for exact-pin stable upstream
+  recertification, end-to-end wire/idiom contract proof, core.async and resource
+  ownership, executable documentation, deterministic generated outputs, and
+  matched-process performance evidence.
+
 ### Added (stable 811adc sync)
 - Added stable `:enable-file-change-tracking?` session config parity through
   upstream commit

--- a/doc/style.md
+++ b/doc/style.md
@@ -76,7 +76,9 @@ Use Clojure terms consistently:
 ## Cross-References
 
 - Use **relative paths** between doc files: `[API Reference](reference/API.md)`
-- From repo root (README, AGENTS.md): `[API Reference](./doc/reference/API.md)`
+- From repo root README: `[API Reference](./doc/reference/API.md)`
+- `AGENTS.md` is a symlink to `.github/copilot-instructions.md`; links in that
+  shared file must use full canonical GitHub URLs so both rendered paths work
 - From examples/: `[BYOK](../doc/auth/byok.md)`
 - Never use absolute filesystem paths
 - Link to specific sections with anchors: `[Events](reference/API.md#event-types)`


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Codify the durable lessons from the comprehensive SDK review so future upstream sync and documentation work repeats the same contract, lifecycle, and evidence rigor without carrying forward transient audit details.

The canonical `AGENTS.md` / Copilot instruction target remains the full repository reference. Detailed procedures live in spec-compliant, self-contained `update-upstream` and `update-docs` skills, while benchmark methodology stays authoritative in `benchmarks/`. The guidance explicitly covers stable-versus-experimental classification, end-to-end wire/idiom proof, async ownership and cleanup, executable examples, deterministic generated outputs, and matched-process performance evidence.

This intentionally does not change production source, benchmark behavior, or user-level skills. The measured send-and-wait performance opportunity remains a separate implementation follow-up.