### PR TITLE
chore: release v1.0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [1.0.9.0] - 2026-08-13
 ### Changed (agent guidance)
 - Consolidated durable repository guidance for exact-pin stable upstream
   recertification, end-to-end wire/idiom contract proof, core.async and resource
@@ -2346,7 +2347,8 @@ This release bumps the upstream marker from `1.0.0-beta.3` to `1.0.0-beta.4`.
 - org.clojure/spec.alpha 0.5.238
 - cheshire/cheshire 5.13.0
 
-[Unreleased]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v1.0.7-preview.2.1...HEAD
+[Unreleased]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v1.0.9.0...HEAD
+[1.0.9.0]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v1.0.7-preview.2.1...v1.0.9.0
 [1.0.7-preview.2.1]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v1.0.7-preview.2.0...v1.0.7-preview.2.1
 [1.0.7-preview.2.0]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v1.0.0.0...v1.0.7-preview.2.0
 [1.0.0.0]: https://github.com/copilot-community-sdk/copilot-sdk-clojure/compare/v1.0.0-beta.3.0...v1.0.0.0

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ io.github.copilot-community-sdk/copilot-sdk-clojure {:mvn/version "1.0.9.0"}
 
 ;; Or git dependency
 io.github.copilot-community-sdk/copilot-sdk-clojure {:git/url "https://github.com/copilot-community-sdk/copilot-sdk-clojure.git"
-                              :git/sha "49b0d5e1e701d3ed312a37867fd79f082b8c59b3"}
+                              :git/sha "0b6668e66abd328d1f3e837ca8826c71202290a6"}
 ```
 
 > **Note:** The Clojars artifact `net.clojars.krukow/copilot-sdk` is deprecated.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -42,7 +42,7 @@ Or use as a Git dependency:
 ```clojure
 {:deps {io.github.copilot-community-sdk/copilot-sdk-clojure
         {:git/url "https://github.com/copilot-community-sdk/copilot-sdk-clojure"
-         :git/sha "49b0d5e1e701d3ed312a37867fd79f082b8c59b3"}}}
+         :git/sha "0b6668e66abd328d1f3e837ca8826c71202290a6"}}}
 ```
 
 ## Step 2: Send Your First Message


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Prepare the `v1.0.9.0` release from the completed SDK review and remediation baseline.

This stamps the accumulated `[Unreleased]` changelog and updates installation documentation to the release source revision. The version remains `1.0.9.0`: it tracks upstream stable `v1.0.9`, and that Maven coordinate has not previously been published.

Created by the Release workflow run 31701373977.