### PR TITLE
perf: reduce protocol event overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. This change
 - Avoided unnecessary camel/snake-case conversion work for already-normalized
   protocol keywords while preserving exact conversion semantics for camel,
   snake, namespaced, and punctuated keys.
+- Buffered TCP protocol input before Content-Length framing so header-byte reads
+  are satisfied from user space instead of repeatedly reaching the socket.
 
 ## [1.0.9.0] - 2026-08-13
 ### Changed (agent guidance)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Changed (performance)
+- Avoided unnecessary camel/snake-case conversion work for already-normalized
+  protocol keywords while preserving exact conversion semantics for camel,
+  snake, namespaced, and punctuated keys.
+
 ## [1.0.9.0] - 2026-08-13
 ### Changed (agent guidance)
 - Consolidated durable repository guidance for exact-pin stable upstream

--- a/src/github/copilot_sdk/client.clj
+++ b/src/github/copilot_sdk/client.clj
@@ -13,7 +13,8 @@
             [github.copilot-sdk.util :as util]
             [github.copilot-sdk.teardown :as td]
             [github.copilot-sdk.logging :as log])
-  (:import [java.net Socket]
+  (:import [java.io BufferedInputStream]
+           [java.net Socket]
            [java.util.concurrent LinkedBlockingQueue]))
 
 (def ^:private sdk-protocol-version-max 3)
@@ -1034,10 +1035,14 @@
   (let [host (:actual-host client)
         {:keys [actual-port]} @(:state client)
         socket (proc/connect-tcp host actual-port 10000)]
-    ;; Initialize connection state before connecting
-    (swap! (:state client) assoc :connection (proto/initial-connection-state))
-    (let [conn (proto/connect (.getInputStream socket) (.getOutputStream socket) (:state client))]
-      (swap! (:state client) assoc :socket socket :connection-io conn))))
+    ;; Transfer socket ownership before stream/protocol initialization so a
+    ;; failure below remains recoverable through release-transport!.
+    (swap! (:state client) assoc
+           :connection (proto/initial-connection-state)
+           :socket socket)
+    (let [input (BufferedInputStream. (.getInputStream socket) 65536)
+          conn (proto/connect input (.getOutputStream socket) (:state client))]
+      (swap! (:state client) assoc :connection-io conn))))
 
 (defn- verify-protocol-version!
   "Verify the server's protocol version matches ours.

--- a/src/github/copilot_sdk/util.clj
+++ b/src/github/copilot_sdk/util.clj
@@ -8,17 +8,47 @@
 ;; Convert between wire format (camelCase) and Clojure idiom (kebab-case)
 ;; -----------------------------------------------------------------------------
 
+(defn- simple-lowercase-keyword?
+  [k allow-hyphen? allow-digits?]
+  (when (and (keyword? k) (nil? (namespace k)))
+    (let [^String value (name k)
+          length (.length value)]
+      (and (pos? length)
+           (loop [index 0
+                  previous-hyphen? false]
+             (if (= index length)
+               true
+               (let [character (.charAt value index)
+                     hyphen? (= character \-)]
+                 (cond
+                   (or (<= (int \a) (int character) (int \z))
+                       (and allow-digits?
+                            (<= (int \0) (int character) (int \9))))
+                   (recur (inc index) false)
+
+                   (and allow-hyphen?
+                        hyphen?
+                        (pos? index)
+                        (< index (dec length))
+                        (not previous-hyphen?))
+                   (recur (inc index) true)
+
+                   :else
+                   false))))))))
+
 (defn- keyword->camel
   [k]
-  (if (keyword? k)
-    (csk/->camelCaseKeyword k)
-    k))
+  (cond
+    (simple-lowercase-keyword? k false true) k
+    (keyword? k) (csk/->camelCaseKeyword k)
+    :else k))
 
 (defn- keyword->kebab
   [k]
-  (if (keyword? k)
-    (csk/->kebab-case-keyword k)
-    k))
+  (cond
+    (simple-lowercase-keyword? k true false) k
+    (keyword? k) (csk/->kebab-case-keyword k)
+    :else k))
 
 (defn ->wire-keys
   "Convert map keys from kebab-case to camelCase for wire format.

--- a/test/github/copilot_sdk/client_buffer_test.clj
+++ b/test/github/copilot_sdk/client_buffer_test.clj
@@ -1,0 +1,58 @@
+(ns github.copilot-sdk.client-buffer-test
+  (:require [clojure.test :refer [deftest is]]
+            [github.copilot-sdk :as sdk]
+            [github.copilot-sdk.client :as client]
+            [github.copilot-sdk.process :as process]
+            [github.copilot-sdk.protocol :as protocol])
+  (:import [java.io BufferedInputStream ByteArrayInputStream
+            ByteArrayOutputStream]
+           [java.net Socket]))
+
+(deftest tcp-connections-buffer-protocol-input
+  (let [input (ByteArrayInputStream. (byte-array 0))
+        output (ByteArrayOutputStream.)
+        socket (proxy [Socket] []
+                 (getInputStream [] input)
+                 (getOutputStream [] output))
+        captured-input (atom nil)
+        copilot-client (sdk/client {:auto-start? false
+                                    :use-stdio? false
+                                    :port 12345})]
+    (swap! (:state copilot-client) assoc :actual-port 12345)
+    (with-redefs [process/connect-tcp
+                  (fn [_host ^long _port ^long _timeout-ms] socket)
+                  protocol/connect
+                  (fn [protocol-input _protocol-output _state]
+                    (reset! captured-input protocol-input)
+                    ::connection)]
+      (#'client/connect-tcp! copilot-client))
+    (is (instance? BufferedInputStream @captured-input))
+    (is (= ::connection (:connection-io @(:state copilot-client))))
+    (is (identical? socket (:socket @(:state copilot-client))))))
+
+(deftest tcp-connection-initialization-failure-retains-socket-for-cleanup
+  (let [closed? (atom false)
+        input (ByteArrayInputStream. (byte-array 0))
+        output (ByteArrayOutputStream.)
+        socket (proxy [Socket] []
+                 (getInputStream [] input)
+                 (getOutputStream [] output)
+                 (close [] (reset! closed? true)))
+        copilot-client (sdk/client {:auto-start? false
+                                    :use-stdio? false
+                                    :port 12345})]
+    (swap! (:state copilot-client) assoc :actual-port 12345)
+    (with-redefs [process/connect-tcp
+                  (fn [_host ^long _port ^long _timeout-ms] socket)
+                  protocol/connect
+                  (fn [_protocol-input _protocol-output _state]
+                    (throw (ex-info "protocol initialization failed" {})))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"protocol initialization failed"
+                            (#'client/connect-tcp! copilot-client))))
+    (is (identical? socket (:socket @(:state copilot-client))))
+    (is (false? @closed?))
+    (is (empty? (#'client/release-transport!
+                 copilot-client {:process :none})))
+    (is (true? @closed?))
+    (is (nil? (:socket @(:state copilot-client))))))

--- a/test/github/copilot_sdk/util_test.clj
+++ b/test/github/copilot_sdk/util_test.clj
@@ -1,0 +1,79 @@
+(ns github.copilot-sdk.util-test
+  (:require [camel-snake-kebab.core :as csk]
+            [clojure.test :refer [deftest is testing]]
+            [github.copilot-sdk.util :as util]))
+
+(defn- names-of-length
+  [alphabet length]
+  (if (zero? length)
+    [""]
+    (for [prefix (names-of-length alphabet (dec length))
+          character alphabet]
+      (str prefix character))))
+
+(deftest case-conversion-fast-path-preserves-library-results
+  (let [key-cases (map keyword
+                       (mapcat #(names-of-length [\a \b \z \0 \1 \9 \-] %)
+                               (range 1 5)))]
+    (is (every?
+         (fn [key]
+           (= (csk/->kebab-case-keyword key)
+              (first (keys (util/wire->clj {key true})))))
+         key-cases))
+    (is (every?
+         (fn [key]
+           (= (csk/->camelCaseKeyword key)
+              (first (keys (util/clj->wire {key true})))))
+         key-cases))))
+
+(deftest simple-keywords-bypass-case-conversion
+  (testing "inbound conversion delegates only keys that can change"
+    (let [original csk/->kebab-case-keyword
+          converted (atom [])]
+      (with-redefs [csk/->kebab-case-keyword
+                    (fn [key]
+                      (swap! converted conj key)
+                      (original key))]
+        (is (= {:jsonrpc "2.0"
+                :method "session.event"
+                :params {:session-id "s"
+                         :sha-256 "hash"
+                         :event {:parent-id nil
+                                 :data {:content "ok"}}}}
+               (util/wire->clj
+                {:jsonrpc "2.0"
+                 :method "session.event"
+                 :params {:sessionId "s"
+                          :sha256 "hash"
+                          :event {:parent_id nil
+                                  :data {:content "ok"}}}})))
+        (is (= #{:sessionId :sha256 :parent_id} (set @converted))))))
+
+  (testing "outbound conversion delegates only keys that can change"
+    (let [original csk/->camelCaseKeyword
+          converted (atom [])]
+      (with-redefs [csk/->camelCaseKeyword
+                    (fn [key]
+                      (swap! converted conj key)
+                      (original key))]
+        (is (= {:jsonrpc "2.0"
+                :method "session.send"
+                :params {:sessionId "s"
+                         :sha256 "hash"
+                         :prompt "hi"}}
+               (util/clj->wire
+                {:jsonrpc "2.0"
+                 :method "session.send"
+                 :params {:session-id "s"
+                          :sha256 "hash"
+                          :prompt "hi"}})))
+        (is (= [:session-id] @converted)))))
+
+  (testing "namespaced and punctuated keys preserve library semantics"
+    (doseq [key [:my.app/user_id :already.kebab/key-name :question? :dot.name
+                 :-leading :trailing- :repeated--separator :utf8 :sha256
+                 :v1beta2 :line10col5]]
+      (is (= (csk/->kebab-case-keyword key)
+             (first (keys (util/wire->clj {key true})))))
+      (is (= (csk/->camelCaseKeyword key)
+             (first (keys (util/clj->wire {key true}))))))))


### PR DESCRIPTION
<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;"> Generated via Copilot <a href="https://adaptivepatchwork.com/ai-attribution">on behalf</a> of @krukow</em></sub>

Reduce public SDK protocol overhead without changing the API or event-routing architecture. Already-normalized protocol keywords now bypass redundant case conversion, and external TCP connections buffer framing input while default process stdio remains unchanged.

The key-conversion fast path is deliberately conservative: inbound digit, namespace, punctuation, Unicode, and non-canonical separator cases continue through camel-snake-kebab. TCP socket ownership moves into client state before stream/protocol initialization so failure cleanup cannot orphan the socket.

One fresh predeclared 20-pair Node/Clojure study on the combined commit produced these Clojure/Node ratios:

| Endpoint | Ratio | 95% CI |
|---|---:|---:|
| Ping latency | 0.843 | [0.836, 0.849] |
| Ping throughput | 1.184 | [1.166, 1.203] |
| Send-and-wait latency | 1.010 | [0.997, 1.024] |
| Send-and-wait throughput | 0.968 | [0.906, 1.007] |

The send endpoints meet the predeclared non-inferiority margins and have no supported directional difference. The notification router, event mult, waiter, and timeout architecture are intentionally unchanged because their isolated costs were small and changing them would expand ordering/backpressure risk.
